### PR TITLE
New receive_onchain.yaml test and associated updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ maestro test shared/flows/features/buy_incoming.yaml
 # Subsequent feature tests reuse that channel:
 maestro test shared/flows/features/buy_more.yaml
 maestro test shared/flows/features/receive.yaml
+maestro test shared/flows/features/receive_onchain.yaml
 maestro test shared/flows/features/swap.yaml
 maestro test shared/flows/features/remove_wallet.yaml
 maestro test shared/flows/features/wrong_pin.yaml

--- a/ios/bittr/Base.lproj/Main.storyboard
+++ b/ios/bittr/Base.lproj/Main.storyboard
@@ -4221,7 +4221,7 @@
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="O5E-tG-CSf" userLabel="Address View">
                                                                         <rect key="frame" x="0.0" y="0.0" width="323" height="45"/>
                                                                         <subviews>
-                                                                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Enter amount" textAlignment="center" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="GlN-GS-RNY" userLabel="Address Text Field">
+                                                                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Enter amount" textAlignment="center" adjustsFontSizeToFit="NO" minimumFontSize="16" translatesAutoresizingMaskIntoConstraints="NO" id="GlN-GS-RNY" userLabel="Address Text Field">
                                                                                 <rect key="frame" x="15" y="11" width="293" height="25"/>
                                                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                                 <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -6670,17 +6670,17 @@
             <objects>
                 <viewController id="EgO-Th-Xdr" customClass="TransactionViewController" customModule="bittr" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="oB9-OZ-Qp1">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="707"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="697"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fvA-bZ-nyJ">
-                                <rect key="frame" x="0.0" y="60" width="393" height="617"/>
+                                <rect key="frame" x="0.0" y="60" width="393" height="607"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UBI-fe-jO0">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="617"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="607"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AwJ-gB-IDb">
-                                                <rect key="frame" x="0.0" y="171" width="393" height="275"/>
+                                                <rect key="frame" x="0.0" y="166" width="393" height="275"/>
                                                 <subviews>
                                                     <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9vf-ju-2A5">
                                                         <rect key="frame" x="0.0" y="0.0" width="393" height="0.0"/>
@@ -7847,8 +7847,8 @@
                                                     <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iuD-4J-AMA">
                                                         <rect key="frame" x="0.0" y="275" width="393" height="0.0"/>
                                                         <subviews>
-                                                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dWW-5N-9eX">
-                                                                <rect key="frame" x="15" y="20" width="363" height="113.33333333333331"/>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dWW-5N-9eX">
+                                                                <rect key="frame" x="15" y="20" width="363" height="103"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Reminder" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W7o-EV-oGF">
                                                                         <rect key="frame" x="20" y="18" width="323" height="16"/>
@@ -13807,9 +13807,9 @@
     <inferredMetricsTieBreakers>
         <segue reference="Owf-uB-9LO"/>
         <segue reference="Aj9-z7-MQt"/>
-        <segue reference="4mq-9G-b1k"/>
+        <segue reference="5NJ-vU-Ume"/>
         <segue reference="7F8-Pl-5uy"/>
-        <segue reference="zKe-6z-HPJ"/>
+        <segue reference="JjT-FP-2YF"/>
         <segue reference="hX6-RE-pvS"/>
         <segue reference="A8J-Ia-44n"/>
     </inferredMetricsTieBreakers>

