### PR TITLE
Add academy.yaml test for the AcademyVC

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ maestro test shared/flows/features/remove_wallet.yaml
 maestro test shared/flows/features/wrong_pin.yaml
 maestro test shared/flows/features/bitcoin_value.yaml
 maestro test shared/flows/features/bitcoin_map.yaml
+maestro test shared/flows/features/academy.yaml
 
 # Forgot-PIN recovery test — needs the wallet's 12-word mnemonic so the
 # flow can type it on the RestoreVC screen. Pass it via --env:

--- a/ios/bittr/Academy/Academy/AcademyVC/AcademyViewController.swift
+++ b/ios/bittr/Academy/Academy/AcademyVC/AcademyViewController.swift
@@ -20,7 +20,10 @@ class AcademyViewController: UIViewController, UITableViewDelegate, UITableViewD
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
+        // Maestro test ID.
+        self.headerLabel.accessibilityIdentifier = TestID.Academy.headerLabel
+
         // Table view.
         self.academyTableView.delegate = self
         self.academyTableView.dataSource = self

--- a/ios/bittr/Academy/Academy/AcademyVC/LevelTableViewCell.swift
+++ b/ios/bittr/Academy/Academy/AcademyVC/LevelTableViewCell.swift
@@ -157,19 +157,23 @@ class LevelTableViewCell: UITableViewCell, UICollectionViewDelegate, UICollectio
                 // Lesson is available to user.
                 cell.removeBlur()
                 cell.lessonButton.alpha = 1
-                
+
                 if CacheManager.getCompletedLessons().contains(thisLesson.id) {
                     // Lesson has been completed.
                     cell.iconCheck.alpha = 1
+                    cell.lessonButton.accessibilityIdentifier = nil
                 } else {
-                    // Lesson has not yet been completed.
+                    // Lesson has not yet been completed — this is the latest
+                    // available lesson (the single "frontier" the user can start).
                     cell.iconCheck.alpha = 0
+                    cell.lessonButton.accessibilityIdentifier = TestID.Academy.nextLessonButton
                 }
             } else {
                 // Lesson is not yet available to user.
                 cell.addBlur()
                 cell.lessonButton.alpha = 0
                 cell.iconCheck.alpha = 0
+                cell.lessonButton.accessibilityIdentifier = nil
             }
             
             return cell

