### PR TITLE
Updates to wrong_pin.yaml test and associated changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,11 @@ maestro test shared/flows/features/swap.yaml
 maestro test shared/flows/features/send_lightning.yaml
 
 maestro test shared/flows/features/remove_wallet.yaml
+# PIN lockout, no open channel (immediate wipe):
 maestro test shared/flows/features/wrong_pin.yaml
+# PIN lockout with an open channel (close + Try again retry loop) — set up a
+# channel first (e.g. run buy_incoming.yaml):
+maestro test shared/flows/features/wrong_pin_with_channel.yaml
 maestro test shared/flows/features/bitcoin_value.yaml
 maestro test shared/flows/features/bitcoin_map.yaml
 maestro test shared/flows/features/academy.yaml

--- a/ios/bittr/Core/CoreViewController.swift
+++ b/ios/bittr/Core/CoreViewController.swift
@@ -196,6 +196,20 @@ class CoreViewController: UIViewController {
         if self.walletIsAvailable {
             self.signupContainerView.alpha = 0
             self.pinContainerView.alpha = 1
+
+            // Check whether the user has been locked out of their wallet.
+            if CacheManager.getFailedPinAttempts() >= 10 {
+                Log.info("Wallet is locked out after 10 failed PIN attempts — resuming removal on launch.")
+                self.removingWalletForIncorrectPin = true
+                self.fullViewCover.alpha = 0.8
+                self.genericSpinner.startAnimating()
+                self.showAlert(presentingController: self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "pinlock"), buttons: [Language.getWord(withID: "okay")], actions: nil)
+                
+                // Start wallet in background.
+                Task {
+                    await self.startWallet()
+                }
+            }
         } else {
             self.signupContainerView.alpha = 1
             self.pinContainerView.alpha = 0

--- a/ios/bittr/Core/CoreViewController.swift
+++ b/ios/bittr/Core/CoreViewController.swift
@@ -198,7 +198,10 @@ class CoreViewController: UIViewController {
             self.pinContainerView.alpha = 1
 
             // Check whether the user has been locked out of their wallet.
-            if CacheManager.getFailedPinAttempts() >= 10 {
+            // Guard against re-entry: once the removal is in progress, don't stack
+            // another lockout alert + a second concurrent startWallet() task if
+            // showPinOrSignup runs again.
+            if CacheManager.getFailedPinAttempts() >= 10, !self.removingWalletForIncorrectPin {
                 Log.info("Wallet is locked out after 10 failed PIN attempts — resuming removal on launch.")
                 self.removingWalletForIncorrectPin = true
                 self.fullViewCover.alpha = 0.8

--- a/ios/bittr/Core/ResetApp.swift
+++ b/ios/bittr/Core/ResetApp.swift
@@ -85,7 +85,13 @@ extension CoreViewController {
                     // on-chain yet (still being swept). Don't wipe — tell the
                     // user to come back once it has settled.
                     Log.info("Channel closed but funds still settling — deferring wallet reset.")
-                    self.showAlert(presentingController: self, title: Language.getWord(withID: "removewallet"), message: Language.getWord(withID: "stillclosing"), buttons: [Language.getWord(withID: "okay")], actions: nil)
+                    
+                    if self.removingWalletForIncorrectPin {
+                        // User is locked out. Show "Try again" button, as only available user action.
+                        self.showAlert(presentingController: self, title: Language.getWord(withID: "removewallet"), message: Language.getWord(withID: "stillclosing"), buttons: [Language.getWord(withID: "tryagain")], actions: [#selector(self.startWalletInBackground)])
+                    } else {
+                        self.showAlert(presentingController: self, title: Language.getWord(withID: "removewallet"), message: Language.getWord(withID: "stillclosing"), buttons: [Language.getWord(withID: "okay")], actions: nil)
+                    }
                 }
             } else {
                 if self.resettingPin || self.removingWalletForIncorrectPin {
@@ -178,10 +184,13 @@ extension CoreViewController {
             DispatchQueue.main.async {
                 self.didCloseChannel()
                 self.genericSpinner.stopAnimating()
-                if !self.removingWalletForIncorrectPin {
+                if self.removingWalletForIncorrectPin {
+                    // User is locked out. Show "Try again" button as only available user action.
+                    self.showAlert(presentingController: self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "stillclosing"), buttons: [Language.getWord(withID: "tryagain")], actions: [#selector(self.startWalletInBackground)])
+                } else {
                     self.fullViewCover.alpha = 0
+                    self.showAlert(presentingController: self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "stillclosing"), buttons: [Language.getWord(withID: "okay")], actions: nil)
                 }
-                self.showAlert(presentingController: self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "stillclosing"), buttons: [Language.getWord(withID: "okay")], actions: nil)
             }
         } else {
             // No channel to close — re-evaluate the wipe gate (wipes only if the

--- a/ios/bittr/Core/ResetApp.swift
+++ b/ios/bittr/Core/ResetApp.swift
@@ -67,10 +67,12 @@ extension CoreViewController {
             // reconstruct — catastrophic for a force-closed channel. We only ever
             // cooperatively close, then wait for the funds to land before resetting.
             if !BitcoinManager.shared.channelsFullyClosedAndSwept() {
-                // We're going to wait, not wipe — take the spinner down.
-                self.genericSpinner.stopAnimating()
-                self.fullViewCover.alpha = 0
-
+                
+                if !self.removingWalletForIncorrectPin {
+                    self.genericSpinner.stopAnimating()
+                    self.fullViewCover.alpha = 0
+                }
+                
                 if BitcoinManager.shared.listChannels().getActiveChannel() != nil {
                     Log.info("Channel still open — initiating cooperative close before any reset.")
                     if self.removingWalletForIncorrectPin {
@@ -138,7 +140,6 @@ extension CoreViewController {
                         // funds behind a CSV delay and risks loss on the wipe) and
                         // don't wipe — surface it and let the user retry later.
                         self.genericSpinner.stopAnimating()
-                        self.fullViewCover.alpha = 0
                         self.showAlert(presentingController: self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "closeretrylater"), buttons: [Language.getWord(withID: "okay")], actions: nil)
                     } else {
                         // Manual reset: let the user explicitly choose force close.
@@ -163,7 +164,6 @@ extension CoreViewController {
                         // Coop close failed during the automated wipe. Do not force
                         // close or wipe — tell the user and let them retry later.
                         self.genericSpinner.stopAnimating()
-                        self.fullViewCover.alpha = 0
                         self.showAlert(presentingController: self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "closeretrylater"), buttons: [Language.getWord(withID: "okay")], actions: nil)
                     } else {
                         self.showAlert(presentingController: self, title: Language.getWord(withID: "closechannel6"), message: Language.getWord(withID: "closechannel7"), buttons: [Language.getWord(withID: "cancel"), Language.getWord(withID: "forceclose")], actions: [nil, #selector(self.forceCloseChannel)])
@@ -178,7 +178,9 @@ extension CoreViewController {
             DispatchQueue.main.async {
                 self.didCloseChannel()
                 self.genericSpinner.stopAnimating()
-                self.fullViewCover.alpha = 0
+                if !self.removingWalletForIncorrectPin {
+                    self.fullViewCover.alpha = 0
+                }
                 self.showAlert(presentingController: self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "stillclosing"), buttons: [Language.getWord(withID: "okay")], actions: nil)
             }
         } else {

--- a/ios/bittr/Core/ResetApp.swift
+++ b/ios/bittr/Core/ResetApp.swift
@@ -144,9 +144,12 @@ extension CoreViewController {
                         // Automated wipe path: we only ever cooperatively close,
                         // which needs the peer online. Don't force close (it locks
                         // funds behind a CSV delay and risks loss on the wipe) and
-                        // don't wipe — surface it and let the user retry later.
+                        // don't wipe. Offer a single "Try again" action
+                        // (startWalletInBackground re-syncs + re-checks), matching
+                        // the "still closing" path — otherwise tapping Okay would
+                        // strand the locked-out user on a static full-screen cover.
                         self.genericSpinner.stopAnimating()
-                        self.showAlert(presentingController: self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "closeretrylater"), buttons: [Language.getWord(withID: "okay")], actions: nil)
+                        self.showAlert(presentingController: self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "closeretrylater"), buttons: [Language.getWord(withID: "tryagain")], actions: [#selector(self.startWalletInBackground)])
                     } else {
                         // Manual reset: let the user explicitly choose force close.
                         self.forceCloseChannel()
@@ -168,9 +171,12 @@ extension CoreViewController {
                     }
                     if self.removingWalletForIncorrectPin {
                         // Coop close failed during the automated wipe. Do not force
-                        // close or wipe — tell the user and let them retry later.
+                        // close or wipe. Offer a single "Try again" action
+                        // (startWalletInBackground re-syncs + re-checks), matching
+                        // the "still closing" path, so the locked-out user isn't
+                        // stranded behind the cover with only a dismiss button.
                         self.genericSpinner.stopAnimating()
-                        self.showAlert(presentingController: self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "closeretrylater"), buttons: [Language.getWord(withID: "okay")], actions: nil)
+                        self.showAlert(presentingController: self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "closeretrylater"), buttons: [Language.getWord(withID: "tryagain")], actions: [#selector(self.startWalletInBackground)])
                     } else {
                         self.showAlert(presentingController: self, title: Language.getWord(withID: "closechannel6"), message: Language.getWord(withID: "closechannel7"), buttons: [Language.getWord(withID: "cancel"), Language.getWord(withID: "forceclose")], actions: [nil, #selector(self.forceCloseChannel)])
                     }

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -122,6 +122,9 @@ extension HomeViewController {
         if !self.coreVC!.walletHasSynced {
             // Finalize sync.
             self.finalizeSync()
+        } else if (self.coreVC!.resettingPin || self.coreVC!.removingWalletForIncorrectPin), self.coreVC!.genericSpinner.isAnimating {
+            // User is locked out and is retrying removing their wallet.
+            self.coreVC!.restoreWalletTapped()
         }
     }
     

--- a/ios/bittr/Notifications/HandlePaymentNotification.swift
+++ b/ios/bittr/Notifications/HandlePaymentNotification.swift
@@ -341,7 +341,9 @@ extension CoreViewController {
                         }
                     }
                     answer = answer.replacingOccurrences(of: "<reason>", with: "")
-                    self.launchQuestion(question: Language.getWord(withID: "closedlightningchannel"), answer: answer, type: nil)
+                    if !self.removingWalletForIncorrectPin {
+                        self.launchQuestion(question: Language.getWord(withID: "closedlightningchannel"), answer: answer, type: nil)
+                    }
                     self.syncLDKnode()
                 }
             case .channelPending(channelId: _, userChannelId: _, formerTemporaryChannelId: _, counterpartyNodeId: _, fundingTxo: let fundingTxo):

--- a/ios/bittr/Pin/PinViewController.swift
+++ b/ios/bittr/Pin/PinViewController.swift
@@ -199,13 +199,13 @@ class PinViewController: UIViewController, UITextFieldDelegate, UICollectionView
 
             if self.correctPin != nil {
                 
-                if CacheManager.getFailedPinAttempts() >= 10 || self.coreVC?.removingWalletForIncorrectPin == true {
-                    Log.info("Wallet is locked out after 10 failed PIN attempts — resuming removal instead of unlocking.")
-                    self.coreVC?.removingWalletForIncorrectPin = true
-                    self.coreVC?.restoreWalletTapped()
+                if CacheManager.getFailedPinAttempts() >= 10 {
+                    Log.info("Wallet is locked out after 10 failed PIN attempts.")
+                    self.clearPinField()
+                    self.removeWallet()
                     return
                 }
-
+                
                 if self.correctPin! == self.pinTextField.text {
                     // Correct pin.
                     CacheManager.resetFailedPinAttempts()
@@ -213,27 +213,21 @@ class PinViewController: UIViewController, UITextFieldDelegate, UICollectionView
                     self.coreVC?.correctPin(spinner:self.pinSpinner)
                 } else {
                     // Wrong pin.
-                    if CacheManager.getFailedPinAttempts() >= 9 {
+                    CacheManager.increaseFailedPinAttempts()
+                    self.clearPinField()
+                    
+                    if CacheManager.getFailedPinAttempts() >= 10 {
                         Log.info("Wrong pin has been entered 10 times.")
-                        CacheManager.increaseFailedPinAttempts()
-                        
-                        self.showAlert(presentingController: self.coreVC ?? self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "pinlock"), buttons: [Language.getWord(withID: "okay")], actions: [#selector(self.clearPinField)])
-
-                        Log.info("Remove wallet from device.")
-                        self.coreVC?.removingWalletForIncorrectPin = true
-                        self.coreVC?.restoreWalletTapped()
-
+                        self.removeWallet()
                         return
                     }
-
-                    CacheManager.increaseFailedPinAttempts()
-
+                    
                     // Warn well before the 10-attempt wipe and steer anyone who
                     // still has their recovery phrase to the non-destructive
                     // Forgot PIN flow — the wipe can cost them their Lightning
                     // funds, so we want them recovering by mnemonic instead.
                     if CacheManager.getFailedPinAttempts() == 3 {
-                        self.showAlert(presentingController: self.coreVC ?? self, title: Language.getWord(withID: "pinwarning"), message: Language.getWord(withID: "pinwarning2"), buttons: [Language.getWord(withID: "okay"), Language.getWord(withID: "forgotpin")], actions: [#selector(self.clearPinField), #selector(self.startPinReset)])
+                        self.showAlert(presentingController: self.coreVC ?? self, title: Language.getWord(withID: "pinwarning"), message: Language.getWord(withID: "pinwarning2"), buttons: [Language.getWord(withID: "okay"), Language.getWord(withID: "forgotpin")], actions: [nil, #selector(self.startPinReset)])
                         return
                     }
 
@@ -254,9 +248,18 @@ class PinViewController: UIViewController, UITextFieldDelegate, UICollectionView
         }
     }
     
+    func removeWallet() {
+        self.showAlert(presentingController: self.coreVC ?? self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "pinlock"), buttons: [Language.getWord(withID: "okay")], actions: nil)
+        
+        Log.info("Remove wallet from device.")
+        self.coreVC?.removingWalletForIncorrectPin = true
+        self.coreVC?.restoreWalletTapped()
+    }
+    
     @objc func clearPinField() {
         self.hideAlert()
         self.pinTextField.text = ""
+        self.pinCollectionView.reloadData()
     }
     
     @IBAction func restoreButtonTapped(_ sender: UIButton) {

--- a/ios/bittr/Pin/PinViewController.swift
+++ b/ios/bittr/Pin/PinViewController.swift
@@ -198,6 +198,14 @@ class PinViewController: UIViewController, UITextFieldDelegate, UICollectionView
             guard (self.coreVC ?? self).checkInternetConnection() else { return }
 
             if self.correctPin != nil {
+                
+                if CacheManager.getFailedPinAttempts() >= 10 || self.coreVC?.removingWalletForIncorrectPin == true {
+                    Log.info("Wallet is locked out after 10 failed PIN attempts — resuming removal instead of unlocking.")
+                    self.coreVC?.removingWalletForIncorrectPin = true
+                    self.coreVC?.restoreWalletTapped()
+                    return
+                }
+
                 if self.correctPin! == self.pinTextField.text {
                     // Correct pin.
                     CacheManager.resetFailedPinAttempts()
@@ -207,6 +215,8 @@ class PinViewController: UIViewController, UITextFieldDelegate, UICollectionView
                     // Wrong pin.
                     if CacheManager.getFailedPinAttempts() >= 9 {
                         Log.info("Wrong pin has been entered 10 times.")
+                        CacheManager.increaseFailedPinAttempts()
+                        
                         self.showAlert(presentingController: self.coreVC ?? self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "pinlock"), buttons: [Language.getWord(withID: "okay")], actions: [#selector(self.clearPinField)])
 
                         Log.info("Remove wallet from device.")

--- a/shared/flows/README.md
+++ b/shared/flows/README.md
@@ -58,9 +58,18 @@ shared/flows/
     remove_wallet.yaml    Settings → Device details → Remove wallet. Handles
                           both branches (active channel → close → mine →
                           re-trigger; no channel → direct confirm).
-    wrong_pin.yaml        PIN lockout from the unlock screen — ten wrong
-                          PINs wipe the wallet and drop back to Signup1
-                          (run onboarding/restore_wallet.yaml first).
+    wrong_pin.yaml        PIN lockout with NO open channel — ten wrong PINs
+                          wipe the wallet (immediately, nothing to close) and
+                          drop back to Signup1. Self-provisions: restores a
+                          wallet first if none exists. Shares the 10 attempts via
+                          helpers/wrong_pin_until_lockout.yaml.
+    wrong_pin_with_channel.yaml  PIN lockout WITH an open channel — the wipe
+                          cooperatively closes the channel and runs the "still
+                          closing" → mine → Try again retry loop before landing
+                          on Signup1. Self-provisions: restores a wallet if
+                          needed and builds a channel (via
+                          helpers/ensure_bittr_channel.yaml) if none is detected.
+                          Same shared lockout helper.
     pin_warning.yaml      The 3-wrong-attempt warning on the unlock screen,
                           then recovery via its Forgot PIN button. Self-
                           contained — runs restore_wallet.yaml first (runFlow)
@@ -84,6 +93,15 @@ shared/flows/
                           (QuestionViewController).
   helpers/         Reusable subflows invoked via runFlow.
     unlock.yaml           Enters PIN 1234 on the unlock screen.
+    wrong_pin_until_lockout.yaml  Enters the wrong PIN ten times on the unlock
+                          screen to trigger the lockout + background wipe; stops
+                          at the 10th confirm so the caller can handle the
+                          channel/no-channel divergence. Used by wrong_pin.yaml
+                          and wrong_pin_with_channel.yaml.
+    ensure_bittr_channel.yaml  Ensures the wallet has an open Lightning channel:
+                          runs buy_signup (if no bittr account) + buy_incoming.
+                          Invoked by wrong_pin_with_channel.yaml only when no
+                          channel is detected. (Best-effort / unverified.)
     show_onchain_address.yaml  From a freshly-opened Receive screen, waits out
                           the QR spinner and switches the type to the onchain
                           Address (via More → Address) when a channel is present.

--- a/shared/flows/features/wrong_pin.yaml
+++ b/shared/flows/features/wrong_pin.yaml
@@ -123,6 +123,23 @@ appId: com.bittr.bittr-regtest
     id: "pin.confirmButton"
 - takeScreenshot: shared/docs/screenshots/wrong_pin/03_wipe_started
 
+# If there was still an open/closing Lightning channel, the wipe can't
+# complete immediately: the "still closing" alert (stillclosing) surfaces
+# with a single Okay button (alert.button.0) while the cooperative close
+# settles on-chain. It's timing-dependent, so give it a brief moment to
+# appear and dismiss it if present — then carry on to Signup1. When no
+# such alert shows, this is a no-op.
+- waitForAnimationToEnd:
+    timeout: 3000
+- runFlow:
+    when:
+      visible:
+        id: "alert.button.0"
+    commands:
+      - takeScreenshot: shared/docs/screenshots/wrong_pin/03b_still_closing
+      - tapOn:
+          id: "alert.button.0"
+
 # The wipe runs in the background: startWalletInBackground syncs the wallet,
 # finalizeSync re-enters restoreWalletTapped, performWalletReset clears
 # state and stops the node, then after a ~1s delay relaunches signup on

--- a/shared/flows/features/wrong_pin.yaml
+++ b/shared/flows/features/wrong_pin.yaml
@@ -99,14 +99,9 @@ appId: com.bittr.bittr-regtest
 
 # Wrong PIN attempt 10. The counter now reads 9, so this entry triggers the
 # lockout instead of the "incorrect PIN" alert, and kicks off the wallet wipe.
-#
-# Note: unlike attempts 1..9, we do NOT tap an Okay button here. The lockout
-# alert (restorewallet / pinlock) is shown and then immediately dismissed by
-# the wipe itself: the handler synchronously calls restoreWalletTapped() ->
-# startWalletInBackground(), whose first line is hideAlert(). All of this runs
-# in one main-thread turn, so the lockout alert never reliably renders — we
-# can't (and don't need to) tap it. The confirm tap goes straight into the
-# wipe, and the app advances to Signup1 on its own.
+# The lockout alert (restorewallet / pinlock — "You've entered an incorrect
+# PIN too many times. Please restore your wallet.") is shown with a single
+# Okay button, and the wipe starts syncing in the background behind it.
 - tapOn:
     id: "pin.button1"
     waitToSettleTimeoutMs: 0
@@ -123,27 +118,50 @@ appId: com.bittr.bittr-regtest
     id: "pin.confirmButton"
 - takeScreenshot: shared/docs/screenshots/wrong_pin/03_wipe_started
 
-# If there was still an open/closing Lightning channel, the wipe can't
-# complete immediately: the "still closing" alert (stillclosing) surfaces
-# with a single Okay button (alert.button.0) while the cooperative close
-# settles on-chain. It's timing-dependent, so give it a brief moment to
-# appear and dismiss it if present — then carry on to Signup1. When no
-# such alert shows, this is a no-op.
+# Acknowledge the lockout alert. It has a single Okay button (alert.button.0)
+# and always shows on the 10th wrong PIN, regardless of channel state. Tapping
+# Okay just dismisses it — the wipe is already syncing in the background.
+- extendedWaitUntil:
+    visible:
+      id: "alert.button.0"
+    timeout: 30000
+- takeScreenshot: shared/docs/screenshots/wrong_pin/03b_lockout_alert
+- tapOn:
+    id: "alert.button.0"
+
+# The wipe continues behind the full-screen yellow cover + spinner. If there
+# was an open Lightning channel it can't complete immediately: a cooperative
+# close is broadcast and the "still closing" alert (stillclosing) appears with
+# a single "Try again" button (alert.button.0). The cover/spinner animate for
+# the whole sync, so wait for the screen to settle into whichever state comes
+# next — that alert, or Signup1 (when there was no channel to close, in which
+# case no second alert appears and the loop below runs zero times).
 - waitForAnimationToEnd:
-    timeout: 3000
-- runFlow:
-    when:
+    timeout: 120000
+
+# While the "still closing" alert keeps reappearing, mine 6 blocks to confirm
+# the cooperative close on-chain (same count as the channel-open/close
+# confirmation elsewhere) and tap "Try again" (alert.button.0). That re-syncs
+# and re-checks whether the funds have settled enough to remove the wallet.
+# Each retry spins the cover again, so wait for it to settle before re-testing
+# the condition. Once the wipe completes the alert stops returning and we fall
+# through to Signup1.
+- repeat:
+    while:
       visible:
         id: "alert.button.0"
     commands:
-      - takeScreenshot: shared/docs/screenshots/wrong_pin/03b_still_closing
+      - takeScreenshot: shared/docs/screenshots/wrong_pin/03c_still_closing
+      - evalScript: ${output.blocksToMine = 6}
+      - runScript: ../scripts/mine_blocks.js
       - tapOn:
           id: "alert.button.0"
+      - waitForAnimationToEnd:
+          timeout: 120000
 
-# The wipe runs in the background: startWalletInBackground syncs the wallet,
-# finalizeSync re-enters restoreWalletTapped, performWalletReset clears
-# state and stops the node, then after a ~1s delay relaunches signup on
-# page 3 (Signup1). Allow generous slack for the sync + node teardown.
+# The wipe has completed: performWalletReset cleared state, stopped the node,
+# and relaunched signup on page 3 (Signup1). Allow generous slack for the
+# final sync + node teardown.
 - extendedWaitUntil:
     visible:
       id: "signup.create.start.createWalletButton"

--- a/shared/flows/features/wrong_pin.yaml
+++ b/shared/flows/features/wrong_pin.yaml
@@ -1,34 +1,34 @@
-# Feature test: the PIN lockout path. Entering the wrong PIN ten times on
-# the unlock screen wipes the wallet from the device and drops the user
-# back on Signup1, so they no longer have access to the installed wallet.
+# Feature test: the PIN lockout path with NO open Lightning channel. Entering
+# the wrong PIN ten times on the unlock screen wipes the wallet from the device
+# and drops the user back on Signup1, so they no longer have access to the
+# installed wallet. With no channel to close, the wipe completes immediately.
 #
-# Prerequisite: an existing wallet on the simulator, freshly set up so the
-# failed-attempt counter is at 0 (CacheManager.getFailedPinAttempts() == 0)
-# and there is no open Lightning channel. The cleanest way to get there is
-# to run `shared/flows/onboarding/restore_wallet.yaml` first — same starting
-# style as buy_signup.yaml. The flow preserves state (no clearState /
-# clearKeychain) and lands on the PIN unlock screen.
+# Self-provisioning: if there is no wallet on the device (fresh device, or a
+# previous run already wiped it) the flow restores one first via
+# onboarding/restore_wallet.yaml, which yields a wallet with NO open channel and
+# the failed-attempt counter at 0 — exactly this test's precondition. If a
+# wallet already exists it is used as-is, so it must have counter 0 and no open
+# channel (otherwise use wrong_pin_with_channel.yaml).
 #
 # This flow is destructive: it removes the wallet. It can only be run once
 # against a freshly-restored wallet (a second run would find no wallet to
 # unlock).
 #
+# For the variant where a Lightning channel must be cooperatively closed
+# first (the "still closing" + Try again retry loop), see
+# wrong_pin_with_channel.yaml. The ten wrong-PIN attempts are shared between
+# the two via helpers/wrong_pin_until_lockout.yaml.
+#
 # Behaviour under test (PinViewController.confirmPinButtonTapped, .core):
 #   - Wrong PIN entries 1..9 each call increaseFailedPinAttempts() and show
 #     the "incorrect PIN" alert (incorrectpin / incorrectpin2).
-#   - On entry 10, getFailedPinAttempts() == 9, so the lockout alert
-#     (restorewallet / pinlock) is shown and removingWalletForIncorrectPin
-#     is set + restoreWalletTapped() kicks off the wipe. The lockout check
-#     lives inside the wrong-pin branch, so a correct 10th entry still
-#     unlocks normally.
-#   - ResetApp drives startWallet → finalizeSync → restoreWalletTapped →
-#     performWalletReset → 1s delay → launchSignup(onPage: 3) → Signup1.
-#
-# Both alerts expose a single Okay button (alert.button.0) wired to
-# clearPinField, which dismisses the alert and clears the PIN field. The
-# alert IDs are set in AlertManager.swift (mainButton.accessibilityIdentifier
-# = "alert.button.\(index)"), not in shared/test-ids/test-ids.json — same
-# pattern forgot_pin.yaml / remove_wallet.yaml rely on.
+#   - On entry 10 the counter reaches 10, so removeWallet() runs:
+#     removingWalletForIncorrectPin is set and restoreWalletTapped() kicks off
+#     the background wipe. The lockout check sits at the top of the wrong-PIN
+#     branch, so a correct 10th entry still unlocks normally.
+#   - ResetApp drives startWallet -> finalizeSync -> restoreWalletTapped. With
+#     no channel, channelsFullyClosedAndSwept() is already true, so
+#     performWalletReset runs -> 1s delay -> launchSignup(onPage: 3) -> Signup1.
 #
 # Run: maestro test shared/flows/features/wrong_pin.yaml
 
@@ -36,134 +36,34 @@ appId: com.bittr.bittr-regtest
 ---
 - launchApp
 
-# Wallet was set up previously, so launch lands on the PIN unlock screen
-# (PinVC in .core embedding). Fail loudly otherwise — there'd be no wallet
-# to lock out of.
-- assertVisible:
-    id: "unlock.topLabel"
+# Self-provision a wallet if there isn't one. On launch an existing wallet shows
+# the PIN unlock screen (unlock.topLabel); if it's absent (fresh device, or a
+# previous run already wiped the wallet) restore one first. restore_wallet ends
+# on Home, so the relaunch below returns us to the locked unlock screen.
+# NOTE: restore_wallet yields a wallet with NO open channel — exactly this
+# test's precondition. For the open-channel case use wrong_pin_with_channel.yaml.
+- runFlow:
+    when:
+      notVisible:
+        id: "unlock.topLabel"
+    file: ../onboarding/restore_wallet.yaml
+
+# Back to the locked unlock screen (no-op relaunch if a wallet already existed).
+- launchApp
 - takeScreenshot: shared/docs/screenshots/wrong_pin/01_unlock
 
-# Wrong PIN attempt 1 of 10. Type 1111 and confirm — correctPin (1234) does
-# not match, so the "incorrect PIN" alert appears. Tapping its Okay button
-# (alert.button.0) runs clearPinField: dismisses the alert and clears the
-# field ready for the next attempt.
-#
-# The digit taps use waitToSettleTimeoutMs: 0 to skip Maestro's
-# wait-for-animation-to-settle after each tap — the PIN buttons only flash a
-# background and toggle a dot, so there's nothing meaningful to wait for. This
-# is the main speed-up for the 40+ digit taps in this flow.
-- tapOn:
-    id: "pin.button1"
-    waitToSettleTimeoutMs: 0
-- tapOn:
-    id: "pin.button1"
-    waitToSettleTimeoutMs: 0
-- tapOn:
-    id: "pin.button1"
-    waitToSettleTimeoutMs: 0
-- tapOn:
-    id: "pin.button1"
-    waitToSettleTimeoutMs: 0
-- tapOn:
-    id: "pin.confirmButton"
-- assertVisible:
-    id: "alert.button.0"
-- takeScreenshot: shared/docs/screenshots/wrong_pin/02_incorrect_alert
-- tapOn:
-    id: "alert.button.0"
+# Enter the wrong PIN ten times -> lockout + background wipe begins.
+- runFlow:
+    file: ../helpers/wrong_pin_until_lockout.yaml
+- takeScreenshot: shared/docs/screenshots/wrong_pin/02_wipe_started
 
-# Wrong PIN attempts 2..9 (8 more "incorrect PIN" alerts). Each iteration
-# re-enters 1111, confirms, waits for the alert and closes it. After the
-# 9th attempt the failed-attempt counter sits at 9.
-- repeat:
-    times: 8
-    commands:
-      - tapOn:
-          id: "pin.button1"
-          waitToSettleTimeoutMs: 0
-      - tapOn:
-          id: "pin.button1"
-          waitToSettleTimeoutMs: 0
-      - tapOn:
-          id: "pin.button1"
-          waitToSettleTimeoutMs: 0
-      - tapOn:
-          id: "pin.button1"
-          waitToSettleTimeoutMs: 0
-      - tapOn:
-          id: "pin.confirmButton"
-      - assertVisible:
-          id: "alert.button.0"
-      - tapOn:
-          id: "alert.button.0"
-
-# Wrong PIN attempt 10. The counter now reads 9, so this entry triggers the
-# lockout instead of the "incorrect PIN" alert, and kicks off the wallet wipe.
-# The lockout alert (restorewallet / pinlock — "You've entered an incorrect
-# PIN too many times. Please restore your wallet.") is shown with a single
-# Okay button, and the wipe starts syncing in the background behind it.
-- tapOn:
-    id: "pin.button1"
-    waitToSettleTimeoutMs: 0
-- tapOn:
-    id: "pin.button1"
-    waitToSettleTimeoutMs: 0
-- tapOn:
-    id: "pin.button1"
-    waitToSettleTimeoutMs: 0
-- tapOn:
-    id: "pin.button1"
-    waitToSettleTimeoutMs: 0
-- tapOn:
-    id: "pin.confirmButton"
-- takeScreenshot: shared/docs/screenshots/wrong_pin/03_wipe_started
-
-# Acknowledge the lockout alert. It has a single Okay button (alert.button.0)
-# and always shows on the 10th wrong PIN, regardless of channel state. Tapping
-# Okay just dismisses it — the wipe is already syncing in the background.
-- extendedWaitUntil:
-    visible:
-      id: "alert.button.0"
-    timeout: 30000
-- takeScreenshot: shared/docs/screenshots/wrong_pin/03b_lockout_alert
-- tapOn:
-    id: "alert.button.0"
-
-# The wipe continues behind the full-screen yellow cover + spinner. If there
-# was an open Lightning channel it can't complete immediately: a cooperative
-# close is broadcast and the "still closing" alert (stillclosing) appears with
-# a single "Try again" button (alert.button.0). The cover/spinner animate for
-# the whole sync, so wait for the screen to settle into whichever state comes
-# next — that alert, or Signup1 (when there was no channel to close, in which
-# case no second alert appears and the loop below runs zero times).
-- waitForAnimationToEnd:
-    timeout: 120000
-
-# While the "still closing" alert keeps reappearing, mine 6 blocks to confirm
-# the cooperative close on-chain (same count as the channel-open/close
-# confirmation elsewhere) and tap "Try again" (alert.button.0). That re-syncs
-# and re-checks whether the funds have settled enough to remove the wallet.
-# Each retry spins the cover again, so wait for it to settle before re-testing
-# the condition. Once the wipe completes the alert stops returning and we fall
-# through to Signup1.
-- repeat:
-    while:
-      visible:
-        id: "alert.button.0"
-    commands:
-      - takeScreenshot: shared/docs/screenshots/wrong_pin/03c_still_closing
-      - evalScript: ${output.blocksToMine = 6}
-      - runScript: ../scripts/mine_blocks.js
-      - tapOn:
-          id: "alert.button.0"
-      - waitForAnimationToEnd:
-          timeout: 120000
-
-# The wipe has completed: performWalletReset cleared state, stopped the node,
-# and relaunched signup on page 3 (Signup1). Allow generous slack for the
-# final sync + node teardown.
+# No channel to close: the wipe syncs behind the full-screen yellow cover +
+# spinner and goes straight to Signup1. No "still closing" alert appears (the
+# lockout alert is hidden in the same turn it's shown), so there's nothing to
+# tap — just wait out the sync + node teardown. performWalletReset cleared
+# state, stopped the node, and relaunched signup on page 3 (Signup1).
 - extendedWaitUntil:
     visible:
       id: "signup.create.start.createWalletButton"
     timeout: 120000
-- takeScreenshot: shared/docs/screenshots/wrong_pin/04_signup1
+- takeScreenshot: shared/docs/screenshots/wrong_pin/03_signup1

--- a/shared/flows/features/wrong_pin_with_channel.yaml
+++ b/shared/flows/features/wrong_pin_with_channel.yaml
@@ -1,0 +1,127 @@
+# Feature test: the PIN lockout path WITH an open Lightning channel. Entering
+# the wrong PIN ten times wipes the wallet — but because a channel is open, the
+# wipe must first cooperatively close it and wait for the funds to settle
+# on-chain before it can complete. This exercises the "still closing" + Try
+# again retry loop, then drops the user back on Signup1.
+#
+# Self-provisioning: the flow ensures the required state itself. It restores a
+# wallet if none exists, then checks for an open channel (via the Receive
+# screen's More button) and, if there is none, builds a bittr account (if
+# missing) and opens a channel via buy_signup + buy_incoming. If an open channel
+# already exists it is reused. The fail counter is at 0 after the unlock/setup.
+# See helpers/ensure_bittr_channel.yaml. (Detection is best-effort — see the
+# UNVERIFIED notes below and in that helper.)
+#
+# This flow is destructive: it removes the wallet. Run once against a wallet
+# in the required state.
+#
+# For the simpler no-channel case (immediate wipe), see wrong_pin.yaml. The ten
+# wrong-PIN attempts are shared via helpers/wrong_pin_until_lockout.yaml.
+#
+# Behaviour under test (PinViewController + ResetApp):
+#   - Entries 1..9 show the "incorrect PIN" alert; entry 10 runs removeWallet()
+#     -> removingWalletForIncorrectPin set -> background wipe.
+#   - restoreWalletTapped finds an open channel and (because this is the
+#     automated lockout wipe) cooperatively closes it via closeChannelConfirmed,
+#     then shows the "still closing" alert with a single "Try again" button
+#     wired to startWalletInBackground. We mine blocks + tap Try again until the
+#     funds have settled and channelsFullyClosedAndSwept() is true, at which
+#     point performWalletReset runs and relaunches Signup1.
+#
+# Run: maestro test shared/flows/features/wrong_pin_with_channel.yaml
+
+appId: com.bittr.bittr-regtest
+---
+- launchApp
+
+# --- Self-provision: ensure a wallet with an OPEN channel --------------------
+# 1) Ensure a wallet and reach Home. On launch an existing wallet shows the PIN
+#    unlock screen; if it's absent, restore one (restore_wallet ends on Home).
+#    If it's present, unlock to reach Home.
+- runFlow:
+    when:
+      notVisible:
+        id: "unlock.topLabel"
+    file: ../onboarding/restore_wallet.yaml
+- runFlow:
+    when:
+      visible:
+        id: "unlock.topLabel"
+    file: ../helpers/unlock.yaml
+- assertVisible:
+    id: "home.headerLabel"
+# Let the post-unlock wallet sync finish so channel state is accurate.
+- extendedWaitUntil:
+    notVisible:
+      id: "home.headerSpinner"
+    timeout: 120000
+
+# 2) Detect a channel via the Receive screen. ReceiveViewController only shows
+#    the "More" button when getActiveChannel() != nil (3 cards / no More without
+#    a channel; 4 cards / More with one), so receive.moreButton is the channel
+#    signal. Wait for the QR spinner to settle so the cards have rendered first.
+#    UNVERIFIED: confirm receive.moreButton is reliably present/absent on the
+#    default Receive view for the with/without-channel cases.
+- tapOn:
+    id: "home.receiveButton"
+- extendedWaitUntil:
+    notVisible:
+      id: "receive.qrSpinner"
+    timeout: 60000
+- takeScreenshot: shared/docs/screenshots/wrong_pin_with_channel/00_channel_check
+
+# 3) No "More" button => no channel => build a bittr account (if needed) and
+#    open a channel. Gated on the single check above, evaluated here while we're
+#    on the Receive screen (so the condition is meaningful).
+- runFlow:
+    when:
+      notVisible:
+        id: "receive.moreButton"
+    file: ../helpers/ensure_bittr_channel.yaml
+
+# 4) Relaunch to return to the locked unlock screen. We may be on Receive (a
+#    channel already existed) or on Home (we just built one) — either way the
+#    relaunch lands on the unlock screen with the fail counter at 0.
+- launchApp
+- takeScreenshot: shared/docs/screenshots/wrong_pin_with_channel/01_unlock
+
+# Enter the wrong PIN ten times -> lockout + background wipe begins.
+- runFlow:
+    file: ../helpers/wrong_pin_until_lockout.yaml
+- takeScreenshot: shared/docs/screenshots/wrong_pin_with_channel/02_wipe_started
+
+# A channel is open, so the wipe can't finish immediately: after the background
+# sync, a cooperative close is broadcast and the "still closing" alert
+# (stillclosing) appears with a single "Try again" button (alert.button.0).
+# The cover/spinner animate during the sync, so wait for the screen to settle
+# into that alert (or, if there turned out to be nothing to close, into Signup1
+# — in which case the loop below runs zero times).
+- waitForAnimationToEnd:
+    timeout: 120000
+
+# While the "still closing" alert keeps reappearing, mine 6 blocks to confirm
+# the cooperative close on-chain (same count used for channel-open/close
+# confirmation elsewhere) and tap "Try again" (alert.button.0). That re-syncs
+# and re-checks whether the funds have settled enough to remove the wallet.
+# Each retry spins the cover again, so wait for it to settle before re-testing
+# the condition. Once the wipe completes the alert stops returning.
+- repeat:
+    while:
+      visible:
+        id: "alert.button.0"
+    commands:
+      - takeScreenshot: shared/docs/screenshots/wrong_pin_with_channel/03_still_closing
+      - evalScript: ${output.blocksToMine = 6}
+      - runScript: ../scripts/mine_blocks.js
+      - tapOn:
+          id: "alert.button.0"
+      - waitForAnimationToEnd:
+          timeout: 120000
+
+# The wipe has completed: performWalletReset cleared state, stopped the node,
+# and relaunched signup on page 3 (Signup1).
+- extendedWaitUntil:
+    visible:
+      id: "signup.create.start.createWalletButton"
+    timeout: 120000
+- takeScreenshot: shared/docs/screenshots/wrong_pin_with_channel/04_signup1

--- a/shared/flows/helpers/ensure_bittr_channel.yaml
+++ b/shared/flows/helpers/ensure_bittr_channel.yaml
@@ -1,0 +1,51 @@
+# Reusable subflow: ensures the wallet has an OPEN Lightning channel, building
+# whatever is missing. Invoked by wrong_pin_with_channel.yaml ONLY when no
+# channel was detected. Assumes a wallet already exists.
+#
+# Steps:
+#   1. Unlock (if locked) and open Buy.
+#   2. If the Buy card shows no deposit code, there's no bittr account yet, so
+#      run buy_signup to create one.
+#   3. Run buy_incoming to open + confirm the channel.
+# buy_signup and buy_incoming each relaunch + unlock themselves, so this flow
+# doesn't manage navigation between them. Ends on Home with an open channel.
+#
+# UNVERIFIED: this flow has not been executed against Maestro. Two assumptions
+# to confirm on a first real run:
+#   - The "no deposit code => run buy_signup" gate waits for the Buy update
+#     spinner to settle first (waitForAnimationToEnd) so an existing card has
+#     rendered before we test buy.yourCode; tune the wait if it races.
+#   - buy_incoming is one-shot (fails if a channel already exists); it only runs
+#     here because the caller already confirmed there is no channel.
+
+appId: com.bittr.bittr-regtest
+---
+- launchApp
+- runFlow:
+    when:
+      visible:
+        id: "unlock.topLabel"
+    file: unlock.yaml
+- assertVisible:
+    id: "home.headerLabel"
+
+# Open Buy and let getDepositCodeData (updateDataSpinner) settle so an existing
+# bittr account's card has rendered before we test for it.
+- tapOn:
+    id: "home.buyButton"
+- assertVisible:
+    id: "buy.headerLabel"
+- waitForAnimationToEnd:
+    timeout: 30000
+
+# No deposit code on the Buy card => no bittr account yet => sign up first.
+- runFlow:
+    when:
+      notVisible:
+        id: "buy.yourCode"
+    file: ../features/buy_signup.yaml
+
+# Open the incoming channel (buy_incoming relaunches + unlocks itself, triggers
+# the bank transaction and mines blocks until the channel confirms).
+- runFlow:
+    file: ../features/buy_incoming.yaml

--- a/shared/flows/helpers/wrong_pin_until_lockout.yaml
+++ b/shared/flows/helpers/wrong_pin_until_lockout.yaml
@@ -1,0 +1,90 @@
+# Reusable subflow: enters the wrong PIN ten times on the unlock screen to
+# trigger the lockout and start the wallet wipe. Assumes the unlock screen is
+# visible (PinViewController in its .core embedding) with the failed-attempt
+# counter at 0. Wrong PIN is 1111 (the correct PIN is 1234, set by the
+# onboarding flows).
+#
+# Attempts 1..9 each show the "incorrect PIN" alert (incorrectpin /
+# incorrectpin2) with a single Okay button (alert.button.0), which this flow
+# taps to clear the field. The 10th confirm triggers removeWallet():
+# removingWalletForIncorrectPin is set and the background wipe begins.
+#
+# This subflow STOPS at the 10th confirm. It deliberately does NOT tap the
+# lockout alert: removeWallet() shows it and then synchronously calls
+# restoreWalletTapped() -> startWalletInBackground(), whose first line is
+# hideAlert(), so the lockout alert is hidden in the same main-thread turn and
+# never reliably renders. What happens next depends on whether a Lightning
+# channel has to be cooperatively closed first, so the caller handles it:
+#   - wrong_pin.yaml              — no channel, the wipe lands on Signup1.
+#   - wrong_pin_with_channel.yaml — channel close + "Try again" retry loop.
+#
+# The digit taps use waitToSettleTimeoutMs: 0 to skip Maestro's per-tap settle
+# wait (the PIN buttons only flash a background and toggle a dot), the main
+# speed-up across the 40+ taps in this flow.
+
+appId: com.bittr.bittr-regtest
+---
+- assertVisible:
+    id: "unlock.topLabel"
+
+# Wrong PIN attempt 1 of 10.
+- tapOn:
+    id: "pin.button1"
+    waitToSettleTimeoutMs: 0
+- tapOn:
+    id: "pin.button1"
+    waitToSettleTimeoutMs: 0
+- tapOn:
+    id: "pin.button1"
+    waitToSettleTimeoutMs: 0
+- tapOn:
+    id: "pin.button1"
+    waitToSettleTimeoutMs: 0
+- tapOn:
+    id: "pin.confirmButton"
+- assertVisible:
+    id: "alert.button.0"
+- tapOn:
+    id: "alert.button.0"
+
+# Wrong PIN attempts 2..9 (8 more "incorrect PIN" alerts). After the 9th the
+# failed-attempt counter sits at 9.
+- repeat:
+    times: 8
+    commands:
+      - tapOn:
+          id: "pin.button1"
+          waitToSettleTimeoutMs: 0
+      - tapOn:
+          id: "pin.button1"
+          waitToSettleTimeoutMs: 0
+      - tapOn:
+          id: "pin.button1"
+          waitToSettleTimeoutMs: 0
+      - tapOn:
+          id: "pin.button1"
+          waitToSettleTimeoutMs: 0
+      - tapOn:
+          id: "pin.confirmButton"
+      - assertVisible:
+          id: "alert.button.0"
+      - tapOn:
+          id: "alert.button.0"
+
+# Wrong PIN attempt 10. The counter increments to 10, so this triggers the
+# lockout + background wipe instead of the "incorrect PIN" alert. No Okay tap
+# here (see the header — the lockout alert never reliably renders).
+- tapOn:
+    id: "pin.button1"
+    waitToSettleTimeoutMs: 0
+- tapOn:
+    id: "pin.button1"
+    waitToSettleTimeoutMs: 0
+- tapOn:
+    id: "pin.button1"
+    waitToSettleTimeoutMs: 0
+- tapOn:
+    id: "pin.button1"
+    waitToSettleTimeoutMs: 0
+- tapOn:
+    id: "pin.confirmButton"


### PR DESCRIPTION
With our recent changes to wallet removal, for a locked out user (after 10 incorrect pin attempts), it may take significant time before their wallet can be successfully removed from the device. The following changes are in support of that.

- I've fixed an issue where, after 10 incorrect pin attempts, a successful 11th attempt would still reinstate the user's access to their wallet. So users are now definitively locked out.
- Upon app launch, the app checks immediately whether the user has been locked out.
- For locked out users, the PinViewController fades out, alerts the user, and retries removing the wallet. 
- As long as the wallet cannot be removed, the only thing the locked out user can do, is tap "Try again" to retry removing the wallet.
- Include these changes in the wrong_pin.yaml test.
- Reset pinCollectionView after each incorrect pin attempt to empty the visual text field.
- When a channel has been closed as a result of incorrect pin, do not show the QuestionViewController with the ldkEventReceived notification.