### PR TITLE
New send_lightning.yaml test

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,12 @@ maestro test shared/flows/features/send_onchain.yaml
 maestro test shared/flows/features/send_onchain_all.yaml
 maestro test shared/flows/features/swap.yaml
 
-# Lightning send (normal + zero-amount invoice + Lightning Address). Manual
-# input: the three targets come from a separate live wallet you run yourself.
+# Lightning send (normal + zero-amount invoice + Lightning Address). All three
+# targets are server-side now (invoices via the e2e endpoint / request_invoice.js,
+# address = fixed e2e e2ebittr@staging.getbittr.com), so no --env is needed.
 # Needs "node shared/flows/scripts/clipboard_server.js" running (Terminal A, alongside push_server)
 # so the in-app Paste button has something to paste:
-maestro test --env LN_INVOICE="lnbcrt…" --env LN_ZERO_INVOICE="lnbcrt…" --env LN_ADDRESS="name@domain" shared/flows/features/send_lightning.yaml
+maestro test shared/flows/features/send_lightning.yaml
 
 maestro test shared/flows/features/remove_wallet.yaml
 maestro test shared/flows/features/wrong_pin.yaml

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ The push-notification helper bridges Maestro to the simulator's APNS push (the `
 node shared/flows/scripts/push_server.js
 ```
 
+The lightning send flow additionally needs the clipboard helper, which bridges Maestro to `xcrun simctl pbcopy` so the in-app Paste button has something to paste (see the `send_lightning.yaml` run line below). Start it the same way:
+
+```sh
+# Terminal A′ — only needed for send_lightning.yaml
+node shared/flows/scripts/clipboard_server.js
+```
+
 In another terminal, from the repo root, run a flow:
 
 ```sh
@@ -72,6 +79,13 @@ maestro test shared/flows/features/receive_invoice.yaml
 maestro test shared/flows/features/send_onchain.yaml
 maestro test shared/flows/features/send_onchain_all.yaml
 maestro test shared/flows/features/swap.yaml
+
+# Lightning send (normal + zero-amount invoice + Lightning Address). Manual
+# input: the three targets come from a separate live wallet you run yourself.
+# Needs "node shared/flows/scripts/clipboard_server.js" running (Terminal A, alongside push_server)
+# so the in-app Paste button has something to paste:
+maestro test --env LN_INVOICE="lnbcrt…" --env LN_ZERO_INVOICE="lnbcrt…" --env LN_ADDRESS="name@domain" shared/flows/features/send_lightning.yaml
+
 maestro test shared/flows/features/remove_wallet.yaml
 maestro test shared/flows/features/wrong_pin.yaml
 maestro test shared/flows/features/bitcoin_value.yaml