--- a/ios/bittr/Academy/Academy/OneLessonVC/Button.swift
+++ b/ios/bittr/Academy/Academy/OneLessonVC/Button.swift
@@ -145,6 +145,9 @@ extension OneLessonViewController {
         nextButton.setTitle("", for: .normal)
         nextButton.isUserInteractionEnabled = true
         nextButton.translatesAutoresizingMaskIntoConstraints = false
+        // Maestro test ID — same button advances the page ("Next") and, on the
+        // final page, completes the lesson ("Complete").
+        nextButton.accessibilityIdentifier = lastPage ? TestID.Academy.completeButton : TestID.Academy.nextPageButton
         nextButton.addTarget(self, action: #selector(self.nextPage), for: .touchUpInside)
         nextButtonView.addSubview(nextButton)
         

--- a/ios/bittr/Academy/Academy/OneLessonVC/OneLessonViewController.swift
+++ b/ios/bittr/Academy/Academy/OneLessonVC/OneLessonViewController.swift
@@ -29,7 +29,10 @@ class OneLessonViewController: UIViewController {
         
         // Color management
         self.changeColors()
-        
+
+        // Maestro test ID.
+        self.centerSpinner.accessibilityIdentifier = TestID.Academy.lessonSpinner
+
         if self.thisLesson != nil {
             
             self.addHeader(iconLight: "iconacademy", iconDark: "iconacademyyellow", title: self.thisLesson!.title)

--- a/ios/bittr/Helpers/TestIDs.swift
+++ b/ios/bittr/Helpers/TestIDs.swift
@@ -3,6 +3,13 @@
 // Regenerate: ./shared/test-ids/build.py
 
 enum TestID {
+    enum Academy {
+        static let completeButton = "academy.completeButton"
+        static let headerLabel = "academy.headerLabel"
+        static let lessonSpinner = "academy.lessonSpinner"
+        static let nextLessonButton = "academy.nextLessonButton"
+        static let nextPageButton = "academy.nextPageButton"
+    }
     enum Buy {
         static let continueButton = "buy.continueButton"
         static let downButton = "buy.downButton"

--- a/shared/docs/parity.md
+++ b/shared/docs/parity.md
@@ -12,11 +12,12 @@ Per-feature status of iOS vs Android implementation. Updated as Maestro flows go
 | Swap (lightning ↔ onchain, both directions) | done | not started | `features/swap.yaml` | Re-uses existing channel + onchain balance from prior buy flow. |
 | Bitcoin value chart | done | not started | `features/bitcoin_value.yaml` | Opens from Home's currency icon; waits for price data, scrubs the graph, switches span m/y/5y. Needs an existing wallet (unlocks with PIN). |
 | Bitcoin map | done | not started | `features/bitcoin_map.yaml` | Opens from Home's map icon; waits for the btcmap sync, opens/closes a place, moves the map, recentres on user. Grants location via launchApp; needs an existing wallet (unlocks with PIN). |
+| Academy | done | not started | `features/academy.yaml` | Opens the Academy tab, plays the latest available lesson to completion (paging Next→Complete, waiting on image-download spinners), then opens the next unlocked lesson. Needs an existing wallet (unlocks with PIN). |
 | Pin unlock (subflow) | done | not started | `helpers/unlock.yaml` | Called by feature tests when the app launches into the unlock screen. |
 
 ## Not yet covered by flows
 
-iOS-side screens that still need a flow before they're parity-tracked: Send (onchain + lightning), Restore wallet, Settings, Academy, Profits, Widget, LNURL-Auth.
+iOS-side screens that still need a flow before they're parity-tracked: Send (onchain + lightning), Restore wallet, Settings, Profits, Widget, LNURL-Auth.
 
 ## Legend
 

--- a/shared/flows/README.md
+++ b/shared/flows/README.md
@@ -35,6 +35,9 @@ shared/flows/
     bitcoin_map.yaml      Bitcoin map (MapViewController) — unlock, open it
                           from Home's map icon, wait for the places to sync,
                           open/close a place, move the map, recentre on user.
+    academy.yaml          Academy tab (AcademyViewController) — unlock, open
+                          the latest available lesson, page through it to
+                          Complete, then open the next freshly-unlocked lesson.
   helpers/         Reusable subflows invoked via runFlow.
     unlock.yaml           Enters PIN 1234 on the unlock screen.
   scripts/         Maestro `runScript` helpers (GraalJS).

--- a/shared/flows/features/academy.yaml
+++ b/shared/flows/features/academy.yaml
@@ -1,0 +1,100 @@
+# Feature test: the Academy tab (AcademyViewController + OneLessonViewController).
+#
+# Prerequisite: an existing wallet on the simulator, so launch lands on the
+# PIN unlock screen. This flow does NOT clearState — it relies on a wallet
+# already being set up (run onboarding/restore_wallet.yaml first if needed).
+#
+# Lesson availability: lessons unlock in order. Completed lessons and the
+# single next-to-do lesson are tappable; later lessons are blurred out. That
+# next-to-do lesson — the "latest available" one — is the only cell tagged
+# academy.nextLessonButton, so the same selector works for the first lesson
+# and (after it completes) the freshly-unlocked one. This assumes the latest
+# available lesson is on-screen; on a wallet that has completed many lessons
+# the table may need scrolling first.
+#
+# Flow:
+#   1. Launch (preserve state) and unlock with the PIN.
+#   2. On Home, tap the Academy tab (nav.academyButton) → AcademyViewController.
+#   3. Tap the latest available lesson (academy.nextLessonButton) →
+#      OneLessonViewController.
+#   4. Page through the lesson: keep tapping Next (academy.nextPageButton)
+#      until the final page, then tap Complete (academy.completeButton — the
+#      same UIButton, relabelled on the last page). After each tap a page may
+#      need to download an image, during which academy.lessonSpinner spins and
+#      the page's button is absent; waiting for the spinner to stop is what
+#      gates the next tap.
+#   5. The lesson dismisses back to the Academy and the next lesson unlocks.
+#      Tap it (academy.nextLessonButton again) to open the following lesson.
+#
+# Run: maestro test shared/flows/features/academy.yaml
+
+appId: com.bittr.bittr-regtest
+---
+- launchApp
+
+# Existing wallet → launch lands on the PIN unlock screen. Enter the PIN.
+- assertVisible:
+    id: "unlock.topLabel"
+- takeScreenshot: shared/docs/screenshots/academy/01_unlock
+- runFlow: ../helpers/unlock.yaml
+
+# Land on Home.
+- assertVisible:
+    id: "home.headerLabel"
+- takeScreenshot: shared/docs/screenshots/academy/02_home
+
+# Tap the Academy tab → AcademyViewController.
+- tapOn:
+    id: "nav.academyButton"
+- assertVisible:
+    id: "academy.headerLabel"
+- takeScreenshot: shared/docs/screenshots/academy/03_academy
+
+# Tap the latest available lesson → OneLessonViewController. Wait for the
+# first page to finish loading (its Next button appears once the spinner stops;
+# every lesson has more than one page, so the Next button — not Complete —
+# shows first).
+- tapOn:
+    id: "academy.nextLessonButton"
+- extendedWaitUntil:
+    visible:
+      id: "academy.nextPageButton"
+    timeout: 30000
+- takeScreenshot: shared/docs/screenshots/academy/04_lesson_page1
+
+# Page through the lesson. Keep tapping Next while it is present; after each
+# tap, wait for academy.lessonSpinner to stop (covers pages that download an
+# image). When the final page is reached, Next is gone (relabelled Complete),
+# so the loop exits.
+- repeat:
+    while:
+      visible:
+        id: "academy.nextPageButton"
+    commands:
+      - tapOn:
+          id: "academy.nextPageButton"
+      - extendedWaitUntil:
+          notVisible:
+            id: "academy.lessonSpinner"
+          timeout: 30000
+
+# Final page → tap Complete (same button, relabelled). The lesson is marked
+# complete and OneLessonViewController dismisses back to the Academy.
+- assertVisible:
+    id: "academy.completeButton"
+- takeScreenshot: shared/docs/screenshots/academy/05_last_page
+- tapOn:
+    id: "academy.completeButton"
+
+# Back on the Academy, the next lesson has unlocked and is now the latest
+# available one. Tap it to open the following lesson.
+- assertVisible:
+    id: "academy.headerLabel"
+- takeScreenshot: shared/docs/screenshots/academy/06_academy_next_unlocked
+- tapOn:
+    id: "academy.nextLessonButton"
+- extendedWaitUntil:
+    visible:
+      id: "academy.nextPageButton"
+    timeout: 30000
+- takeScreenshot: shared/docs/screenshots/academy/07_next_lesson_open

--- a/shared/test-ids/test-ids.json
+++ b/shared/test-ids/test-ids.json
@@ -49,6 +49,13 @@
       "closeButton": null
     }
   },
+  "academy": {
+    "headerLabel": null,
+    "nextLessonButton": null,
+    "nextPageButton": null,
+    "completeButton": null,
+    "lessonSpinner": null
+  },
   "history": {
     "swapPending": null,
     "swapComplete": null


### PR DESCRIPTION
Cover AcademyViewController + OneLessonViewController end-to-end: unlock with the PIN, open the Academy tab, start the latest available lesson, page through it (tapping Next, waiting on any per-page image-download spinner) to the final Complete, then open the next freshly-unlocked lesson.

Wire up the accessibility identifiers the flow needs: add an academy.* block to test-ids.json (regenerated TestIDs.swift) and set them on the Academy header, the single "frontier" lesson button (latest available, not-yet-completed), the OneLesson spinner, and the dynamic Next/Complete button. Document the flow in the READMEs and parity tracker.