### PR TITLE
New wrong_pin test and associated updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ maestro test shared/flows/features/buy_more.yaml
 maestro test shared/flows/features/receive.yaml
 maestro test shared/flows/features/swap.yaml
 maestro test shared/flows/features/remove_wallet.yaml
+maestro test shared/flows/features/wrong_pin.yaml
 
 # Forgot-PIN recovery test — needs the wallet's 12-word mnemonic so the
 # flow can type it on the RestoreVC screen. Pass it via --env:

--- a/ios/bittr/BDKManager.swift
+++ b/ios/bittr/BDKManager.swift
@@ -18,10 +18,21 @@ extension BitcoinManager {
             if self.bdkWallet == nil {
                 Log.info("Will start blockchain and wallet.")
                 
+                // Bail out if the mnemonic has been cleared from the cache. This
+                // happens during a wallet wipe: performWalletReset deletes the
+                // mnemonic (deleteClientInfo) and clears bdkWallet (resetNodeState),
+                // so a didStartBDK that runs after teardown would force-unwrap a
+                // nil mnemonic and trap with a Swift _assertionFailure.
+                guard let cachedMnemonic = CacheManager.getMnemonic() else {
+                    Log.info("No mnemonic in cache; wallet is being torn down. Aborting BDK start.")
+                    completion(false)
+                    return
+                }
+
                 // Attempt to create a mnemonic object from the provided mnemonic string.
                 let mnemonic:BitcoinDevKit.Mnemonic
                 do {
-                    mnemonic = try BitcoinDevKit.Mnemonic.fromString(mnemonic: CacheManager.getMnemonic()!)
+                    mnemonic = try BitcoinDevKit.Mnemonic.fromString(mnemonic: cachedMnemonic)
                 } catch {
                     self.handleError(error: error, row: 178)
                     completion(false)

--- a/ios/bittr/Base.lproj/Main.storyboard
+++ b/ios/bittr/Base.lproj/Main.storyboard
@@ -1396,7 +1396,7 @@
                                                         <view contentMode="scaleToFill" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="sVK-Sk-MNX" userLabel="Labels View">
                                                             <rect key="frame" x="82.333333333333329" y="12.333333333333336" width="255.66666666666669" height="35"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="+ 3 700 sats" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="97L-nn-l0P">
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="+ 3 700 sats" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="97L-nn-l0P">
                                                                     <rect key="frame" x="0.0" y="0.0" width="87.666666666666671" height="16"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="5" id="Omc-6m-9MB"/>
@@ -1405,7 +1405,7 @@
                                                                     <color key="textColor" red="0.1647058824" green="0.16862745100000001" blue="0.18039215689999999" alpha="1" colorSpace="calibratedRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="+ 30 €" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xRz-e9-LZI">
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="+ 30 €" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xRz-e9-LZI">
                                                                     <rect key="frame" x="0.0" y="21" width="39.333333333333336" height="14"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="5" id="StM-Ll-Dhj"/>
@@ -4776,7 +4776,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="questionmark.circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="KOs-4g-DFg">
-                                                                <rect key="frame" x="292" y="15.666666666666666" width="16" height="14.66666666666667"/>
+                                                                <rect key="frame" x="292" y="15.666666666666664" width="16" height="14.666666666666671"/>
                                                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="16" id="Pn8-yh-hap"/>
@@ -5305,7 +5305,7 @@
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="questionmark.circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="dq2-SL-iU3">
-                                                                        <rect key="frame" x="81" y="15.666666666666664" width="16" height="14.666666666666671"/>
+                                                                        <rect key="frame" x="81" y="15.666666666666666" width="16" height="14.66666666666667"/>
                                                                         <color key="tintColor" red="0.96470588239999999" green="0.78039215689999997" blue="0.2666666667" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" constant="16" id="Ngv-Nw-Gml"/>
@@ -5695,7 +5695,7 @@
                                                             <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kG5-Qs-5Fr">
                                                                 <rect key="frame" x="15" y="456.99999999999994" width="333" height="0.0"/>
                                                                 <subviews>
-                                                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="m68-r3-Pfp" userLabel="Amount Stack">
+                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="m68-r3-Pfp" userLabel="Amount Stack">
                                                                         <rect key="frame" x="0.0" y="14" width="333" height="45"/>
                                                                         <subviews>
                                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y8U-vs-ZEU" userLabel="Amount Stack">
@@ -5788,7 +5788,7 @@
                                                                             <constraint firstAttribute="bottom" secondItem="y8U-vs-ZEU" secondAttribute="bottom" id="ySW-dr-nOy"/>
                                                                         </constraints>
                                                                     </view>
-                                                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FfM-w7-k3O" userLabel="Description Stack">
+                                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FfM-w7-k3O" userLabel="Description Stack">
                                                                         <rect key="frame" x="0.0" y="59" width="333" height="55"/>
                                                                         <subviews>
                                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zLc-nS-Jef" userLabel="Description View">
@@ -7022,7 +7022,7 @@
                                                                 <rect key="frame" x="0.0" y="155" width="363" height="0.0"/>
                                                                 <subviews>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zdf-NG-6QO">
-                                                                        <rect key="frame" x="10" y="10" width="343" height="45"/>
+                                                                        <rect key="frame" x="10" y="10" width="343" height="14"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Description" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ou8-ne-Kdk">
                                                                                 <rect key="frame" x="15" y="16" width="84.666666666666671" height="16"/>
@@ -7044,7 +7044,7 @@
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JmT-eu-OKC">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="45"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="14"/>
                                                                                 <state key="normal" title="Button"/>
                                                                                 <buttonConfiguration key="configuration" style="plain"/>
                                                                                 <connections>
@@ -7690,7 +7690,7 @@
                                                                 <rect key="frame" x="0.0" y="265" width="363" height="0.0"/>
                                                                 <subviews>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uI8-V5-ew0">
-                                                                        <rect key="frame" x="10" y="10" width="343" height="45"/>
+                                                                        <rect key="frame" x="10" y="10" width="343" height="14"/>
                                                                         <subviews>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Note" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Xu-wD-MUR">
                                                                                 <rect key="frame" x="15" y="16" width="84.666666666666671" height="16"/>
@@ -7712,7 +7712,7 @@
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eWK-5t-hc0">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="45"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="14"/>
                                                                                 <state key="normal" title="Button"/>
                                                                                 <buttonConfiguration key="configuration" style="plain"/>
                                                                                 <connections>
@@ -8453,11 +8453,11 @@
                                                                 <collectionViewCell opaque="NO" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="LessonCell" id="bJT-XL-71f" customClass="LessonCollectionViewCell" customModule="bittr" customModuleProvider="target">
                                                                     <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                                    <collectionViewCellContentView key="contentView" opaque="NO" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="J7n-2u-shf">
+                                                                    <collectionViewCellContentView key="contentView" opaque="NO" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="J7n-2u-shf">
                                                                         <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                         <subviews>
-                                                                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="p4g-Q8-wrQ">
+                                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p4g-Q8-wrQ">
                                                                                 <rect key="frame" x="34" y="0.0" width="60" height="60"/>
                                                                                 <subviews>
                                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="QOD-e6-nHB">
@@ -8475,24 +8475,24 @@
                                                                                     <constraint firstAttribute="width" constant="60" id="nD7-cD-BaX"/>
                                                                                 </constraints>
                                                                             </view>
-                                                                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="iconcheck" translatesAutoresizingMaskIntoConstraints="NO" id="WRW-oV-d1f">
+                                                                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconcheck" translatesAutoresizingMaskIntoConstraints="NO" id="WRW-oV-d1f">
                                                                                 <rect key="frame" x="55" y="49" width="18" height="18"/>
                                                                                 <constraints>
                                                                                     <constraint firstAttribute="width" constant="18" id="HPV-z8-UXk"/>
                                                                                     <constraint firstAttribute="height" constant="18" id="bDj-Wj-Cbl"/>
                                                                                 </constraints>
                                                                             </imageView>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rkN-45-mAZ">
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rkN-45-mAZ">
                                                                                 <rect key="frame" x="0.0" y="73" width="128" height="55"/>
                                                                                 <fontDescription key="fontDescription" name="Gilroy-Bold" family="Gilroy-Bold" pointSize="15"/>
                                                                                 <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
-                                                                            <view alpha="0.0" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="arb-yg-aZ4">
+                                                                            <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="arb-yg-aZ4">
                                                                                 <rect key="frame" x="-2.6666666666666714" y="-10" width="133.33333333333337" height="148"/>
                                                                                 <color key="backgroundColor" red="0.89803921568627454" green="0.74117647058823533" blue="0.30980392156862746" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="displayP3"/>
                                                                             </view>
-                                                                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FyW-61-BPb">
+                                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FyW-61-BPb">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                                                 <state key="normal" title="Button"/>
                                                                                 <buttonConfiguration key="configuration" style="plain"/>
@@ -12319,7 +12319,7 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AWQ-U6-cqX" userLabel="Center View">
-                                                <rect key="frame" x="0.0" y="135" width="393" height="502"/>
+                                                <rect key="frame" x="0.0" y="143" width="393" height="486"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter your 12-word recovery phrase." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b2U-cM-wNI">
                                                         <rect key="frame" x="40" y="0.0" width="313" height="16"/>
@@ -12331,7 +12331,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RAM-7X-Ggi" userLabel="Background Button">
-                                                        <rect key="frame" x="0.0" y="0.0" width="393" height="502"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="393" height="486"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain"/>
                                                         <connections>
@@ -12816,10 +12816,10 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C3v-qR-7E9" userLabel="Save View">
-                                                        <rect key="frame" x="130.66666666666669" y="316" width="131.66666666666669" height="45"/>
+                                                        <rect key="frame" x="130.66666666666669" y="316" width="131.66666666666669" height="40"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Restore wallet" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dp7-f1-bPp">
-                                                                <rect key="frame" x="20.000000000000007" y="16.666666666666686" width="91.666666666666686" height="14"/>
+                                                                <rect key="frame" x="20.000000000000007" y="14" width="91.666666666666686" height="14"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="25h-e4-s4k"/>
                                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="10" id="5C9-16-7o8"/>
@@ -12829,11 +12829,11 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="zmA-Fz-18a">
-                                                                <rect key="frame" x="56" y="12.666666666666686" width="20" height="20"/>
+                                                                <rect key="frame" x="56" y="10" width="20" height="20"/>
                                                                 <color key="color" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                             </activityIndicatorView>
                                                             <button opaque="NO" tag="-3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kzb-Os-Awg">
-                                                                <rect key="frame" x="0.0" y="0.0" width="131.66666666666666" height="45"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="131.66666666666666" height="40"/>
                                                                 <accessibility key="accessibilityConfiguration" identifier="-3"/>
                                                                 <state key="normal" title="Button"/>
                                                                 <buttonConfiguration key="configuration" style="plain"/>
@@ -12853,7 +12853,7 @@
                                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="KoV-Dy-Zk1"/>
                                                             <constraint firstItem="Dp7-f1-bPp" firstAttribute="centerY" secondItem="C3v-qR-7E9" secondAttribute="centerY" constant="1" id="QiG-dj-J4P"/>
                                                             <constraint firstItem="zmA-Fz-18a" firstAttribute="centerX" secondItem="C3v-qR-7E9" secondAttribute="centerX" id="Tki-XD-Wbe"/>
-                                                            <constraint firstAttribute="height" constant="45" id="be8-Oh-W6A"/>
+                                                            <constraint firstAttribute="height" constant="40" id="be8-Oh-W6A"/>
                                                             <constraint firstItem="kzb-Os-Awg" firstAttribute="top" secondItem="C3v-qR-7E9" secondAttribute="top" id="gb4-mk-kD4"/>
                                                             <constraint firstItem="Dp7-f1-bPp" firstAttribute="leading" secondItem="C3v-qR-7E9" secondAttribute="leading" constant="20" id="hmz-bF-dHc"/>
                                                             <constraint firstItem="zmA-Fz-18a" firstAttribute="centerY" secondItem="C3v-qR-7E9" secondAttribute="centerY" id="j7T-qn-fOk"/>
@@ -12861,7 +12861,7 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bvf-DZ-G8h" userLabel="Restore View">
-                                                        <rect key="frame" x="116.66666666666669" y="371" width="160" height="25"/>
+                                                        <rect key="frame" x="116.66666666666669" y="366" width="160" height="25"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cancel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4hr-5n-L9F">
                                                                 <rect key="frame" x="56.999999999999986" y="6.6666666666666288" width="46" height="14"/>
@@ -12899,26 +12899,26 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YT8-l7-o0H" userLabel="Card View">
-                                                        <rect key="frame" x="146" y="446" width="101" height="56"/>
+                                                        <rect key="frame" x="156.66666666666666" y="441" width="80" height="45"/>
                                                         <subviews>
                                                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gRi-6I-U13" userLabel="Image Container">
-                                                                <rect key="frame" x="0.0" y="0.0" width="86" height="56"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="53" height="45"/>
                                                                 <subviews>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="4rh-of-tCk">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="66" height="56"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="45" height="45"/>
                                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         <constraints>
-                                                                            <constraint firstAttribute="width" constant="66" id="K4N-qV-4Xt"/>
+                                                                            <constraint firstAttribute="width" constant="45" id="K4N-qV-4Xt"/>
                                                                         </constraints>
                                                                     </imageView>
                                                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="QOP-GF-pFR">
-                                                                        <rect key="frame" x="23" y="18" width="20" height="20"/>
+                                                                        <rect key="frame" x="12.333333333333343" y="12.666666666666629" width="20" height="20"/>
                                                                         <color key="color" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                     </activityIndicatorView>
                                                                 </subviews>
                                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" constant="86" id="8me-LN-2fQ"/>
+                                                                    <constraint firstAttribute="width" constant="53" id="8me-LN-2fQ"/>
                                                                     <constraint firstItem="QOP-GF-pFR" firstAttribute="centerX" secondItem="4rh-of-tCk" secondAttribute="centerX" id="IfM-pe-k9J"/>
                                                                     <constraint firstItem="4rh-of-tCk" firstAttribute="leading" secondItem="gRi-6I-U13" secondAttribute="leading" id="JBc-OH-raI"/>
                                                                     <constraint firstAttribute="bottom" secondItem="4rh-of-tCk" secondAttribute="bottom" id="gr3-Ef-so4"/>
@@ -12927,13 +12927,13 @@
                                                                 </constraints>
                                                             </view>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fj1-P5-K6P" userLabel="Title Label">
-                                                                <rect key="frame" x="81" y="7" width="0.0" height="46"/>
+                                                                <rect key="frame" x="60" y="7" width="0.0" height="35"/>
                                                                 <fontDescription key="fontDescription" name="Gilroy-Bold" family="Gilroy-Bold" pointSize="15"/>
                                                                 <color key="textColor" red="0.1647058824" green="0.16862745100000001" blue="0.18039215689999999" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j3s-rm-YyA">
-                                                                <rect key="frame" x="0.0" y="0.0" width="101" height="56"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="80" height="45"/>
                                                                 <state key="normal" title="Button"/>
                                                                 <buttonConfiguration key="configuration" style="plain"/>
                                                                 <connections>
@@ -12948,17 +12948,17 @@
                                                             <constraint firstAttribute="bottom" secondItem="fj1-P5-K6P" secondAttribute="bottom" constant="3" id="Cze-VB-dPN"/>
                                                             <constraint firstAttribute="bottom" secondItem="gRi-6I-U13" secondAttribute="bottom" id="Lf7-oR-lKU"/>
                                                             <constraint firstAttribute="bottom" secondItem="j3s-rm-YyA" secondAttribute="bottom" id="TLt-Bc-Nkg"/>
-                                                            <constraint firstItem="fj1-P5-K6P" firstAttribute="leading" secondItem="gRi-6I-U13" secondAttribute="trailing" constant="-5" id="XNq-ma-7DE"/>
+                                                            <constraint firstItem="fj1-P5-K6P" firstAttribute="leading" secondItem="gRi-6I-U13" secondAttribute="trailing" constant="7" id="XNq-ma-7DE"/>
                                                             <constraint firstItem="gRi-6I-U13" firstAttribute="leading" secondItem="YT8-l7-o0H" secondAttribute="leading" id="YCN-QX-ETQ"/>
                                                             <constraint firstItem="j3s-rm-YyA" firstAttribute="top" secondItem="YT8-l7-o0H" secondAttribute="top" id="djz-JG-G5C"/>
                                                             <constraint firstItem="fj1-P5-K6P" firstAttribute="top" secondItem="YT8-l7-o0H" secondAttribute="top" constant="7" id="iiq-Li-LrB"/>
                                                             <constraint firstItem="j3s-rm-YyA" firstAttribute="leading" secondItem="YT8-l7-o0H" secondAttribute="leading" id="lza-aO-q4N"/>
-                                                            <constraint firstAttribute="height" constant="56" id="yIS-0S-hSW"/>
+                                                            <constraint firstAttribute="height" constant="45" id="yIS-0S-hSW"/>
                                                             <constraint firstItem="gRi-6I-U13" firstAttribute="top" secondItem="YT8-l7-o0H" secondAttribute="top" id="ysm-3i-8Zl"/>
                                                         </constraints>
                                                     </view>
                                                     <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ghE-Qq-ybU" userLabel="Remove Wallet Stack">
-                                                        <rect key="frame" x="0.0" y="502" width="393" height="0.0"/>
+                                                        <rect key="frame" x="0.0" y="486" width="393" height="0.0"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Remove wallet from device" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2bH-cK-uoZ">
                                                                 <rect key="frame" x="109.33333333333333" y="-24" width="174.33333333333337" height="14"/>
@@ -13879,10 +13879,10 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGreenColor">
-            <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemRedColor">
-            <color red="1" green="0.2196078431372549" blue="0.23529411764705882" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.21960784310000001" blue="0.23529411759999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/ios/bittr/BitcoinManager.swift
+++ b/ios/bittr/BitcoinManager.swift
@@ -336,9 +336,13 @@ class BitcoinManager {
             throw NSError(domain: "InvalidInput", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid input string. Couldn't convert to UTF8 data."])
         }
         
+        guard let actualLdkNode = self.ldkNode else {
+            throw NSError(domain: "NodeUnavailable", code: 0, userInfo: [NSLocalizedDescriptionKey: "Lightning node is not available."])
+        }
+
         let bytes = [UInt8](data)
-        let signedMessage = self.ldkNode!.signMessage(msg: bytes)
-        
+        let signedMessage = actualLdkNode.signMessage(msg: bytes)
+
         return signedMessage
     }
     

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -346,7 +346,13 @@ extension HomeViewController {
         let cachedBtcBalance = (CacheManager.getCachedData(key: "satsbalance") as? String ?? "0").toNumber().inBTC()
         let conversionLabelText = self.updateConversionLabel(btcValue: cachedBtcBalance)
         CacheManager.updateCachedData(data: conversionLabelText, key: "conversion")
-        self.conversionLabel.alpha = 1
+
+        // Only reveal the conversion once the balance is known (i.e. the sats
+        // balance label is showing). Otherwise it would display €0 while the
+        // wallet is still syncing and has no cached balance.
+        if self.balanceLabel.alpha == 1 {
+            self.conversionLabel.alpha = 1
+        }
     }
     
     
@@ -532,12 +538,16 @@ extension HomeViewController {
         
         if accumulatedInvestments != 0 {
             self.balanceCardGainLabel.text = "\(Int(((CGFloat(accumulatedProfit)/CGFloat(accumulatedInvestments))*100).rounded())) %".replacingOccurrences(of: "-", with: "")
-            self.balanceCardGainLabel.alpha = 1
-            self.balanceCardProfitView.alpha = 1
         } else {
+            self.balanceCardGainLabel.text = "0 %"
+        }
+
+        // Only reveal the profit once the balance is known (i.e. the sats
+        // balance label is showing). Otherwise it would display 0 % while the
+        // wallet is still syncing and has no cached balance.
+        if self.balanceLabel.alpha == 1 {
             self.balanceCardGainLabel.alpha = 1
             self.balanceCardProfitView.alpha = 1
-            self.balanceCardGainLabel.text = "0 %"
         }
         
         if accumulatedProfit < 0 {
@@ -598,7 +608,10 @@ extension HomeViewController {
                     userHasBittrAccount = true
                 }
             }
-            if userHasBittrAccount {
+            // Skip the payout check when a wipe / PIN reset is in progress: the
+            // node is about to be torn down, so signing a message against it
+            // would race the teardown (force-unwrap of a nil ldkNode).
+            if userHasBittrAccount, !self.coreVC!.resettingPin, !self.coreVC!.removingWalletForIncorrectPin {
                 Log.info("Check for pending payout.")
                 self.coreVC!.checkPendingPayout()
             }

--- a/ios/bittr/Pin/PinViewController.swift
+++ b/ios/bittr/Pin/PinViewController.swift
@@ -196,18 +196,7 @@ class PinViewController: UIViewController, UITextFieldDelegate, UICollectionView
         case .core:
             // Check internet connection.
             guard (self.coreVC ?? self).checkInternetConnection() else { return }
-            
-            if CacheManager.getFailedPinAttempts() > 9 {
-                Log.info("Wrong pin has been entered 10 times.")
-                self.showAlert(presentingController: self.coreVC ?? self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "pinlock"), buttons: [Language.getWord(withID: "okay")], actions: [#selector(self.clearPinField)])
-                
-                Log.info("Remove wallet from device.")
-                self.coreVC?.removingWalletForIncorrectPin = true
-                self.coreVC?.restoreWalletTapped()
-                
-                return
-            }
-            
+
             if self.correctPin != nil {
                 if self.correctPin! == self.pinTextField.text {
                     // Correct pin.
@@ -216,6 +205,17 @@ class PinViewController: UIViewController, UITextFieldDelegate, UICollectionView
                     self.coreVC?.correctPin(spinner:self.pinSpinner)
                 } else {
                     // Wrong pin.
+                    if CacheManager.getFailedPinAttempts() == 9 {
+                        Log.info("Wrong pin has been entered 10 times.")
+                        self.showAlert(presentingController: self.coreVC ?? self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "pinlock"), buttons: [Language.getWord(withID: "okay")], actions: [#selector(self.clearPinField)])
+
+                        Log.info("Remove wallet from device.")
+                        self.coreVC?.removingWalletForIncorrectPin = true
+                        self.coreVC?.restoreWalletTapped()
+
+                        return
+                    }
+
                     CacheManager.increaseFailedPinAttempts()
                     self.showAlert(presentingController: self.coreVC ?? self, title: Language.getWord(withID: "incorrectpin"), message: Language.getWord(withID: "incorrectpin2"), buttons: [Language.getWord(withID: "okay")], actions: [#selector(self.clearPinField)])
                 }

--- a/ios/bittr/Pin/PinViewController.swift
+++ b/ios/bittr/Pin/PinViewController.swift
@@ -205,7 +205,7 @@ class PinViewController: UIViewController, UITextFieldDelegate, UICollectionView
                     self.coreVC?.correctPin(spinner:self.pinSpinner)
                 } else {
                     // Wrong pin.
-                    if CacheManager.getFailedPinAttempts() == 9 {
+                    if CacheManager.getFailedPinAttempts() >= 9 {
                         Log.info("Wrong pin has been entered 10 times.")
                         self.showAlert(presentingController: self.coreVC ?? self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "pinlock"), buttons: [Language.getWord(withID: "okay")], actions: [#selector(self.clearPinField)])
 

--- a/ios/bittr/Signup/Restore Wallet/RestoreViewController.swift
+++ b/ios/bittr/Signup/Restore Wallet/RestoreViewController.swift
@@ -88,9 +88,11 @@ class RestoreViewController: UIViewController, UITextFieldDelegate {
 
         // Corner radii
         self.mnemonicView.layer.cornerRadius = 13
-        self.restoreView.layer.cornerRadius = 13
-        self.cardView.layer.cornerRadius = 13
-        self.imageContainer.layer.cornerRadius = 13
+        self.mnemonicView.setShadow()
+        self.restoreView.layer.cornerRadius = 8
+        self.cardView.layer.cornerRadius = 8
+        self.cardView.setShadow()
+        self.imageContainer.layer.cornerRadius = 8
         
         // Button titles
         self.restoreButton.setTitle("", for: .normal)

--- a/shared/flows/README.md
+++ b/shared/flows/README.md
@@ -26,6 +26,9 @@ shared/flows/
     remove_wallet.yaml    Settings → Restore wallet. Handles both branches
                           (active channel → close → mine → re-trigger; no
                           channel → direct confirm).
+    wrong_pin.yaml        PIN lockout from the unlock screen — ten wrong
+                          PINs wipe the wallet and drop back to Signup1
+                          (run onboarding/restore_wallet.yaml first).
   helpers/         Reusable subflows invoked via runFlow.
     unlock.yaml           Enters PIN 1234 on the unlock screen.
   scripts/         Maestro `runScript` helpers (GraalJS).

--- a/shared/flows/features/wrong_pin.yaml
+++ b/shared/flows/features/wrong_pin.yaml
@@ -47,14 +47,23 @@ appId: com.bittr.bittr-regtest
 # not match, so the "incorrect PIN" alert appears. Tapping its Okay button
 # (alert.button.0) runs clearPinField: dismisses the alert and clears the
 # field ready for the next attempt.
+#
+# The digit taps use waitToSettleTimeoutMs: 0 to skip Maestro's
+# wait-for-animation-to-settle after each tap — the PIN buttons only flash a
+# background and toggle a dot, so there's nothing meaningful to wait for. This
+# is the main speed-up for the 40+ digit taps in this flow.
 - tapOn:
     id: "pin.button1"
+    waitToSettleTimeoutMs: 0
 - tapOn:
     id: "pin.button1"
+    waitToSettleTimeoutMs: 0
 - tapOn:
     id: "pin.button1"
+    waitToSettleTimeoutMs: 0
 - tapOn:
     id: "pin.button1"
+    waitToSettleTimeoutMs: 0
 - tapOn:
     id: "pin.confirmButton"
 - assertVisible:
@@ -71,12 +80,16 @@ appId: com.bittr.bittr-regtest
     commands:
       - tapOn:
           id: "pin.button1"
+          waitToSettleTimeoutMs: 0
       - tapOn:
           id: "pin.button1"
+          waitToSettleTimeoutMs: 0
       - tapOn:
           id: "pin.button1"
+          waitToSettleTimeoutMs: 0
       - tapOn:
           id: "pin.button1"
+          waitToSettleTimeoutMs: 0
       - tapOn:
           id: "pin.confirmButton"
       - assertVisible:
@@ -85,24 +98,30 @@ appId: com.bittr.bittr-regtest
           id: "alert.button.0"
 
 # Wrong PIN attempt 10. The counter now reads 9, so this entry triggers the
-# lockout alert (different copy: "restore wallet" / pinlock) instead of the
-# "incorrect PIN" alert, and simultaneously kicks off the wallet wipe. Close
-# the lockout alert via its Okay button.
+# lockout instead of the "incorrect PIN" alert, and kicks off the wallet wipe.
+#
+# Note: unlike attempts 1..9, we do NOT tap an Okay button here. The lockout
+# alert (restorewallet / pinlock) is shown and then immediately dismissed by
+# the wipe itself: the handler synchronously calls restoreWalletTapped() ->
+# startWalletInBackground(), whose first line is hideAlert(). All of this runs
+# in one main-thread turn, so the lockout alert never reliably renders — we
+# can't (and don't need to) tap it. The confirm tap goes straight into the
+# wipe, and the app advances to Signup1 on its own.
 - tapOn:
     id: "pin.button1"
+    waitToSettleTimeoutMs: 0
 - tapOn:
     id: "pin.button1"
+    waitToSettleTimeoutMs: 0
 - tapOn:
     id: "pin.button1"
+    waitToSettleTimeoutMs: 0
 - tapOn:
     id: "pin.button1"
+    waitToSettleTimeoutMs: 0
 - tapOn:
     id: "pin.confirmButton"
-- assertVisible:
-    id: "alert.button.0"
-- takeScreenshot: shared/docs/screenshots/wrong_pin/03_lockout_alert
-- tapOn:
-    id: "alert.button.0"
+- takeScreenshot: shared/docs/screenshots/wrong_pin/03_wipe_started
 
 # The wipe runs in the background: startWalletInBackground syncs the wallet,
 # finalizeSync re-enters restoreWalletTapped, performWalletReset clears

--- a/shared/flows/features/wrong_pin.yaml
+++ b/shared/flows/features/wrong_pin.yaml
@@ -1,0 +1,115 @@
+# Feature test: the PIN lockout path. Entering the wrong PIN ten times on
+# the unlock screen wipes the wallet from the device and drops the user
+# back on Signup1, so they no longer have access to the installed wallet.
+#
+# Prerequisite: an existing wallet on the simulator, freshly set up so the
+# failed-attempt counter is at 0 (CacheManager.getFailedPinAttempts() == 0)
+# and there is no open Lightning channel. The cleanest way to get there is
+# to run `shared/flows/onboarding/restore_wallet.yaml` first — same starting
+# style as buy_signup.yaml. The flow preserves state (no clearState /
+# clearKeychain) and lands on the PIN unlock screen.
+#
+# This flow is destructive: it removes the wallet. It can only be run once
+# against a freshly-restored wallet (a second run would find no wallet to
+# unlock).
+#
+# Behaviour under test (PinViewController.confirmPinButtonTapped, .core):
+#   - Wrong PIN entries 1..9 each call increaseFailedPinAttempts() and show
+#     the "incorrect PIN" alert (incorrectpin / incorrectpin2).
+#   - On entry 10, getFailedPinAttempts() == 9, so the lockout alert
+#     (restorewallet / pinlock) is shown and removingWalletForIncorrectPin
+#     is set + restoreWalletTapped() kicks off the wipe. The lockout check
+#     lives inside the wrong-pin branch, so a correct 10th entry still
+#     unlocks normally.
+#   - ResetApp drives startWallet → finalizeSync → restoreWalletTapped →
+#     performWalletReset → 1s delay → launchSignup(onPage: 3) → Signup1.
+#
+# Both alerts expose a single Okay button (alert.button.0) wired to
+# clearPinField, which dismisses the alert and clears the PIN field. The
+# alert IDs are set in AlertManager.swift (mainButton.accessibilityIdentifier
+# = "alert.button.\(index)"), not in shared/test-ids/test-ids.json — same
+# pattern forgot_pin.yaml / remove_wallet.yaml rely on.
+#
+# Run: maestro test shared/flows/features/wrong_pin.yaml
+
+appId: com.bittr.bittr-regtest
+---
+- launchApp
+
+# Wallet was set up previously, so launch lands on the PIN unlock screen
+# (PinVC in .core embedding). Fail loudly otherwise — there'd be no wallet
+# to lock out of.
+- assertVisible:
+    id: "unlock.topLabel"
+- takeScreenshot: shared/docs/screenshots/wrong_pin/01_unlock
+
+# Wrong PIN attempt 1 of 10. Type 1111 and confirm — correctPin (1234) does
+# not match, so the "incorrect PIN" alert appears. Tapping its Okay button
+# (alert.button.0) runs clearPinField: dismisses the alert and clears the
+# field ready for the next attempt.
+- tapOn:
+    id: "pin.button1"
+- tapOn:
+    id: "pin.button1"
+- tapOn:
+    id: "pin.button1"
+- tapOn:
+    id: "pin.button1"
+- tapOn:
+    id: "pin.confirmButton"
+- assertVisible:
+    id: "alert.button.0"
+- takeScreenshot: shared/docs/screenshots/wrong_pin/02_incorrect_alert
+- tapOn:
+    id: "alert.button.0"
+
+# Wrong PIN attempts 2..9 (8 more "incorrect PIN" alerts). Each iteration
+# re-enters 1111, confirms, waits for the alert and closes it. After the
+# 9th attempt the failed-attempt counter sits at 9.
+- repeat:
+    times: 8
+    commands:
+      - tapOn:
+          id: "pin.button1"
+      - tapOn:
+          id: "pin.button1"
+      - tapOn:
+          id: "pin.button1"
+      - tapOn:
+          id: "pin.button1"
+      - tapOn:
+          id: "pin.confirmButton"
+      - assertVisible:
+          id: "alert.button.0"
+      - tapOn:
+          id: "alert.button.0"
+
+# Wrong PIN attempt 10. The counter now reads 9, so this entry triggers the
+# lockout alert (different copy: "restore wallet" / pinlock) instead of the
+# "incorrect PIN" alert, and simultaneously kicks off the wallet wipe. Close
+# the lockout alert via its Okay button.
+- tapOn:
+    id: "pin.button1"
+- tapOn:
+    id: "pin.button1"
+- tapOn:
+    id: "pin.button1"
+- tapOn:
+    id: "pin.button1"
+- tapOn:
+    id: "pin.confirmButton"
+- assertVisible:
+    id: "alert.button.0"
+- takeScreenshot: shared/docs/screenshots/wrong_pin/03_lockout_alert
+- tapOn:
+    id: "alert.button.0"
+
+# The wipe runs in the background: startWalletInBackground syncs the wallet,
+# finalizeSync re-enters restoreWalletTapped, performWalletReset clears
+# state and stops the node, then after a ~1s delay relaunches signup on
+# page 3 (Signup1). Allow generous slack for the sync + node teardown.
+- extendedWaitUntil:
+    visible:
+      id: "signup.create.start.createWalletButton"
+    timeout: 120000
+- takeScreenshot: shared/docs/screenshots/wrong_pin/04_signup1


### PR DESCRIPTION
## Summary
- New test `shared/flows/features/wrong_pin.yaml` — enters the wrong PIN ten
  times, closes each alert, asserts the wallet is wiped and lands on Signup1.
- PinViewController: lockout check moved inside the wrong-PIN branch.
- BitcoinManager.signMessage: guard self.ldkNode instead of force-unwrapping, to prevent crash during wallet reset.
- LoadWalletData: skip checkPendingPayout during a wipe/PIN reset.
- LoadWalletData: only reveal the euro + profit labels once the sats balance is known.
- Incidental: RestoreViewController styling.