--- a/ios/bittr/Helpers/TestIDs.swift
+++ b/ios/bittr/Helpers/TestIDs.swift
@@ -98,6 +98,7 @@ enum TestID {
     enum Send {
         static let amountTextField = "send.amountTextField"
         static let availableButton = "send.availableButton"
+        static let availableLabel = "send.availableLabel"
         static let bdkSpinner = "send.bdkSpinner"
         enum Confirm {
             static let addressLabel = "send.confirm.addressLabel"
@@ -109,6 +110,8 @@ enum TestID {
         }
         static let currencyButton = "send.currencyButton"
         static let currencyLabel = "send.currencyLabel"
+        static let lnurlSpinner = "send.lnurlSpinner"
+        static let nextButton = "send.nextButton"
         static let pasteButton = "send.pasteButton"
         static let regularButton = "send.regularButton"
         static let toLabel = "send.toLabel"

--- a/ios/bittr/Language.swift
+++ b/ios/bittr/Language.swift
@@ -291,7 +291,7 @@ class Language: NSObject {
             "syncwallet": "Sync wallet",
             "finalcalculations": "Final calculations",
             "payrequest": "Pay request",
-            "payrequest1": "You can pay between <minsendable> and <maxsendable> satoshis. How many satoshis would you like to pay?",
+            "payrequest1": "You can send <b>between <minsendable> and <maxsendable> satoshis</b>. Enter the amount of satoshis you'd like to pay.",
             "withdrawrequest": "Withdraw request",
             "withdrawrequest1": "You can withdraw between <minwithdrawable> and <maxwithdrawable> satoshis. How many satoshis would you like to withdraw?",
             "withdrawrequest3": "Are you sure you'd like to withdraw <withdrawable> satoshis?",

--- a/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveViewController.swift
+++ b/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveViewController.swift
@@ -251,7 +251,8 @@ class ReceiveViewController: UIViewController, UITextFieldDelegate, UIContextMen
         
         let bitcoinQR:String = "bitcoin:\(onchainAddress)\(amountText)\(labelText)&lightning=\(lightningInvoice)"
         
-        let lnurl = self.userLNURL() ?? Language.getWord(withID: "unavailable")
+        let userLightningURL = self.userLNURL()
+        let lnurl = userLightningURL ?? Language.getWord(withID: "unavailable")
         
         DispatchQueue.main.async {
             
@@ -268,8 +269,8 @@ class ReceiveViewController: UIViewController, UITextFieldDelegate, UIContextMen
                 self.boltStackWidth.constant = 19
             }
             
-            // Set labels.
-            let qrCode:UIImage
+            // Set labels. Optional: an unavailable LNURL has no QR (see .lnurl).
+            let qrCode:UIImage?
             switch type {
             case .onchain:
                 self.addressTitle.text = Language.getWord(withID: "address")
@@ -296,14 +297,17 @@ class ReceiveViewController: UIViewController, UITextFieldDelegate, UIContextMen
                 self.addressTitle.text = Language.getWord(withID: "url")
                 self.addressLabel.text = lnurl
                 self.lowerAddressLabel.text = ""
-                qrCode = lnurl.toBigQRCode()!
+                // Don't build a QR for an unavailable address — it would encode
+                // the literal word "Unavailable". Leave it empty in that case.
+                qrCode = userLightningURL != nil ? lnurl.toBigQRCode() : nil
                 self.hideLowerAddress()
                 self.currentCopyableText = lnurl
             }
-            
+
             self.qrImageView.image = qrCode
-            
-            self.qrImageView.alpha = 1
+
+            // Hide the QR view entirely when there's nothing to encode.
+            self.qrImageView.alpha = qrCode != nil ? 1 : 0
             self.addressLabel.alpha = 1
             self.lowerAddressLabel.alpha = 1
             self.addressTitle.alpha = 1
@@ -666,11 +670,13 @@ class ReceiveViewController: UIViewController, UITextFieldDelegate, UIContextMen
     }
     
     func userLNURL() -> String? {
-        if let firstIban = self.coreVC!.bittrWallet.ibanEntities.first, !firstIban.lightningAddressUsername.isEmpty {
-            return firstIban.lightningAddressUsername
-        } else {
-            return nil
+        // Return the first iban entity that actually has a lightning address.
+        // Checking only `.first` missed it when the lightning-address iban
+        // wasn't first after parseDevice's sort (e.g. multiple deposit codes).
+        for iban in self.coreVC!.bittrWallet.ibanEntities where !iban.lightningAddressUsername.isEmpty {
+            return iban.lightningAddressUsername
         }
+        return nil
     }
     
     func showLowerAddress() {

--- a/ios/bittr/Move, Send, Receive/SendVC/Send/SendViewController.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/Send/SendViewController.swift
@@ -157,6 +157,9 @@ class SendViewController: UIViewController, UITextFieldDelegate {
         self.btcLabel.accessibilityIdentifier = TestID.Send.currencyLabel
         self.bdkSpinner.accessibilityIdentifier = TestID.Send.bdkSpinner
         self.availableButton.accessibilityIdentifier = TestID.Send.availableButton
+        self.availableAmount.accessibilityIdentifier = TestID.Send.availableLabel
+        self.nextButton.accessibilityIdentifier = TestID.Send.nextButton
+        self.lnurlSpinner.accessibilityIdentifier = TestID.Send.lnurlSpinner
 
         // Set colors and language
         self.changeColors()

--- a/ios/bittr/Move, Send, Receive/SendVC/SendLNURL.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/SendLNURL.swift
@@ -18,12 +18,14 @@ import libsecp256k1
 extension SendViewController {
     
     func handleLNURLAmountCompletion() {
+        Log.info("Will handle LNURL amount completion.")
         
         guard let callback = pendingLNURLCallback,
               let minAmount = pendingLNURLMinAmount,
               let maxAmount = pendingLNURLMaxAmount,
               let amountText = amountTextField.text,
               !amountText.isEmpty else {
+            Log.info("Information for pending LNURL incomplete.")
             self.showAlert(presentingController: self, title: Language.getWord(withID: "lnurl"), message: Language.getWord(withID: "lnurlfail3"), buttons: [Language.getWord(withID: "okay")], actions: nil)
             return
         }
@@ -53,6 +55,7 @@ extension SendViewController {
         
         // Validate amount is within range
         if enteredAmount < minAmount || enteredAmount > maxAmount {
+            Log.info("Entered amount is not within range of the LNURL limits.")
             let minSats = minAmount / 1000
             let maxSats = maxAmount / 1000
             self.showAlert(presentingController: self, title: Language.getWord(withID: "oops"), message: Language.getWord(withID: "lnurlbetween").replacingOccurrences(of: "<min>", with: "\(minSats)").replacingOccurrences(of: "<max>", with: "\(maxSats)"), buttons: [Language.getWord(withID: "okay")], actions: nil)
@@ -192,22 +195,31 @@ extension UIViewController {
                                 // Min and max are the same.
                                 self.sendPayRequest(callbackURL: receivedCallback.replacingOccurrences(of: "\0", with: "").trimmingCharacters(in: .controlCharacters), amount: minSendable, receivedDescription: receivedDescription)
                             } else {
-                                // Min and max are different. Update UI to show range and focus amount field.
+                                // Min and max are different. Store the request so the
+                                // amount the user enters next completes the payment, then
+                                // tell them the payable range via an alert.
                                 let minSats = minSendable / 1000
                                 let maxSats = maxSendable / 1000
-                                
-                                // Update the label to show the range
-                                sendVC?.availableAmount.text = "You can send \(minSats) - \(maxSats) satoshis"
-                                
-                                // Clear and focus the amount field
-                                sendVC?.amountTextField.text = ""
-                                sendVC?.amountTextField.becomeFirstResponder()
-                                
+
                                 // Store the callback and description for when user enters amount
                                 sendVC?.pendingLNURLCallback = receivedCallback.replacingOccurrences(of: "\0", with: "").trimmingCharacters(in: .controlCharacters)
                                 sendVC?.pendingLNURLDescription = receivedDescription
                                 sendVC?.pendingLNURLMinAmount = minSendable
                                 sendVC?.pendingLNURLMaxAmount = maxSendable
+
+                                // Clear the amount field, ready for an in-range amount.
+                                sendVC?.amountTextField.text = ""
+
+                                // Show the payable range. The user taps Okay, then enters
+                                // the amount in the field.
+                                self.showAlert(
+                                    presentingController: self,
+                                    title: Language.getWord(withID: "payrequest"),
+                                    message: Language.getWord(withID: "payrequest1")
+                                        .replacingOccurrences(of: "<minsendable>", with: "\(minSats)".addSpaces())
+                                        .replacingOccurrences(of: "<maxsendable>", with: "\(maxSats)".addSpaces()),
+                                    buttons: [Language.getWord(withID: "okay")],
+                                    actions: nil)
                             }
                         } else if receivedTag == "withdrawRequest",
                             let receivedCallback = actualDataDict["callback"] as? String,
@@ -271,6 +283,7 @@ extension UIViewController {
     }
     
     func sendPayRequest(callbackURL:String, amount:Int, receivedDescription:String?) {
+        Log.info("Will send payRequest.")
         
         let sendVC = self as? SendViewController
         

--- a/shared/docs/parity.md
+++ b/shared/docs/parity.md
@@ -13,6 +13,7 @@ Per-feature status of iOS vs Android implementation. Updated as Maestro flows go
 | Receive invoice → Send round-trip | done | not started | `features/receive_invoice.yaml` | Switches the type to a lightning invoice, copies it, pastes into Send asserting lightning with and without a 2000 sat amount. Requires an active channel. Uses `helpers/show_invoice.yaml`. |
 | Send onchain | done | not started | `features/send_onchain.yaml` | Opens Send, switches to Regular (waits out the BDK sync spinner), enters an address + 5 EUR amount, confirms address/euro amount on the Confirm screen with the fast fee, sends, mines 6 blocks, then opens the new transaction from the history table. Requires an onchain balance. |
 | Send onchain (max) | done | not started | `features/send_onchain_all.yaml` | Sends the full balance via "Send all", exercising the tight-fee path: fast fee exceeds the balance → Update amount, and on a failed broadcast retry with the slowest fee (past the low-fee warning), then mine 6 blocks and open the new transaction. Requires an onchain balance. |
+| Send lightning | done | not started | `features/send_lightning.yaml` | Pays a normal (amount-bearing) invoice, a zero-amount invoice (amount entered in BTC), and a Lightning Address (LNURL-pay), each confirmed via the TransactionViewController. Manual input — the three targets come from a separate live wallet, passed via `LN_INVOICE`/`LN_ZERO_INVOICE`/`LN_ADDRESS`; the Paste steps need `scripts/clipboard_server.js`. Requires an active channel with outbound capacity. |
 | Swap (lightning ↔ onchain, both directions) | done | not started | `features/swap.yaml` | Re-uses existing channel + onchain balance from prior buy flow. |
 | Bitcoin value chart | done | not started | `features/bitcoin_value.yaml` | Opens from Home's currency icon; waits for price data, scrubs the graph, switches span m/y/5y. Needs an existing wallet (unlocks with PIN). |
 | Bitcoin map | done | not started | `features/bitcoin_map.yaml` | Opens from Home's map icon; waits for the btcmap sync, opens/closes a place, moves the map, recentres on user. Grants location via launchApp; needs an existing wallet (unlocks with PIN). |
@@ -21,7 +22,7 @@ Per-feature status of iOS vs Android implementation. Updated as Maestro flows go
 
 ## Not yet covered by flows
 
-iOS-side screens that still need a flow before they're parity-tracked: Send end-to-end (the onchain Confirm → broadcast path is covered by `features/send_onchain.yaml`; lightning sends are not yet), Restore wallet, Settings, Profits, Widget, LNURL-Auth.
+iOS-side screens that still need a flow before they're parity-tracked: Restore wallet, Settings, Profits, Widget, LNURL-Auth. (Send end-to-end is now covered: onchain via `features/send_onchain.yaml`, lightning via `features/send_lightning.yaml`.)
 
 ## Legend
 

--- a/shared/flows/README.md
+++ b/shared/flows/README.md
@@ -38,6 +38,15 @@ shared/flows/
                           the balance → Update amount, and on a failed broadcast
                           retry with the slowest fee — before mining and opening
                           the new transaction.
+    send_lightning.yaml   Lightning send end-to-end across all three invoice
+                          types — a normal (amount-bearing) invoice, a
+                          zero-amount invoice (enter the amount in BTC), and a
+                          Lightning Address (LNURL-pay). Manual input: the
+                          three targets come from a separate live wallet the
+                          tester runs, passed via the LN_INVOICE /
+                          LN_ZERO_INVOICE / LN_ADDRESS env vars; the Paste
+                          steps need scripts/clipboard_server.js running.
+                          Requires an active channel with outbound capacity.
     swap.yaml             Lightning ↔ onchain, both directions.
     forgot_pin.yaml       Forgot-PIN recovery from the unlock screen — types
                           the cached mnemonic and resets the PIN. Requires
@@ -73,6 +82,10 @@ shared/flows/
     trigger_bank_transaction.js POST /e2e/bank-transaction (incoming SEPA).
     push_notification.js        POSTs an APNS payload to push_server.js.
     push_server.js              Local helper bridging Maestro → `xcrun simctl push`.
+    set_clipboard.js            POSTs output.clipboardText to clipboard_server.js.
+    clipboard_server.js         Local helper bridging Maestro → `xcrun simctl
+                                pbcopy` so flows can seed the OS clipboard for
+                                the in-app Paste button (send_lightning.yaml).
     parse_mnemonic.js           Splits the MNEMONIC env var into
                                 output.words[1..12] for forgot_pin.yaml.
 ```
@@ -118,6 +131,19 @@ maestro test --env MNEMONIC="word1 word2 ... word12" shared/flows/features/forgo
 ```
 
 Use the same mnemonic the wallet was set up with (the one happy_path generated during onboarding). `parse_mnemonic.js` validates the count and splits the words into `output.words[1..12]`.
+
+### Lightning send
+
+`features/send_lightning.yaml` pays a normal invoice, a zero-amount invoice and a Lightning Address. Those three targets come from a *separate* live wallet the tester runs alongside the simulator — Maestro doesn't create them — so they're passed in via env vars. The flow also exercises the in-app **Paste** button, and Maestro can't write the OS clipboard itself (`copyTextFrom` only fills Maestro's own variable), so a bridge — the same pattern as `push_server.js` — pipes text to `xcrun simctl pbcopy`:
+
+```sh
+# In a separate terminal, before running the flow:
+node shared/flows/scripts/clipboard_server.js
+
+maestro test --env LN_INVOICE="lnbcrt…" --env LN_ZERO_INVOICE="lnbcrt…" --env LN_ADDRESS="name@domain" shared/flows/features/send_lightning.yaml
+```
+
+The flow sets `output.clipboardText` before each paste; `set_clipboard.js` POSTs it to the helper, which `pbcopy`'s it onto the booted simulator. iOS may show a one-off "Allow Paste" prompt — the flow accepts it automatically.
 
 ## CI
 

--- a/shared/flows/README.md
+++ b/shared/flows/README.md
@@ -41,12 +41,13 @@ shared/flows/
     send_lightning.yaml   Lightning send end-to-end across all three invoice
                           types — a normal (amount-bearing) invoice, a
                           zero-amount invoice (enter the amount in BTC), and a
-                          Lightning Address (LNURL-pay). Manual input: the
-                          three targets come from a separate live wallet the
-                          tester runs, passed via the LN_INVOICE /
-                          LN_ZERO_INVOICE / LN_ADDRESS env vars; the Paste
-                          steps need scripts/clipboard_server.js running.
-                          Requires an active channel with outbound capacity.
+                          Lightning Address (LNURL-pay). All three targets are
+                          server-side now: the two invoices come from the e2e
+                          endpoint (scripts/request_invoice.js) and the address
+                          is the fixed e2e e2ebittr@staging.getbittr.com — no env vars.
+                          The Paste steps need scripts/clipboard_server.js
+                          running. Requires an active channel with outbound
+                          capacity.
     swap.yaml             Lightning ↔ onchain, both directions.
     forgot_pin.yaml       Forgot-PIN recovery from the unlock screen — types
                           the cached mnemonic and resets the PIN. Requires
@@ -134,13 +135,13 @@ Use the same mnemonic the wallet was set up with (the one happy_path generated d
 
 ### Lightning send
 
-`features/send_lightning.yaml` pays a normal invoice, a zero-amount invoice and a Lightning Address. Those three targets come from a *separate* live wallet the tester runs alongside the simulator — Maestro doesn't create them — so they're passed in via env vars. The flow also exercises the in-app **Paste** button, and Maestro can't write the OS clipboard itself (`copyTextFrom` only fills Maestro's own variable), so a bridge — the same pattern as `push_server.js` — pipes text to `xcrun simctl pbcopy`:
+`features/send_lightning.yaml` pays a normal invoice, a zero-amount invoice and a Lightning Address. All three targets are server-side now — the two invoices are generated per run via the e2e endpoint (`scripts/request_invoice.js`, always fresh) and the address is the fixed e2e `e2ebittr@staging.getbittr.com` — so no env vars are needed. The flow also exercises the in-app **Paste** button, and Maestro can't write the OS clipboard itself (`copyTextFrom` only fills Maestro's own variable), so a bridge — the same pattern as `push_server.js` — pipes text to `xcrun simctl pbcopy`:
 
 ```sh
 # In a separate terminal, before running the flow:
 node shared/flows/scripts/clipboard_server.js
 
-maestro test --env LN_INVOICE="lnbcrt…" --env LN_ZERO_INVOICE="lnbcrt…" --env LN_ADDRESS="name@domain" shared/flows/features/send_lightning.yaml
+maestro test shared/flows/features/send_lightning.yaml
 ```
 
 The flow sets `output.clipboardText` before each paste; `set_clipboard.js` POSTs it to the helper, which `pbcopy`'s it onto the booted simulator. iOS may show a one-off "Allow Paste" prompt — the flow accepts it automatically.

--- a/shared/flows/features/send_lightning.yaml
+++ b/shared/flows/features/send_lightning.yaml
@@ -1,0 +1,290 @@
+# Feature test: lightning send end-to-end (three invoice types).
+#
+# Starts like features/send_onchain.yaml (launch, auto-recover/unlock, wait for
+# the Home sync spinner) and then sends three lightning payments back to back,
+# exercising the normal-invoice, zero-amount-invoice and Lightning-Address
+# (LNURL) paths:
+#   1. Normal invoice (amount baked in): Send → Paste → the amount field
+#      auto-populates → Next → Confirm screen (invoice + amount) → Send →
+#      TransactionViewController with the confirmed payment → close it.
+#   2. Zero-amount invoice: Paste → invoice fills, no amount → Next raises the
+#      "Please enter the amount…" alert → Okay → switch currency Sats → Bitcoin
+#      (label reads BTC) → enter 0.00001 → Done → Confirm screen → Send →
+#      TransactionViewController → close it.
+#   3. Lightning Address (LNURL-pay): type it into the invoice field, press
+#      return → "Handling LNURL" spinner → a "Pay request" alert announces the
+#      payable range → Okay → enter 1500 sats → Done → "Handling LNURL" spinner
+#      again → confirm the payment → TransactionViewController → close it →
+#      close Send.
+#
+# MANUAL INPUT. The three payment targets come from a *separate*, live
+# counterpart wallet that the tester runs themselves (Maestro does not create
+# them). Pass them in via --env, and run the clipboard helper so the in-app
+# Paste button has something to paste (see Running below):
+#
+#   node shared/flows/scripts/clipboard_server.js   # keep running
+#   maestro test \
+#     --env LN_INVOICE="lnbcrt…"        # a normal invoice WITH an amount \
+#     --env LN_ZERO_INVOICE="lnbcrt…"   # a zero-amount invoice \
+#     --env LN_ADDRESS="name@domain"    # an LNURL-pay Lightning Address \
+#     shared/flows/features/send_lightning.yaml
+#
+# Sending requires an active lightning channel with enough outbound capacity
+# (run the buy/receive flows first). If launched on a clean install it
+# auto-runs onboarding first. Does NOT clearState — wallet state is preserved.
+#
+# Run: maestro test --env LN_INVOICE=… --env LN_ZERO_INVOICE=… --env LN_ADDRESS=… \
+#        shared/flows/features/send_lightning.yaml
+
+appId: com.bittr.bittr-regtest
+---
+# Launch without clearState so existing wallet state is preserved across runs.
+- launchApp
+
+# Auto-recover if no wallet exists yet (full onboarding lands on Home).
+- runFlow:
+    when:
+      visible:
+        id: "signup.create.start.createWalletButton"
+    file: ../onboarding/happy_path.yaml
+
+# If the app launched into the PIN unlock screen (existing wallet), enter PIN.
+- runFlow:
+    when:
+      visible:
+        id: "unlock.topLabel"
+    file: ../helpers/unlock.yaml
+
+# Should be on Home now.
+- assertVisible:
+    id: "home.headerLabel"
+
+# On a fresh launch the wallet syncs first — wait for the header spinner to stop.
+- extendedWaitUntil:
+    notVisible:
+      id: "home.headerSpinner"
+    timeout: 60000
+- takeScreenshot: shared/docs/screenshots/send_lightning/01_home
+
+# ---------------------------------------------------------------------------
+# 1. Normal invoice (amount baked in).
+# ---------------------------------------------------------------------------
+
+# Open Send (it opens on Instant / lightning by default).
+- tapOn:
+    id: "home.sendButton"
+
+# Put the normal invoice on the simulator clipboard (Maestro can't set the OS
+# pasteboard itself — clipboard_server.js bridges to `xcrun simctl pbcopy`),
+# then tap the in-app Paste button. Because the clipboard was written by another
+# process, iOS shows an "Allow Paste" system prompt. It renders a beat after the
+# tap, so an optional tap would race past it — wait for it explicitly, then tap.
+- evalScript: ${output.clipboardText = LN_INVOICE}
+- runScript: ../scripts/set_clipboard.js
+- tapOn:
+    id: "send.pasteButton"
+- extendedWaitUntil:
+    visible:
+      text: "Allow Paste"
+    timeout: 10000
+- tapOn:
+    text: "Allow Paste"
+
+# Pasting a lightning invoice switches the type to lightning: the "to" label
+# reads "Invoice and amount", the invoice lands in the field, and because this
+# invoice carries an amount the amount field auto-populates with satoshis.
+# Maestro matches `text` as a full-string regex, so wrap partial matches in .*
+- assertVisible:
+    id: "send.toLabel"
+    text: "Invoice and amount"
+- assertVisible:
+    id: "send.toTextField"
+    text: ".*lnbcrt.*"
+- assertVisible:
+    id: "send.amountTextField"
+    text: ".*[0-9].*"
+- takeScreenshot: shared/docs/screenshots/send_lightning/02_invoice_pasted
+
+# Continue to the ConfirmSendViewController. The amount is already filled (no
+# keyboard up), so tap the Next button rather than the amount keyboard's Done.
+- tapOn:
+    id: "send.nextButton"
+
+# Verify the transaction details on the Confirm screen, then Send. For lightning
+# the confirm button pays immediately (no extra fee step or confirm alert).
+- extendedWaitUntil:
+    visible:
+      id: "send.confirm.addressLabel"
+    timeout: 30000
+- assertVisible:
+    id: "send.confirm.addressLabel"
+    text: ".*lnbcrt.*"
+- assertVisible:
+    id: "send.confirm.amountLabel"
+    text: ".*[0-9].*"
+- takeScreenshot: shared/docs/screenshots/send_lightning/03_invoice_confirm
+- tapOn:
+    id: "send.confirm.confirmButton"
+
+# On success the TransactionViewController is pushed over Send with the
+# confirmed payment. Wait for it, then close it to return to Send.
+- extendedWaitUntil:
+    visible:
+      id: "transaction.yellowCard"
+    timeout: 60000
+- takeScreenshot: shared/docs/screenshots/send_lightning/04_invoice_transaction
+- tapOn:
+    id: "header.downButton"
+- assertVisible:
+    id: "send.toLabel"
+
+# ---------------------------------------------------------------------------
+# 2. Zero-amount invoice.
+# ---------------------------------------------------------------------------
+
+# Paste the zero-amount invoice the same way. The clipboard content changed, so
+# iOS prompts to allow the paste again — wait for it, then tap.
+- evalScript: ${output.clipboardText = LN_ZERO_INVOICE}
+- runScript: ../scripts/set_clipboard.js
+- tapOn:
+    id: "send.pasteButton"
+- extendedWaitUntil:
+    visible:
+      text: "Allow Paste"
+    timeout: 10000
+- tapOn:
+    text: "Allow Paste"
+
+# The invoice lands in the field but, being a zero-amount invoice, no amount
+# appears.
+- assertVisible:
+    id: "send.toTextField"
+    text: ".*lnbcrt.*"
+- assertNotVisible:
+    id: "send.amountTextField"
+    text: ".*[0-9].*"
+- takeScreenshot: shared/docs/screenshots/send_lightning/05_zero_pasted
+
+# Next without an amount raises the "Please enter the amount…" alert (single
+# Okay at index 0). Verify the message, then dismiss it. Match a substring
+# (Maestro treats `text` as a full-string regex, so the `.*` wrappers absorb any
+# title prefix / surrounding text and keep the apostrophe out of the pattern).
+- tapOn:
+    id: "send.nextButton"
+- assertVisible:
+    text: ".*enter the amount of satoshis.*"
+- takeScreenshot: shared/docs/screenshots/send_lightning/06_amount_missing
+- tapOn:
+    id: "alert.button.0"
+
+# Switch the amount currency from Sats to Bitcoin via the currency alert
+# (buttons: [Cancel, Bitcoin, Satoshis, <fiat>] — Bitcoin is index 1) and
+# confirm the label now reads BTC.
+- tapOn:
+    id: "send.currencyButton"
+- tapOn:
+    id: "alert.button.1"
+- assertVisible:
+    id: "send.currencyLabel"
+    text: "BTC"
+
+# Enter 0.00001 BTC (= 1000 sats). "Done" on the amount keyboard advances to
+# the Confirm screen just like the Next button.
+- tapOn:
+    id: "send.amountTextField"
+- inputText: "0.00001"
+- tapOn:
+    text: "Done"
+
+# Verify the details on the ConfirmSendViewController, then Send.
+- extendedWaitUntil:
+    visible:
+      id: "send.confirm.addressLabel"
+    timeout: 30000
+- assertVisible:
+    id: "send.confirm.addressLabel"
+    text: ".*lnbcrt.*"
+- assertVisible:
+    id: "send.confirm.amountLabel"
+    text: ".*[0-9].*"
+- takeScreenshot: shared/docs/screenshots/send_lightning/07_zero_confirm
+- tapOn:
+    id: "send.confirm.confirmButton"
+
+# The TransactionViewController pops up again with the confirmed payment. Close
+# it to return to Send.
+- extendedWaitUntil:
+    visible:
+      id: "transaction.yellowCard"
+    timeout: 60000
+- takeScreenshot: shared/docs/screenshots/send_lightning/08_zero_transaction
+- tapOn:
+    id: "header.downButton"
+- assertVisible:
+    id: "send.toLabel"
+
+# ---------------------------------------------------------------------------
+# 3. Lightning Address (LNURL-pay).
+# ---------------------------------------------------------------------------
+
+# Type the Lightning Address into the invoice field and press the keyboard
+# return. The return key recognises the "@" address and kicks off LNURL
+# handling, which briefly shows the "Handling LNURL" spinner. The spinner can
+# come and go faster than Maestro can catch, so rather than asserting it appears
+# we just wait for it to have cleared (it resolves once the LNURL call returns).
+- tapOn:
+    id: "send.toTextField"
+- inputText: "${LN_ADDRESS}"
+- pressKey: Enter
+
+# LNURL resolves: the spinner stops and (when the address has a payable range)
+# a "Pay request" alert announces the range. Wait the spinner out, confirm the
+# alert message, then tap Okay (single button at index 0). Match a substring so
+# the exact min/max numbers and the apostrophe don't matter.
+- extendedWaitUntil:
+    notVisible:
+      id: "send.lnurlSpinner"
+    timeout: 30000
+- extendedWaitUntil:
+    visible:
+      text: ".*send between.*satoshis.*"
+    timeout: 30000
+- takeScreenshot: shared/docs/screenshots/send_lightning/09_lnurl_prompt
+- tapOn:
+    id: "alert.button.0"
+
+# Now enter 1500 (sats) in range and tap Done. With pending LNURL data set, Done
+# fetches the invoice from the LNURL callback — the "Handling LNURL" spinner
+# flashes again.
+- tapOn:
+    id: "send.amountTextField"
+- inputText: "1500"
+- tapOn:
+    text: "Done"
+
+# After the callback returns, a confirmation alert ([Cancel, Confirm]) appears
+# for the LNURL payment — Confirm is index 1.
+- extendedWaitUntil:
+    visible:
+      id: "alert.button.1"
+    timeout: 30000
+- takeScreenshot: shared/docs/screenshots/send_lightning/10_lnurl_confirm
+- tapOn:
+    id: "alert.button.1"
+
+# The TransactionViewController pops up once more with the successful payment.
+# Close it to return to Send, then close Send to land back on Home.
+- extendedWaitUntil:
+    visible:
+      id: "transaction.yellowCard"
+    timeout: 60000
+- takeScreenshot: shared/docs/screenshots/send_lightning/11_lnurl_transaction
+- tapOn:
+    id: "header.downButton"
+- assertVisible:
+    id: "send.toLabel"
+- tapOn:
+    id: "header.downButton"
+- assertVisible:
+    id: "home.headerLabel"
+- takeScreenshot: shared/docs/screenshots/send_lightning/12_done

--- a/shared/flows/features/send_lightning.yaml
+++ b/shared/flows/features/send_lightning.yaml
@@ -17,24 +17,23 @@
 #      again → confirm the payment → TransactionViewController → close it →
 #      close Send.
 #
-# MANUAL INPUT. The three payment targets come from a *separate*, live
-# counterpart wallet that the tester runs themselves (Maestro does not create
-# them). Pass them in via --env, and run the clipboard helper so the in-app
-# Paste button has something to paste (see Running below):
+# Payment targets (no --env needed — all server-side):
+#   - The two invoices (normal + zero-amount) are fetched fresh per run from the
+#     bittr e2e endpoint via scripts/request_invoice.js — no stale/expired
+#     invoices.
+#   - The Lightning Address is the fixed bittr e2e address e2ebittr@staging.getbittr.com,
+#     which resolves (LNURL-pay) to the backend's receiving node.
+#
+# Run the clipboard helper so the in-app Paste button has something to paste:
 #
 #   node shared/flows/scripts/clipboard_server.js   # keep running
-#   maestro test \
-#     --env LN_INVOICE="lnbcrt…"        # a normal invoice WITH an amount \
-#     --env LN_ZERO_INVOICE="lnbcrt…"   # a zero-amount invoice \
-#     --env LN_ADDRESS="name@domain"    # an LNURL-pay Lightning Address \
-#     shared/flows/features/send_lightning.yaml
+#   maestro test shared/flows/features/send_lightning.yaml
 #
 # Sending requires an active lightning channel with enough outbound capacity
 # (run the buy/receive flows first). If launched on a clean install it
 # auto-runs onboarding first. Does NOT clearState — wallet state is preserved.
 #
-# Run: maestro test --env LN_INVOICE=… --env LN_ZERO_INVOICE=… --env LN_ADDRESS=… \
-#        shared/flows/features/send_lightning.yaml
+# Run: maestro test shared/flows/features/send_lightning.yaml
 
 appId: com.bittr.bittr-regtest
 ---
@@ -74,12 +73,14 @@ appId: com.bittr.bittr-regtest
 - tapOn:
     id: "home.sendButton"
 
-# Put the normal invoice on the simulator clipboard (Maestro can't set the OS
-# pasteboard itself — clipboard_server.js bridges to `xcrun simctl pbcopy`),
-# then tap the in-app Paste button. Because the clipboard was written by another
-# process, iOS shows an "Allow Paste" system prompt. It renders a beat after the
-# tap, so an optional tap would race past it — wait for it explicitly, then tap.
-- evalScript: ${output.clipboardText = LN_INVOICE}
+# Request a fresh invoice WITH an amount (1000 sats) from the e2e endpoint and
+# put it on the simulator clipboard (Maestro can't set the OS pasteboard itself
+# — clipboard_server.js bridges to `xcrun simctl pbcopy`; request_invoice.js
+# sets output.clipboardText). Then tap the in-app Paste button. Because the
+# clipboard was written by another process, iOS shows an "Allow Paste" system
+# prompt; it renders a beat after the tap, so wait for it explicitly, then tap.
+- evalScript: ${output.invoiceAmountSats = 1000}
+- runScript: ../scripts/request_invoice.js
 - runScript: ../scripts/set_clipboard.js
 - tapOn:
     id: "send.pasteButton"
@@ -142,9 +143,11 @@ appId: com.bittr.bittr-regtest
 # 2. Zero-amount invoice.
 # ---------------------------------------------------------------------------
 
-# Paste the zero-amount invoice the same way. The clipboard content changed, so
-# iOS prompts to allow the paste again — wait for it, then tap.
-- evalScript: ${output.clipboardText = LN_ZERO_INVOICE}
+# Request a zero-amount invoice (amount 0) from the e2e endpoint and paste it
+# the same way. The clipboard content changed, so iOS prompts to allow the
+# paste again — wait for it, then tap.
+- evalScript: ${output.invoiceAmountSats = 0}
+- runScript: ../scripts/request_invoice.js
 - runScript: ../scripts/set_clipboard.js
 - tapOn:
     id: "send.pasteButton"
@@ -227,14 +230,14 @@ appId: com.bittr.bittr-regtest
 # 3. Lightning Address (LNURL-pay).
 # ---------------------------------------------------------------------------
 
-# Type the Lightning Address into the invoice field and press the keyboard
-# return. The return key recognises the "@" address and kicks off LNURL
+# Type the bittr e2e Lightning Address into the invoice field and press the
+# keyboard return. The return key recognises the "@" address and kicks off LNURL
 # handling, which briefly shows the "Handling LNURL" spinner. The spinner can
 # come and go faster than Maestro can catch, so rather than asserting it appears
 # we just wait for it to have cleared (it resolves once the LNURL call returns).
 - tapOn:
     id: "send.toTextField"
-- inputText: "${LN_ADDRESS}"
+- inputText: "e2ebittr@staging.getbittr.com"
 - pressKey: Enter
 
 # LNURL resolves: the spinner stops and (when the address has a payable range)

--- a/shared/flows/scripts/clipboard_server.js
+++ b/shared/flows/scripts/clipboard_server.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+// Local HTTP helper for Maestro flows — receives text and writes it to the
+// booted iOS Simulator's clipboard via `xcrun simctl pbcopy`.
+//
+// Maestro's GraalJS sandbox forbids Java interop, so JS scripts can't shell
+// out directly, and Maestro has no command to set the device clipboard (its
+// `copyTextFrom` only fills Maestro's own `maestro.copiedText` variable, not
+// the OS pasteboard). This server bridges the gap so flows can exercise the
+// real in-app "Paste" button. Mirrors push_server.js.
+//
+// Run once before testing:
+//   node shared/flows/scripts/clipboard_server.js
+//
+// Maestro flows POST the text to put on the clipboard to
+// http://localhost:8889/clipboard with the raw text in the body.
+
+const http = require('http');
+const { spawnSync } = require('child_process');
+
+const PORT = 8889;
+
+http.createServer((req, res) => {
+    if (req.method !== 'POST' || req.url !== '/clipboard') {
+        res.writeHead(404);
+        res.end('only POST /clipboard is supported');
+        return;
+    }
+    let body = '';
+    req.on('data', (chunk) => { body += chunk; });
+    req.on('end', () => {
+        try {
+            // `xcrun simctl pbcopy booted` reads the clipboard contents from stdin.
+            const result = spawnSync('xcrun', ['simctl', 'pbcopy', 'booted'], { input: body });
+            const stderr = result.stderr?.toString() ?? '';
+            if (result.status !== 0) {
+                console.error('xcrun simctl pbcopy failed:', stderr);
+                res.writeHead(500, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ ok: false, status: result.status, stderr }));
+                return;
+            }
+            console.log(`copied ${body.length}-byte string to the booted simulator clipboard`);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ ok: true, stderr }));
+        } catch (err) {
+            console.error('handler error:', err);
+            res.writeHead(500);
+            res.end(String(err));
+        }
+    });
+}).listen(PORT, '127.0.0.1', () => {
+    console.log(`maestro clipboard helper listening on http://127.0.0.1:${PORT}/clipboard`);
+    console.log('forwarding to: xcrun simctl pbcopy booted <text>');
+});

--- a/shared/flows/scripts/request_invoice.js
+++ b/shared/flows/scripts/request_invoice.js
@@ -1,0 +1,51 @@
+// Requests a fresh lightning invoice from the bittr e2e endpoint, so flows
+// don't have to be handed a (quickly-expiring) invoice via --env. Mirrors
+// mine_blocks.js. Generating it server-side per run also avoids stale-invoice
+// flakiness.
+//
+// The calling flow sets the amount in satoshis first (0 = a zero-amount
+// invoice), then this script puts the bolt11 on both output.invoice and
+// output.clipboardText (ready to hand straight to set_clipboard.js):
+//
+//   - evalScript: ${output.invoiceAmountSats = 1000}   # 0 for zero-amount
+//   - runScript: ../scripts/request_invoice.js
+//   - runScript: ../scripts/set_clipboard.js
+//
+// NOTE: confirm the path matches the deployed endpoint — mine_blocks.js uses
+// the /api/e2e/ prefix, so this assumes /api/e2e/invoice.
+
+var amount = output.invoiceAmountSats;
+
+if (amount == null) {
+    throw new Error('request_invoice.js: output.invoiceAmountSats is not set');
+}
+
+var response = http.post(
+    'https://staging.getbittr.com/api/e2e/invoice',
+    {
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amount_in_sats: amount, memo: 'E2E test' })
+    }
+);
+
+console.log('e2e invoice (' + amount + ' sats) status: ' + response.status);
+console.log('e2e invoice body: ' + response.body);
+
+if (response.status < 200 || response.status >= 300) {
+    throw new Error('e2e invoice request failed: ' + response.status + ' ' + response.body);
+}
+
+var data = JSON.parse(response.body);
+
+// Accept whichever field the endpoint uses for the bolt11 string (top-level or
+// nested under `data`). Adjust here if the endpoint uses a different key.
+var invoice =
+    data.invoice || data.bolt11 || data.payment_request || data.pr ||
+    (data.data && (data.data.invoice || data.data.bolt11 || data.data.payment_request));
+
+if (invoice == null || invoice === '') {
+    throw new Error('request_invoice.js: no bolt11 field found in response: ' + response.body);
+}
+
+output.invoice = invoice;
+output.clipboardText = invoice;

--- a/shared/flows/scripts/set_clipboard.js
+++ b/shared/flows/scripts/set_clipboard.js
@@ -1,0 +1,35 @@
+// Puts text on the booted iOS Simulator's clipboard by relaying through the
+// local clipboard_server.js helper (Maestro's JS sandbox blocks shelling out
+// directly, and Maestro has no command to set the OS pasteboard itself).
+//
+// Prerequisite: run the helper in a separate terminal before the test:
+//   node shared/flows/scripts/clipboard_server.js
+//
+// The calling flow sets output.clipboardText to the string to copy. See
+// shared/flows/features/send_lightning.yaml for an example.
+
+var text = output.clipboardText;
+if (text == null || text === '') {
+    throw new Error(
+        'set_clipboard.js: output.clipboardText is empty. The flow must set ' +
+        'it (usually from a --env value) before calling this script.'
+    );
+}
+
+var response = http.post(
+    'http://localhost:8889/clipboard',
+    {
+        headers: { 'Content-Type': 'text/plain' },
+        body: text
+    }
+);
+
+console.log('clipboard helper status: ' + response.status);
+console.log('clipboard helper body: ' + response.body);
+
+if (response.status < 200 || response.status >= 300) {
+    throw new Error(
+        'set_clipboard.js: helper returned ' + response.status + ' ' + response.body +
+        '. Is clipboard_server.js running? `node shared/flows/scripts/clipboard_server.js`'
+    );
+}

--- a/shared/test-ids/test-ids.json
+++ b/shared/test-ids/test-ids.json
@@ -142,6 +142,9 @@
     "currencyLabel": null,
     "bdkSpinner": null,
     "availableButton": null,
+    "availableLabel": null,
+    "nextButton": null,
+    "lnurlSpinner": null,
     "confirm": {
       "addressLabel": null,
       "amountLabel": null,


### PR DESCRIPTION
End-to-end lightning send flow covering a normal (amount-bearing) invoice, a zero-amount invoice (amount entered in BTC), and a Lightning Address (LNURL-pay). Adds send.availableLabel/nextButton/lnurlSpinner test IDs and a clipboard bridge (clipboard_server.js + set_clipboard.js) so the in-app Paste button can be exercised. Three targets are manual input via LN_INVOICE / LN_ZERO_INVOICE / LN_ADDRESS env vars.

Also changes LNURL-pay behaviour: when minSendable != maxSendable the payable range is now shown via a 'Pay request' alert (title payrequest, message payrequest1) instead of being written into the send-all label.