### PR TITLE
Fix keyboard flicker when moving between seed-phrase fields

### DIFF
--- a/ios/bittr/Signup/Create Wallet/Signup4ViewController.swift
+++ b/ios/bittr/Signup/Create Wallet/Signup4ViewController.swift
@@ -103,8 +103,14 @@ class Signup4ViewController: UIViewController, UITextFieldDelegate {
     override func viewWillAppear(_ animated: Bool) {
         
         // Set notification observers.
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillDisappear), name: UIResponder.keyboardWillHideNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillAppear), name: UIResponder.keyboardWillShowNotification, object: nil)
+        // Use a single keyboardWillChangeFrame observer instead of the
+        // willShow/willHide pair: when focus moves between the word fields iOS
+        // posts a hide immediately followed by a show, and reacting to both
+        // bounced the content down then back up — the keyboard appeared to
+        // dismiss and re-open on every field change. Remove first so repeated
+        // viewWillAppear calls don't stack duplicate observers.
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillChangeFrame), name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
     }
     
     func setMnemonic() {
@@ -129,25 +135,25 @@ class Signup4ViewController: UIViewController, UITextFieldDelegate {
         }
     }
     
-    @objc func keyboardWillDisappear() {
-        
+    @objc func keyboardWillChangeFrame(_ notification: Notification) {
+
+        guard let userInfo = notification.userInfo,
+              let endFrame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue else { return }
+
+        // How much of the view the keyboard now covers (0 once it's fully gone).
+        let endFrameInView = self.view.convert(endFrame, from: nil)
+        let overlap = max(0, self.view.bounds.maxY - endFrameInView.minY)
+
+        // Moving between fields fires this with an unchanged frame — skip it so
+        // the layout doesn't churn, which is what produced the flicker.
+        if self.contentViewBottom.constant == -overlap { return }
+
         NSLayoutConstraint.deactivate([self.contentViewBottom])
-        self.contentViewBottom = NSLayoutConstraint(item: contentView!, attribute: .bottom, relatedBy: .equal, toItem: scrollView, attribute: .bottom, multiplier: 1, constant: 0)
+        self.contentViewBottom = NSLayoutConstraint(item: contentView!, attribute: .bottom, relatedBy: .equal, toItem: scrollView, attribute: .bottom, multiplier: 1, constant: -overlap)
         NSLayoutConstraint.activate([self.contentViewBottom])
-        
-        self.view.layoutIfNeeded()
-    }
-    
-    @objc func keyboardWillAppear(_ notification:Notification) {
-        
-        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-            
-            let keyboardHeight = keyboardSize.height
-            
-            NSLayoutConstraint.deactivate([self.contentViewBottom])
-            self.contentViewBottom = NSLayoutConstraint(item: contentView!, attribute: .bottom, relatedBy: .equal, toItem: scrollView, attribute: .bottom, multiplier: 1, constant: -keyboardHeight)
-            NSLayoutConstraint.activate([self.contentViewBottom])
-            
+
+        let duration = (userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double) ?? 0.25
+        UIView.animate(withDuration: duration) {
             self.view.layoutIfNeeded()
         }
     }

--- a/ios/bittr/Signup/Restore Wallet/RestoreViewController.swift
+++ b/ios/bittr/Signup/Restore Wallet/RestoreViewController.swift
@@ -145,30 +145,36 @@ class RestoreViewController: UIViewController, UITextFieldDelegate {
     
     override func viewWillAppear(_ animated: Bool) {
         
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillDisappear), name: UIResponder.keyboardWillHideNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillAppear), name: UIResponder.keyboardWillShowNotification, object: nil)
+        // Use a single keyboardWillChangeFrame observer instead of the
+        // willShow/willHide pair: when focus moves between two word fields iOS
+        // posts a hide immediately followed by a show, and reacting to both
+        // bounced the content down then back up — the keyboard appeared to
+        // dismiss and re-open on every field change. Remove first so repeated
+        // viewWillAppear calls don't stack duplicate observers.
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillChangeFrame), name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(changeColors), name: NSNotification.Name(rawValue: "changecolors"), object: nil)
     }