--- a/ios/bittr/Helpers/BittrWallet.swift
+++ b/ios/bittr/Helpers/BittrWallet.swift
@@ -23,6 +23,7 @@ class BittrWallet: NSObject {
     // Blockchain
     var currentHeight:Int?
     var onchainAddresses:[OnchainAddress]?
+    var onchainAddressesVerified:Bool = false
     
     // Currency conversion
     var valueInEUR:CGFloat?

--- a/ios/bittr/Helpers/EnvironmentConfig.swift
+++ b/ios/bittr/Helpers/EnvironmentConfig.swift
@@ -119,7 +119,7 @@ struct EnvironmentConfig {
     
     /// Lightning node IDs based on environment
     static var lightningNodeId: String {
-        isDevelopment ? "0252fcaa7d532a288200a165b896219e83ededcd38bdf2f5fae909e8d6b09c99b7" : "03e8d988a67ee7de983cd39d9d3d4d19771019305da4d2332be76c8b9fb1687776"
+        isDevelopment ? "021926bec21c1e815b954d35166e93172fdecc49f58e2a2e838f95ef3bbed47ee0" : "03e8d988a67ee7de983cd39d9d3d4d19771019305da4d2332be76c8b9fb1687776"
     }
     
     /// Lightning node addresses based on environment

--- a/ios/bittr/Helpers/TestIDs.swift
+++ b/ios/bittr/Helpers/TestIDs.swift
@@ -83,11 +83,20 @@ enum TestID {
     enum Receive {
         static let addressLabel = "receive.addressLabel"
         static let addressTitle = "receive.addressTitle"
+        static let amountTextField = "receive.amountTextField"
         static let copyButton = "receive.copyButton"
         static let editButton = "receive.editButton"
         static let moreButton = "receive.moreButton"
         static let qrImageView = "receive.qrImageView"
+        static let qrSpinner = "receive.qrSpinner"
+        static let questionButton = "receive.questionButton"
         static let refreshButton = "receive.refreshButton"
+    }
+    enum Send {
+        static let amountTextField = "send.amountTextField"
+        static let pasteButton = "send.pasteButton"
+        static let toLabel = "send.toLabel"
+        static let toTextField = "send.toTextField"
     }
     enum Settings {
         enum Row {

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -161,7 +161,10 @@ extension HomeViewController {
             }
             
             // Add funding transaction ID.
-            if let cachedFundingTxID = CacheManager.getTxoID(), !CacheManager.getSentToBittr().contains(cachedFundingTxID) {
+            if
+                let cachedFundingTxID = CacheManager.getTxoID(),
+                !(CacheManager.getSentToBittr().contains(cachedFundingTxID) &&
+                self.visibleTransactions.contains(where: { transaction in transaction.id == cachedFundingTxID})) {
                 sendableTxIDs += [cachedFundingTxID]
             }
         }

--- a/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveOnchain.swift
+++ b/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveOnchain.swift
@@ -38,28 +38,28 @@ extension [OnchainAddress] {
         guard self.count != 0 else { return nil }
         
         // Check the index of the current cached address.
-        let cachedAddress = CacheManager.getLastAddress() ?? nil
+        let cachedAddress = CacheManager.getLastAddress()
         
-        var resultHasBeenFound = false
+        // Walk down from the top until we hit the current cached address or a
+        // used one, then advance to the address above it.
         var checkIndex = self.count - 1
-        
-        while !resultHasBeenFound {
+        while checkIndex >= 0 {
             if (self[checkIndex].onchainAddress == cachedAddress) || self[checkIndex].hasBeenUsedByBittr {
                 // This is the current address, or this address has been used.
                 // Return the next unused address.
                 if (checkIndex + 1) < self.count {
                     CacheManager.storeLastAddress(newAddress: self[checkIndex+1].onchainAddress)
-                    resultHasBeenFound = true
                     return self[checkIndex+1].onchainAddress
                 } else {
-                    resultHasBeenFound = true
                     return nil
                 }
-            } else {
-                // Address hasn't been used.
-                checkIndex -= 1
             }
+            // Address hasn't been used.
+            checkIndex -= 1
         }
+        
+        // No cached/used address found in the pool.
+        return nil
     }
 }
 
@@ -173,6 +173,20 @@ extension CoreViewController {
             } else {
                 // Enough addresses available.
                 Log.info("Onchain address management successful.")
+
+                // Verify the currently cached address.
+                let unusedAddresses = self.bittrWallet.onchainAddresses!.filter { !$0.hasBeenUsedByBittr }
+                let cached = CacheManager.getLastAddress()
+                let cachedIsValidUnused = cached != nil && unusedAddresses.contains { $0.onchainAddress == cached }
+                if !cachedIsValidUnused, let firstUnused = unusedAddresses.first {
+                    CacheManager.storeLastAddress(newAddress: firstUnused.onchainAddress)
+                }
+                
+                // Alert ReceiveVC that address management has completed.
+                DispatchQueue.main.async {
+                    self.bittrWallet.onchainAddressesVerified = true
+                    self.receiveVC?.onchainAddressesReady()
+                }
             }
         }
     }

--- a/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveOnchain.swift
+++ b/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveOnchain.swift
@@ -79,9 +79,21 @@ extension CoreViewController {
     
     func revealOnchainAddresses() {
         Log.info("Reveal onchain addresses.")
-        
-        guard let lastRevealedOnchainAddress = self.getNewOnchainAddress() else { return }
-        
+
+        guard let lastRevealedOnchainAddress = self.getNewOnchainAddress() else {
+            // Could not derive an address (e.g. the LDK node is unavailable). The
+            // normal completion path (checkOnchainAddressesWithBittr → "enough
+            // addresses" branch) is what sets onchainAddressesVerified, and we're
+            // bailing before reaching it — so without this, ReceiveVC's onchain
+            // gate would wait forever. Mark verification done and notify so the
+            // screen shows the best-available (cached) address instead of hanging.
+            DispatchQueue.main.async {
+                self.bittrWallet.onchainAddressesVerified = true
+                self.receiveVC?.onchainAddressesReady()
+            }
+            return
+        }
+
         var revealedAddresses = [OnchainAddress]()
         var revealAddressIndex:Int = 0
         while revealedAddresses.last?.onchainAddress != lastRevealedOnchainAddress {

--- a/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveViewController.swift
+++ b/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveViewController.swift
@@ -483,13 +483,33 @@ class ReceiveViewController: UIViewController, UITextFieldDelegate, UIContextMen
         self.iconQuestion.alpha = 0
         self.qrSpinner.startAnimating()
         
-        // Wait for onchain address management to finish before showing onchain address.
+        // Wait for onchain address management to finish before showing the onchain
+        // address — manageOnchainAddresses() calls onchainAddressesReady() when it
+        // sets onchainAddressesVerified, which re-enters this method.
         if (type == .onchain || type == .bitcoinqr) && !newAddress && self.coreVC?.bittrWallet.onchainAddressesVerified == false {
             self.currentType = type
             self.updateCards(for: type)
+
+            // SAFETY NET: never wait forever. Verification can fail to complete —
+            // e.g. revealOnchainAddresses() bails when getNewOnchainAddress()
+            // returns nil, or manageOnchainAddresses() never ran because startup
+            // didn't reach it — and there's otherwise no path that clears this
+            // gate, so the QR/address would spin indefinitely. After a timeout,
+            // give up waiting and show the best-available (cached) address. Guarded
+            // on `verified == false` so it no-ops if onchainAddressesReady() already
+            // fired (the normal, fast path), and on currentType so it doesn't fire
+            // after the user switched to a different receive type.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 8) { [weak self] in
+                guard let self = self,
+                      self.coreVC?.bittrWallet.onchainAddressesVerified == false,
+                      self.currentType == .onchain || self.currentType == .bitcoinqr else { return }
+                Log.info("Onchain address verification timed out — showing best-available address.")
+                self.coreVC?.bittrWallet.onchainAddressesVerified = true
+                self.alertTapped(for: self.currentType, withoutAnimation: true)
+            }
             return
         }
-        
+
         let delay:Double = withoutAnimation ? 0 : 0.7
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
             Task { await self.setLabels(for: type, newAddress: newAddress) }

--- a/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveViewController.swift
+++ b/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveViewController.swift
@@ -136,6 +136,9 @@ class ReceiveViewController: UIViewController, UITextFieldDelegate, UIContextMen
         self.addressTitle.accessibilityIdentifier = TestID.Receive.addressTitle
         self.addressLabel.accessibilityIdentifier = TestID.Receive.addressLabel
         self.qrImageView.accessibilityIdentifier = TestID.Receive.qrImageView
+        self.qrSpinner.accessibilityIdentifier = TestID.Receive.qrSpinner
+        self.questionButton.accessibilityIdentifier = TestID.Receive.questionButton
+        self.bothAmountTextField.accessibilityIdentifier = TestID.Receive.amountTextField
         self.copyButton.accessibilityIdentifier = TestID.Receive.copyButton
         self.refreshButton.accessibilityIdentifier = TestID.Receive.refreshButton
         self.editButton.accessibilityIdentifier = TestID.Receive.editButton

--- a/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveViewController.swift
+++ b/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveViewController.swift
@@ -177,7 +177,7 @@ class ReceiveViewController: UIViewController, UITextFieldDelegate, UIContextMen
                     }
                     return nextUnusedAddress ?? self.getCachedOnchainAddress() ?? Language.getWord(withID: "unavailable")
                 } else {
-                    return self.getCachedOnchainAddress() ?? self.coreVC?.bittrWallet.onchainAddresses?.getNextUnusedAddress() ?? Language.getWord(withID: "unavailable")
+                    return self.getCachedOnchainAddress() ?? Language.getWord(withID: "unavailable")
                 }
             } else {
                 return ""
@@ -480,13 +480,25 @@ class ReceiveViewController: UIViewController, UITextFieldDelegate, UIContextMen
         self.iconQuestion.alpha = 0
         self.qrSpinner.startAnimating()
         
-        let delay:Double = withoutAnimation ? 0 : 0.7
+        // Wait for onchain address management to finish before showing onchain address.
+        if (type == .onchain || type == .bitcoinqr) && !newAddress && self.coreVC?.bittrWallet.onchainAddressesVerified == false {
+            self.currentType = type
+            self.updateCards(for: type)
+            return
+        }
         
+        let delay:Double = withoutAnimation ? 0 : 0.7
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
             Task { await self.setLabels(for: type, newAddress: newAddress) }
         }
     }
     
+    func onchainAddressesReady() {
+        // Onchain address management complete.
+        guard self.currentType == .onchain || self.currentType == .bitcoinqr else { return }
+        self.alertTapped(for: self.currentType, withoutAnimation: true)
+    }
+
     override func viewWillAppear(_ animated: Bool) {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillDisappear), name: UIResponder.keyboardWillHideNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillAppear), name: UIResponder.keyboardWillShowNotification, object: nil)

