### PR TITLE
Keychain fallbacks and migration flag

### DIFF
--- a/bittr/AppDelegate.swift
+++ b/bittr/AppDelegate.swift
@@ -141,8 +141,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             }
         }
 
+        KeychainManager.migrateFromUserDefaults()
+
         UNUserNotificationCenter.current().delegate = self
-        
+
         return true
     }
 

--- a/bittr/CacheManager.swift
+++ b/bittr/CacheManager.swift
@@ -12,14 +12,20 @@ class CacheManager: NSObject {
     
     
     static func deleteClientInfo() {
-        
+
         let defaults = UserDefaults.standard
         defaults.removeObject(forKey: EnvironmentConfig.cacheKey(for: "device"))
         defaults.removeObject(forKey: EnvironmentConfig.cacheKey(for: "cache"))
-        defaults.removeObject(forKey: EnvironmentConfig.cacheKey(for: "pin"))
-        defaults.removeObject(forKey: EnvironmentConfig.cacheKey(for: "mnemonic"))
         defaults.removeObject(forKey: EnvironmentConfig.cacheKey(for: "lastaddress"))
         defaults.removeObject(forKey: EnvironmentConfig.cacheKey(for: "lightning"))
+
+        KeychainManager.delete(forKey: EnvironmentConfig.cacheKey(for: "pin"))
+        KeychainManager.delete(forKey: EnvironmentConfig.cacheKey(for: "mnemonic"))
+
+        // Clear any leftover UserDefaults entries from before migration
+        defaults.removeObject(forKey: EnvironmentConfig.cacheKey(for: "pin"))
+        defaults.removeObject(forKey: EnvironmentConfig.cacheKey(for: "mnemonic"))
+
         self.resetFailedPinAttempts()
     }
     
@@ -795,51 +801,39 @@ class CacheManager: NSObject {
     }
     
     // MARK: - Mnemonic
-    
-    static func storeMnemonic(mnemonic:String) {
-        
+
+    @discardableResult
+    static func storeMnemonic(mnemonic:String) -> Bool {
         let envKey = EnvironmentConfig.cacheKey(for: "mnemonic")
-        
-        let defaults = UserDefaults.standard
-        defaults.set(mnemonic, forKey: envKey)
+        let success = KeychainManager.save(mnemonic, forKey: envKey)
+        if !success {
+            print("ERROR: Failed to save mnemonic to Keychain")
+            UserDefaults.standard.set(mnemonic, forKey: envKey)
+        }
+        return success
     }
-    
+
     static func getMnemonic() -> String? {
-        
         let envKey = EnvironmentConfig.cacheKey(for: "mnemonic")
-        
-        let defaults = UserDefaults.standard
-        let cachedMnemonic = defaults.value(forKey: envKey) as? String
-        
-        if let actualCachedMnemonic = cachedMnemonic {
-            return actualCachedMnemonic
-        } else {
-            return nil
-        }
+        return KeychainManager.load(forKey: envKey) ?? UserDefaults.standard.value(forKey: envKey) as? String
     }
-    
+
     // MARK: - Pin
-    
-    static func storePin(pin:String) {
-        
+
+    @discardableResult
+    static func storePin(pin:String) -> Bool {
         let envKey = EnvironmentConfig.cacheKey(for: "pin")
-        
-        let defaults = UserDefaults.standard
-        defaults.set(pin, forKey: envKey)
-    }
-    
-    static func getPin() -> String? {
-        
-        let envKey = EnvironmentConfig.cacheKey(for: "pin")
-        
-        let defaults = UserDefaults.standard
-        let cachedPin = defaults.value(forKey: envKey) as? String
-        
-        if let actualCachedPin = cachedPin {
-            return actualCachedPin
-        } else {
-            return nil
+        let success = KeychainManager.save(pin, forKey: envKey)
+        if !success {
+            print("ERROR: Failed to save PIN to Keychain")
+            UserDefaults.standard.set(pin, forKey: envKey)
         }
+        return success
+    }
+
+    static func getPin() -> String? {
+        let envKey = EnvironmentConfig.cacheKey(for: "pin")
+        return KeychainManager.load(forKey: envKey) ?? UserDefaults.standard.value(forKey: envKey) as? String
     }
     
     // MARK: - Txo ID
@@ -1057,9 +1051,6 @@ class CacheManager: NSObject {
         if thisSwap.createdInvoice != nil {
             swapDictionary.setValue(thisSwap.createdInvoice!, forKey: "createdInvoice")
         }
-        if thisSwap.privateKey != nil {
-            swapDictionary.setValue(thisSwap.privateKey!, forKey: "privateKey")
-        }
         if thisSwap.boltzID != nil {
             swapDictionary.setValue(thisSwap.boltzID!, forKey: "boltzID")
         }
@@ -1116,14 +1107,24 @@ class CacheManager: NSObject {
     }
     
     static func saveLatestSwap(_ latestSwap:Swap?) {
-        
-        if latestSwap != nil {
-            let swapDictionary = CacheManager.swapToDictionary(latestSwap!)
+
+        if let swap = latestSwap {
+            let swapDictionary = CacheManager.swapToDictionary(swap).mutableCopy() as! NSMutableDictionary
+
+            if let privateKey = swap.privateKey, let boltzID = swap.boltzID {
+                if !KeychainManager.save(privateKey, forKey: "swapkey_\(boltzID)") {
+                    print("ERROR: Failed to save swap key to Keychain, keeping in UserDefaults")
+                    swapDictionary.setValue(privateKey, forKey: "privateKey")
+                }
+            }
+
             UserDefaults.standard.set(swapDictionary, forKey: "ongoingswap")
         } else {
-            if let storedSwap = UserDefaults.standard.value(forKey: "ongoingswap") as? NSDictionary {
-                UserDefaults.standard.removeObject(forKey: "ongoingswap")
+            if let storedSwap = UserDefaults.standard.value(forKey: "ongoingswap") as? NSDictionary,
+               let boltzID = storedSwap["boltzID"] as? String {
+                KeychainManager.delete(forKey: "swapkey_\(boltzID)")
             }
+            UserDefaults.standard.removeObject(forKey: "ongoingswap")
         }
     }
     
@@ -1145,11 +1146,9 @@ class CacheManager: NSObject {
         if let createdInvoice = dictionary["createdInvoice"] as? String {
             thisSwap.createdInvoice = createdInvoice
         }
-        if let privateKey = dictionary["privateKey"] as? String {
-            thisSwap.privateKey = privateKey
-        }
         if let boltzID = dictionary["boltzID"] as? String {
             thisSwap.boltzID = boltzID
+            thisSwap.privateKey = KeychainManager.load(forKey: "swapkey_\(boltzID)") ?? dictionary["privateKey"] as? String
         }
         if let boltzOnchainAddress = dictionary["boltzOnchainAddress"] as? String {
             thisSwap.boltzOnchainAddress = boltzOnchainAddress

--- a/bittr/Helpers/KeychainManager.swift
+++ b/bittr/Helpers/KeychainManager.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Security
+
+struct KeychainManager {
+
+    private static let serviceName = "com.getbittr.bittr"
+
+    // MARK: - Core Operations
+
+    static func save(_ value: String, forKey key: String) -> Bool {
+        guard let data = value.data(using: .utf8) else { return false }
+
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: key
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly
+        ]
+
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+
+    static func load(forKey key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func delete(forKey key: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: key
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+
+    // MARK: - Migration
+
+    static func migrateFromUserDefaults() {
+        guard !UserDefaults.standard.bool(forKey: "keychain_migration_v1") else { return }
+
+        let defaults = UserDefaults.standard
+
+        let mnemonicKey = EnvironmentConfig.cacheKey(for: "mnemonic")
+        if let mnemonic = defaults.value(forKey: mnemonicKey) as? String {
+            if save(mnemonic, forKey: mnemonicKey) {
+                defaults.removeObject(forKey: mnemonicKey)
+            }
+        }
+
+        let pinKey = EnvironmentConfig.cacheKey(for: "pin")
+        if let pin = defaults.value(forKey: pinKey) as? String {
+            if save(pin, forKey: pinKey) {
+                defaults.removeObject(forKey: pinKey)
+            }
+        }
+
+        migrateSwapPrivateKeys()
+
+        defaults.set(true, forKey: "keychain_migration_v1")
+    }
+
+    private static func migrateSwapPrivateKeys() {
+        if let swapDict = UserDefaults.standard.value(forKey: "ongoingswap") as? NSDictionary,
+           let privateKey = swapDict["privateKey"] as? String,
+           let boltzID = swapDict["boltzID"] as? String {
+            let swapKeyName = "swapkey_\(boltzID)"
+            if save(privateKey, forKey: swapKeyName) {
+                let mutableSwap = swapDict.mutableCopy() as! NSMutableDictionary
+                mutableSwap.removeObject(forKey: "privateKey")
+                UserDefaults.standard.set(mutableSwap, forKey: "ongoingswap")
+            }
+        }
+
+        migrateSwapFilesOnDisk()
+    }
+
+    private static func migrateSwapFilesOnDisk() {
+        let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        guard let files = try? FileManager.default.contentsOfDirectory(at: documentsPath, includingPropertiesForKeys: nil) else { return }
+
+        for file in files where file.pathExtension == "json" {
+            guard let data = try? Data(contentsOf: file),
+                  let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let privateKey = dict["privateKey"] as? String else { continue }
+
+            let swapID = file.deletingPathExtension().lastPathComponent
+            let swapKeyName = "swapkey_\(swapID)"
+            if save(privateKey, forKey: swapKeyName) {
+                var updated = dict
+                updated.removeValue(forKey: "privateKey")
+                if let updatedData = try? JSONSerialization.data(withJSONObject: updated, options: .prettyPrinted) {
+                    try? updatedData.write(to: file)
+                }
+            }
+        }
+    }
+}

--- a/bittr/Swaps/SwapManager.swift
+++ b/bittr/Swaps/SwapManager.swift
@@ -510,16 +510,23 @@ class SwapManager: NSObject {
     
     static func saveSwapDetailsToFile(swapID: String, swapDictionary: NSDictionary) {
         do {
-            // Convert NSDictionary to JSON Data
-            let jsonData = try JSONSerialization.data(withJSONObject: swapDictionary, options: .prettyPrinted)
-            
-            // Get the documents directory
+            let sanitised = swapDictionary.mutableCopy() as! NSMutableDictionary
+
+            if let privateKey = sanitised["privateKey"] as? String {
+                if KeychainManager.save(privateKey, forKey: "swapkey_\(swapID)") {
+                    sanitised.removeObject(forKey: "privateKey")
+                } else {
+                    print("ERROR: Failed to save swap key to Keychain, keeping in file")
+                }
+            }
+
+            let jsonData = try JSONSerialization.data(withJSONObject: sanitised, options: .prettyPrinted)
+
             let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
             let fileURL = documentsPath.appendingPathComponent("\(swapID).json")
-            
-            // Write the JSON data to file
+
             try jsonData.write(to: fileURL)
-            
+
             print("Swap details saved to: \(fileURL.path)")
         } catch {
             print("Error saving swap details to file: \(error)")
@@ -540,8 +547,10 @@ class SwapManager: NSObject {
             // Read the JSON data from file
             let jsonData = try Data(contentsOf: fileURL)
             
-            // Convert JSON Data to NSDictionary
-            if let dictionary = try JSONSerialization.jsonObject(with: jsonData, options: []) as? NSDictionary {
+            if let dictionary = try JSONSerialization.jsonObject(with: jsonData, options: .mutableContainers) as? NSMutableDictionary {
+                if let privateKey = KeychainManager.load(forKey: "swapkey_\(swapID)") {
+                    dictionary.setValue(privateKey, forKey: "privateKey")
+                }
                 return dictionary
             }
         } catch {


### PR DESCRIPTION
- storeMnemonic/storePin fall back to UserDefaults if Keychain save fails
- getMnemonic/getPin check both Keychain and UserDefaults
- saveLatestSwap keeps privateKey in dictionary if Keychain save fails
- saveSwapDetailsToFile keeps privateKey in JSON file if Keychain save fails
- dictionaryToSwap falls back to dictionary for privateKey
- Migration skips on subsequent launches via keychain_migration_v1 flag