-    
-    @objc func keyboardWillDisappear() {
-        
+
+    @objc func keyboardWillChangeFrame(_ notification: Notification) {
+
+        guard let userInfo = notification.userInfo,
+              let endFrame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue else { return }
+
+        // How much of the view the keyboard now covers (0 once it's fully gone).
+        let endFrameInView = self.view.convert(endFrame, from: nil)
+        let overlap = max(0, self.view.bounds.maxY - endFrameInView.minY)
+
+        // Moving between fields fires this with an unchanged frame — skip it so
+        // the layout doesn't churn, which is what produced the flicker.
+        if self.contentViewBottom.constant == -overlap { return }
+
         NSLayoutConstraint.deactivate([self.contentViewBottom])
-        self.contentViewBottom = NSLayoutConstraint(item: self.contentView!, attribute: .bottom, relatedBy: .equal, toItem: self.scrollView, attribute: .bottom, multiplier: 1, constant: 0)
+        self.contentViewBottom = NSLayoutConstraint(item: self.contentView!, attribute: .bottom, relatedBy: .equal, toItem: self.scrollView, attribute: .bottom, multiplier: 1, constant: -overlap)
         NSLayoutConstraint.activate([self.contentViewBottom])
-        
-        self.view.layoutIfNeeded()
-    }
-    
-    @objc func keyboardWillAppear(_ notification:Notification) {
-        
-        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-            
-            let keyboardHeight = keyboardSize.height
-            
-            NSLayoutConstraint.deactivate([self.contentViewBottom])
-            self.contentViewBottom = NSLayoutConstraint(item: self.contentView!, attribute: .bottom, relatedBy: .equal, toItem: self.scrollView, attribute: .bottom, multiplier: 1, constant: -keyboardHeight)
-            NSLayoutConstraint.activate([self.contentViewBottom])
-            
+
+        let duration = (userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double) ?? 0.25
+        UIView.animate(withDuration: duration) {
             self.view.layoutIfNeeded()
         }
     }


### PR DESCRIPTION
## What

Stops the keyboard from appearing to dismiss and re-open every time you move between word-entry fields on:

- **Wallet restore** and **Forgot PIN** recovery — `RestoreViewController` (shared by both flows)
- **New-wallet backup confirmation** (the 3 words you re-enter) — `Signup4ViewController`

## Why

Both screens observed **both** `keyboardWillShow` and `keyboardWillHide`. When focus moves between two text fields, iOS posts a hide *immediately followed by* a show even though the keyboard never actually leaves. The handlers reacted to both: `willHide` snapped the content view's bottom constraint back to `0`, then `willShow` shoved it back to `-keyboardHeight`. That un-animated down-then-up bounce is the "keyboard kind of re-appears" flicker.

Two aggravating factors: the constraint change wasn't animated (hard jump), and the observers were re-added on every `viewWillAppear` without removal, so the handlers multiplied on revisits.

## How

- Replace the `willShow`/`willHide` pair with a single **`keyboardWillChangeFrame`** observer.
- Compute the keyboard's actual overlap with the view and **bail out when it's unchanged** — which is exactly the field-to-field case, so the layout no longer churns.
- Animate the adjustment with the keyboard's own duration.
- Remove the observer before re-adding it so repeated `viewWillAppear` calls don't stack duplicates.

For these full-screen view controllers the computed overlap equals the previous `keyboardHeight`, so the resting content position is unchanged — only the flicker is gone.

## Testing

⚠️ Not compiled — built in the sandbox isn't possible here, so **please build in Xcode** and verify:
- Restore wallet: tab/return and tap between all 12 fields — keyboard stays put, no bounce.
- Forgot PIN (reset PIN flow): same fields, same check.
- New wallet → backup confirmation: move between the 3 fields.
- Keyboard still shows/hides correctly on entering/leaving the screen, and content isn't hidden behind the keyboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)