--- a/ios/bittr/Move, Send, Receive/SendVC/Send/AddressParsing.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/Send/AddressParsing.swift
@@ -131,7 +131,8 @@ extension String {
             "^1[a-km-zA-HJ-NP-Z1-9]{25,34}$",  // P2PKH Mainnet
             "^[mn2][a-km-zA-HJ-NP-Z1-9]{33}$",  // P2PKH or P2SH Testnet
             "^bc1[qzp][a-z0-9]{38,}$",  // Bech32 Mainnet
-            "^tb1[qzp][a-z0-9]{38,}$",  // Bech32 Testnet
+            "^tb1[qzp][a-z0-9]{38,}$",  // Bech32 Testnet,
+            "^bcrt1[qzp][a-z0-9]{38,}$"  // Bech32 Regtest
         ]
         return patterns.contains {
             self.range(of: $0, options: [.regularExpression, .caseInsensitive]) != nil

--- a/ios/bittr/Move, Send, Receive/SendVC/Send/SendViewController.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/Send/SendViewController.swift
@@ -147,7 +147,12 @@ class SendViewController: UIViewController, UITextFieldDelegate {
         self.toTextField.smartDashesType = .no
         self.amountTextField.delegate = self
         self.amountTextField.inputAccessoryView = createAmountInputAccessoryView()
-        
+
+        self.toLabel.accessibilityIdentifier = TestID.Send.toLabel
+        self.toTextField.accessibilityIdentifier = TestID.Send.toTextField
+        self.amountTextField.accessibilityIdentifier = TestID.Send.amountTextField
+        self.pasteButton.accessibilityIdentifier = TestID.Send.pasteButton
+
         // Set colors and language
         self.changeColors()
         self.setWords()

--- a/shared/docs/parity.md
+++ b/shared/docs/parity.md
@@ -9,6 +9,7 @@ Per-feature status of iOS vs Android implementation. Updated as Maestro flows go
 | Buy — first incoming bank transaction | done | not started | `features/buy_incoming.yaml` | Opens the lightning channel; needs `fresh_install` first. |
 | Buy — subsequent top up | done | not started | `features/buy_more.yaml` | Preserves wallet state; needs prior `buy_incoming` run for the channel. Requires `scripts/push_server.js` running. |
 | Receive | done | not started | `features/receive.yaml` | Auto-recovers via `onboarding/happy_path.yaml` if launched on a clean install. |
+| Receive onchain → Send round-trip | done | not started | `features/receive_onchain.yaml` | Shows the onchain address (waits out the verification spinner), copies it, pastes into Send asserting Regular/onchain with and without a 5000 sat amount, then renews until the address pool is exhausted. Uses `helpers/show_onchain_address.yaml`. |
 | Swap (lightning ↔ onchain, both directions) | done | not started | `features/swap.yaml` | Re-uses existing channel + onchain balance from prior buy flow. |
 | Bitcoin value chart | done | not started | `features/bitcoin_value.yaml` | Opens from Home's currency icon; waits for price data, scrubs the graph, switches span m/y/5y. Needs an existing wallet (unlocks with PIN). |
 | Bitcoin map | done | not started | `features/bitcoin_map.yaml` | Opens from Home's map icon; waits for the btcmap sync, opens/closes a place, moves the map, recentres on user. Grants location via launchApp; needs an existing wallet (unlocks with PIN). |
@@ -17,7 +18,7 @@ Per-feature status of iOS vs Android implementation. Updated as Maestro flows go
 
 ## Not yet covered by flows
 
-iOS-side screens that still need a flow before they're parity-tracked: Send (onchain + lightning), Restore wallet, Settings, Profits, Widget, LNURL-Auth.
+iOS-side screens that still need a flow before they're parity-tracked: Send end-to-end (broadcast/confirm — onchain paste + parsing is exercised by `features/receive_onchain.yaml`, but the Confirm → send path and lightning sends are not), Restore wallet, Settings, Profits, Widget, LNURL-Auth.
 
 ## Legend
 

--- a/shared/flows/README.md
+++ b/shared/flows/README.md
@@ -16,6 +16,12 @@ shared/flows/
     buy_incoming.yaml     First-time top up — opens the lightning channel.
     buy_more.yaml         Subsequent top up — channel already open.
     receive.yaml          Receive screen (auto-recovers via happy_path if no wallet).
+    receive_onchain.yaml  Onchain receive → send round-trip: show the onchain
+                          address (waiting out the verification spinner), read
+                          its info + copy it, paste into Send and assert it
+                          lands as Regular/onchain (no amount, then with a 5000
+                          sat amount), then renew the address until the pool is
+                          exhausted. Uses helpers/show_onchain_address.yaml.
     swap.yaml             Lightning ↔ onchain, both directions.
     forgot_pin.yaml       Forgot-PIN recovery from the unlock screen — types
                           the cached mnemonic and resets the PIN. Requires
@@ -40,6 +46,9 @@ shared/flows/
                           Complete, then open the next freshly-unlocked lesson.
   helpers/         Reusable subflows invoked via runFlow.
     unlock.yaml           Enters PIN 1234 on the unlock screen.
+    show_onchain_address.yaml  From a freshly-opened Receive screen, waits out
+                          the QR spinner and switches the type to the onchain
+                          Address (via More → Address) when a channel is present.
   scripts/         Maestro `runScript` helpers (GraalJS).
     mine_blocks.js              POST /e2e/mine-blocks on the regtest backend.
     trigger_bank_transaction.js POST /e2e/bank-transaction (incoming SEPA).

--- a/shared/flows/features/receive_onchain.yaml
+++ b/shared/flows/features/receive_onchain.yaml
@@ -1,0 +1,223 @@
+# Feature test: onchain receive → send round-trip.
+#
+# Starts like features/receive.yaml (launch, auto-recover/unlock, open the
+# Receive screen) and then exercises the full onchain address journey:
+#   1. Show the onchain address (waiting out the QR spinner — the address pool
+#      verifies asynchronously before an address is safe to display).
+#   2. Read the address info (question mark) and copy it.
+#   3. Paste it into Send and verify it lands as a Regular (onchain) payment
+#      with the address filled in and no amount.
+#   4. Back in Receive, attach a 5000 sat amount, copy, paste into Send and
+#      verify the address + amount carry across.
+#   5. Renew the onchain address repeatedly until the pool is exhausted and the
+#      "no new address available" alert appears.
+#
+# Assumes a wallet exists. If launched on a clean install it auto-runs the
+# onboarding subflow first. Does NOT clearState — wallet state is preserved.
+#
+# Run: maestro test shared/flows/features/receive_onchain.yaml
+
+appId: com.bittr.bittr-regtest
+---
+# Launch without clearState so existing wallet state is preserved across runs.
+- launchApp
+
+# Auto-recover if no wallet exists yet (full onboarding lands on Home).
+- runFlow:
+    when:
+      visible:
+        id: "signup.create.start.createWalletButton"
+    file: ../onboarding/happy_path.yaml
+
+# If the app launched into the PIN unlock screen (existing wallet), enter PIN.
+- runFlow:
+    when:
+      visible:
+        id: "unlock.topLabel"
+    file: ../helpers/unlock.yaml
+
+# Should be on Home now.
+- assertVisible:
+    id: "home.headerLabel"
+- takeScreenshot: shared/docs/screenshots/receive_onchain/01_home
+
+# Open Receive and make sure the onchain address is on screen (waits out the
+# QR spinner, and switches type via More → Address when a channel is present).
+- tapOn:
+    id: "home.receiveButton"
+- runFlow:
+    file: ../helpers/show_onchain_address.yaml
+- takeScreenshot: shared/docs/screenshots/receive_onchain/02_onchain_address
+
+# Tap the question mark to read the address info alert, then close it.
+- tapOn:
+    id: "receive.questionButton"
+- assertVisible:
+    id: "alert.button.0"
+- takeScreenshot: shared/docs/screenshots/receive_onchain/03_address_info
+- tapOn:
+    id: "alert.button.0"
+
+# Copy the address (puts "bitcoin:<address>" on the clipboard), close the
+# "Copied" alert.
+- tapOn:
+    id: "receive.copyButton"
+- assertVisible:
+    id: "alert.button.0"
+- takeScreenshot: shared/docs/screenshots/receive_onchain/04_copied
+- tapOn:
+    id: "alert.button.0"
+
+# Close Receive via the shared header down button (added by addHeader).
+- tapOn:
+    id: "header.downButton"
+- assertVisible:
+    id: "home.headerLabel"
+
+# Open Send and paste the copied onchain address.
+- tapOn:
+    id: "home.sendButton"
+- tapOn:
+    id: "send.pasteButton"
+
+# Switching to onchain recomputes the max sendable amount; if BDK hasn't
+# finished its scan yet that surfaces a "syncing wallet" alert. Dismiss it if
+# present (no-op otherwise).
+- tapOn:
+    id: "alert.button.0"
+    optional: true
+
+# Pasting an onchain address switches the type to Regular (onchain): the "to"
+# label flips from "Invoice and amount" to "Address and amount", the address
+# lands in the field, and no amount is set.
+# Maestro matches `text` as a full-string regex, so wrap partial matches in .*
+- assertVisible:
+    id: "send.toLabel"
+    text: "Address and amount"
+- assertVisible:
+    id: "send.toTextField"
+    text: ".*bcrt1.*"
+- assertNotVisible:
+    id: "send.amountTextField"
+    text: ".*[0-9].*"
+- takeScreenshot: shared/docs/screenshots/receive_onchain/05_send_address_only
+
+# Close Send.
+- tapOn:
+    id: "header.downButton"
+- assertVisible:
+    id: "home.headerLabel"
+
+# Back into Receive, show the onchain address again, then attach an amount.
+- tapOn:
+    id: "home.receiveButton"
+- runFlow:
+    file: ../helpers/show_onchain_address.yaml
+
+# "Add amount" (the edit button) reveals the amount field. Default currency is
+# satoshis, so 5000 = 5000 sats = 0.00005 BTC.
+- tapOn:
+    id: "receive.editButton"
+- tapOn:
+    id: "receive.amountTextField"
+- inputText: "5000"
+- tapOn:
+    text: "Done"
+
+# The address regenerates with the amount appended (?amount=0.00005). Wait for
+# the spinner to settle, then confirm the label updated.
+- extendedWaitUntil:
+    notVisible:
+      id: "receive.qrSpinner"
+    timeout: 30000
+- assertVisible:
+    id: "receive.addressLabel"
+    text: ".*0.00005.*"
+- takeScreenshot: shared/docs/screenshots/receive_onchain/06_address_with_amount
+
+# Copy (now "bitcoin:<address>?amount=0.00005"), close the alert.
+- tapOn:
+    id: "receive.copyButton"
+- assertVisible:
+    id: "alert.button.0"
+- tapOn:
+    id: "alert.button.0"
+
+# Close Receive.
+- tapOn:
+    id: "header.downButton"
+- assertVisible:
+    id: "home.headerLabel"
+
+# Open Send and paste again — this time both the address and amount carry.
+- tapOn:
+    id: "home.sendButton"
+- tapOn:
+    id: "send.pasteButton"
+# Dismiss the "syncing wallet" alert if BDK is mid-scan (no-op otherwise).
+- tapOn:
+    id: "alert.button.0"
+    optional: true
+- assertVisible:
+    id: "send.toLabel"
+    text: "Address and amount"
+- assertVisible:
+    id: "send.toTextField"
+    text: ".*bcrt1.*"
+- assertVisible:
+    id: "send.amountTextField"
+    text: "5000"
+- takeScreenshot: shared/docs/screenshots/receive_onchain/07_send_address_amount
+
+# Close Send.
+- tapOn:
+    id: "header.downButton"
+- assertVisible:
+    id: "home.headerLabel"
+
+# Back into Receive once more to renew the onchain address until the pool is
+# exhausted.
+- tapOn:
+    id: "home.receiveButton"
+- runFlow:
+    file: ../helpers/show_onchain_address.yaml
+- takeScreenshot: shared/docs/screenshots/receive_onchain/08_before_renew
+
+# Keep tapping Renew → Confirm until a new address can't be generated. The
+# pool keeps ~10 unused addresses, so this terminates after a bounded number
+# of renews. Loop exit is detected structurally rather than by alert text:
+# the Renew confirm dialog has two buttons (Cancel, Confirm), while the
+# "no new address available" alert that ends the loop has a single Okay
+# button. So between iterations, alert.button.0 is only present once that
+# final alert appears. (We can't match the alert's message text — it's set as
+# attributedText, which Maestro reads unreliably.)
+- repeat:
+    while:
+      notVisible:
+        id: "alert.button.0"
+    commands:
+      - tapOn:
+          id: "receive.refreshButton"
+      # Renew confirm dialog: [Cancel, Confirm]. Confirm is index 1.
+      - extendedWaitUntil:
+          visible:
+            id: "alert.button.1"
+          timeout: 10000
+      - tapOn:
+          id: "alert.button.1"
+      # Wait for the regeneration to settle (renders a new address, or raises
+      # the no-address alert).
+      - extendedWaitUntil:
+          notVisible:
+            id: "receive.qrSpinner"
+          timeout: 15000
+
+# The "no new address available" alert is up (single Okay button). Close it.
+- assertVisible:
+    id: "alert.button.0"
+- takeScreenshot: shared/docs/screenshots/receive_onchain/09_no_address_available
+- tapOn:
+    id: "alert.button.0"
+- assertVisible:
+    id: "receive.addressLabel"
+- takeScreenshot: shared/docs/screenshots/receive_onchain/10_done

--- a/shared/flows/features/receive_onchain.yaml
+++ b/shared/flows/features/receive_onchain.yaml
@@ -39,6 +39,14 @@ appId: com.bittr.bittr-regtest
 # Should be on Home now.
 - assertVisible:
     id: "home.headerLabel"
+
+# On a fresh launch the wallet syncs first — the header spinner spins until the
+# sync finishes. Wait for it to stop before doing anything so the onchain
+# address pool is ready by the time we open Receive.
+- extendedWaitUntil:
+    notVisible:
+      id: "home.headerSpinner"
+    timeout: 60000
 - takeScreenshot: shared/docs/screenshots/receive_onchain/01_home
 
 # Open Receive and make sure the onchain address is on screen (waits out the

--- a/shared/flows/helpers/show_onchain_address.yaml
+++ b/shared/flows/helpers/show_onchain_address.yaml
@@ -1,0 +1,43 @@
+# Reusable subflow: from a freshly-opened ReceiveViewController, make sure the
+# onchain address is the one being shown.
+#
+# The receive screen opens on a default type that depends on lightning
+# availability:
+#   - no active channel  → it opens straight on the onchain address, and the
+#     More button is hidden (there are no other types to switch to).
+#   - active channel     → it opens on bitcoin-QR / LNURL and exposes a More
+#     button to switch the transaction type.
+#
+# So: first wait for the QR spinner to stop (the address pool finishes
+# verifying and the QR renders), then — only if a More button is present —
+# open the type picker and choose "Address".
+
+appId: com.bittr.bittr-regtest
+---
+# Wait for the address pool to finish verifying and the QR to render.
+- extendedWaitUntil:
+    notVisible:
+      id: "receive.qrSpinner"
+    timeout: 30000
+
+# If a More button is present the onchain address isn't the current type yet.
+- runFlow:
+    when:
+      visible:
+        id: "receive.moreButton"
+    commands:
+      - tapOn:
+          id: "receive.moreButton"
+      # Type-picker alert buttons: [Cancel, Address, Bitcoin QR, Create
+      # invoice, Show LNURL]. "Address" is index 1.
+      - tapOn:
+          id: "alert.button.1"
+      # Switching type re-renders the QR; wait for the spinner again.
+      - extendedWaitUntil:
+          notVisible:
+            id: "receive.qrSpinner"
+          timeout: 30000
+
+# Onchain address is now displayed.
+- assertVisible:
+    id: "receive.addressLabel"

--- a/shared/test-ids/test-ids.json
+++ b/shared/test-ids/test-ids.json
@@ -121,10 +121,19 @@
     "addressTitle": null,
     "addressLabel": null,
     "qrImageView": null,
+    "qrSpinner": null,
+    "questionButton": null,
+    "amountTextField": null,
     "copyButton": null,
     "refreshButton": null,
     "editButton": null,
     "moreButton": null
+  },
+  "send": {
+    "toLabel": null,
+    "toTextField": null,
+    "amountTextField": null,
+    "pasteButton": null
   },
   "signup": {
     "create": {


### PR DESCRIPTION
- Fixes the onchain receive-address race (background verifier is the single cache writer; read-only display path; alertTapped gate + onchainAddressesReady notification; bounds guard in getNextUnusedAddress).
- Adds the receive_onchain Maestro flow + show_onchain_address helper, new receive/send test IDs (regenerated TestIDs.swift), and README/parity doc updates.