### PR TITLE
Add lightning/onchain payout-mode toggle on the Buy screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ maestro test shared/flows/features/send_onchain.yaml
 maestro test shared/flows/features/send_onchain_all.yaml
 maestro test shared/flows/features/swap.yaml
 
+# Payout-mode toggle (lightning <-> onchain) on the Buy card. Self-provisioning
+# (restores a wallet + creates an order if needed), so it can run on its own:
+maestro test shared/flows/features/payment_mode.yaml
+
 # Lightning send (normal + zero-amount invoice + Lightning Address). All three
 # targets are server-side now (invoices via the e2e endpoint / request_invoice.js,
 # address = fixed e2e e2ebittr@staging.getbittr.com), so no --env is needed.

--- a/ios/bittr/Base.lproj/Main.storyboard
+++ b/ios/bittr/Base.lproj/Main.storyboard
@@ -1917,10 +1917,10 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <collectionView multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" contentInsetAdjustmentBehavior="never" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="hTZ-oO-qDM" userLabel="Iban Collection View">
-                                                        <rect key="frame" x="0.0" y="78" width="393" height="285"/>
+                                                        <rect key="frame" x="0.0" y="78" width="393" height="340"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="height" constant="285" id="NHM-6V-QQk"/>
+                                                            <constraint firstAttribute="height" constant="340" id="NHM-6V-QQk"/>
                                                         </constraints>
                                                         <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" automaticEstimatedItemSize="YES" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="pm6-lU-avI">
                                                             <size key="itemSize" width="0.0" height="230"/>
@@ -1930,7 +1930,7 @@
                                                         </collectionViewFlowLayout>
                                                         <cells>
                                                             <collectionViewCell opaque="NO" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="IbanCell" id="Rli-T9-zqC" customClass="IbanCollectionViewCell" customModule="bittr" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="0.0" width="0.0" height="285"/>
+                                                                <rect key="frame" x="0.0" y="27.666666666666668" width="0.0" height="285"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                 <collectionViewCellContentView key="contentView" opaque="NO" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="Ayn-gO-bkP">
                                                                     <rect key="frame" x="0.0" y="0.0" width="0.0" height="285"/>
@@ -2175,23 +2175,94 @@
                                                                                         <constraint firstItem="oTw-ex-XaH" firstAttribute="trailing" secondItem="byT-e7-soa" secondAttribute="trailing" constant="-15" id="z8L-UE-CT0"/>
                                                                                     </constraints>
                                                                                 </view>
+                                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JcC-dV-dcC">
+                                                                                    <rect key="frame" x="10" y="120" width="320" height="45"/>
+                                                                                    <subviews>
+                                                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bolt.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="61u-PV-ad0">
+                                                                                            <rect key="frame" x="153" y="14.333333333333371" width="14" height="15"/>
+                                                                                            <color key="tintColor" red="0.96470588239999999" green="0.78039215689999997" blue="0.2666666667" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                                                            <constraints>
+                                                                                                <constraint firstAttribute="height" constant="14" id="ENh-aA-67t"/>
+                                                                                                <constraint firstAttribute="width" constant="14" id="ZYG-PN-9wX"/>
+                                                                                            </constraints>
+                                                                                        </imageView>
+                                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Your IBAN" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QBX-GJ-uO5">
+                                                                                            <rect key="frame" x="15" y="15.666666666666671" width="80" height="16"/>
+                                                                                            <constraints>
+                                                                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" id="Tf9-Tj-oL6"/>
+                                                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" id="xgG-ux-Q0W"/>
+                                                                                            </constraints>
+                                                                                            <fontDescription key="fontDescription" name="Gilroy-Bold" family="Gilroy-Bold" pointSize="16"/>
+                                                                                            <color key="textColor" red="0.96470588239999999" green="0.78039215689999997" blue="0.2666666667" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                                                            <nil key="highlightedColor"/>
+                                                                                        </label>
+                                                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="questionmark.circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="hG8-Ky-q4K">
+                                                                                            <rect key="frame" x="152" y="14.333333333333371" width="16" height="14.666666666666629"/>
+                                                                                            <color key="tintColor" red="0.96470588239999999" green="0.78039215689999997" blue="0.2666666667" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                                                            <constraints>
+                                                                                                <constraint firstAttribute="width" constant="16" id="Mwn-YC-ShG"/>
+                                                                                                <constraint firstAttribute="height" constant="16" id="aPZ-L5-IQS"/>
+                                                                                            </constraints>
+                                                                                        </imageView>
+                                                                                        <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8qC-up-TSN">
+                                                                                            <rect key="frame" x="122" y="4.3333333333333712" width="75" height="35"/>
+                                                                                            <state key="normal" title="Button"/>
+                                                                                            <buttonConfiguration key="configuration" style="plain"/>
+                                                                                            <connections>
+                                                                                                <action selector="paymentModeQuestionTapped:" destination="73z-sj-uDN" eventType="touchUpInside" id="o5T-wJ-uzN"/>
+                                                                                            </connections>
+                                                                                        </button>
+                                                                                        <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" hidesWhenStopped="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="osA-an-rU1">
+                                                                                            <rect key="frame" x="150" y="12.333333333333371" width="20" height="20"/>
+                                                                                        </activityIndicatorView>
+                                                                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="292-FG-mpq">
+                                                                                            <rect key="frame" x="129" y="8.3333333333333712" width="61" height="28"/>
+                                                                                            <connections>
+                                                                                                <action selector="didChangePaymentModeSwitch:" destination="Rli-T9-zqC" eventType="valueChanged" id="9oD-1D-14E"/>
+                                                                                            </connections>
+                                                                                        </switch>
+                                                                                    </subviews>
+                                                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                                    <constraints>
+                                                                                        <constraint firstItem="8qC-up-TSN" firstAttribute="trailing" secondItem="hG8-Ky-q4K" secondAttribute="trailing" constant="15" id="6Xy-eQ-0dg"/>
+                                                                                        <constraint firstAttribute="height" constant="45" id="7nZ-g0-cfM"/>
+                                                                                        <constraint firstAttribute="trailing" secondItem="292-FG-mpq" secondAttribute="trailing" constant="15" id="FAt-CI-h7E"/>
+                                                                                        <constraint firstItem="osA-an-rU1" firstAttribute="centerY" secondItem="JcC-dV-dcC" secondAttribute="centerY" id="HUM-ZE-FdR"/>
+                                                                                        <constraint firstItem="QBX-GJ-uO5" firstAttribute="leading" secondItem="61u-PV-ad0" secondAttribute="trailing" constant="5" id="IS2-jY-Vme"/>
+                                                                                        <constraint firstItem="292-FG-mpq" firstAttribute="centerY" secondItem="JcC-dV-dcC" secondAttribute="centerY" id="KzJ-WD-htE"/>
+                                                                                        <constraint firstItem="8qC-up-TSN" firstAttribute="top" secondItem="JcC-dV-dcC" secondAttribute="top" id="Zv2-ty-2e7"/>
+                                                                                        <constraint firstItem="8qC-up-TSN" firstAttribute="leading" secondItem="JcC-dV-dcC" secondAttribute="leading" id="c2d-Un-Bf1"/>
+                                                                                        <constraint firstItem="hG8-Ky-q4K" firstAttribute="leading" secondItem="QBX-GJ-uO5" secondAttribute="trailing" constant="7" id="efa-Ox-UkX"/>
+                                                                                        <constraint firstItem="QBX-GJ-uO5" firstAttribute="centerY" secondItem="JcC-dV-dcC" secondAttribute="centerY" constant="1" id="gep-C0-f1b"/>
+                                                                                        <constraint firstItem="hG8-Ky-q4K" firstAttribute="centerY" secondItem="QBX-GJ-uO5" secondAttribute="centerY" constant="-1" id="h0p-qa-2KS"/>
+                                                                                        <constraint firstItem="61u-PV-ad0" firstAttribute="leading" secondItem="JcC-dV-dcC" secondAttribute="leading" constant="15" id="jKX-H7-h36"/>
+                                                                                        <constraint firstItem="osA-an-rU1" firstAttribute="trailing" secondItem="292-FG-mpq" secondAttribute="leading" constant="-7" id="jjs-b9-63p"/>
+                                                                                        <constraint firstAttribute="bottom" secondItem="8qC-up-TSN" secondAttribute="bottom" id="xn2-x8-3Qx"/>
+                                                                                        <constraint firstItem="61u-PV-ad0" firstAttribute="centerY" secondItem="JcC-dV-dcC" secondAttribute="centerY" id="zfR-o1-5eM"/>
+                                                                                    </constraints>
+                                                                                </view>
                                                                             </subviews>
                                                                             <color key="backgroundColor" red="0.96470588239999999" green="0.78039215689999997" blue="0.2666666667" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                                             <constraints>
+                                                                                <constraint firstAttribute="trailing" secondItem="JcC-dV-dcC" secondAttribute="trailing" constant="10" id="2wX-Vu-iYq"/>
                                                                                 <constraint firstItem="ZYH-uF-oeJ" firstAttribute="leading" secondItem="z96-S7-cwO" secondAttribute="leading" constant="10" id="I4H-Wl-WLc"/>
                                                                                 <constraint firstItem="aJq-w3-xHl" firstAttribute="top" secondItem="s2J-km-9qr" secondAttribute="bottom" constant="10" id="IJC-dA-Cxe"/>
                                                                                 <constraint firstItem="P98-KT-ymT" firstAttribute="leading" secondItem="z96-S7-cwO" secondAttribute="leading" constant="10" id="Mq4-tU-jyr"/>
                                                                                 <constraint firstAttribute="width" constant="340" id="PoA-MK-msH"/>
                                                                                 <constraint firstItem="aJq-w3-xHl" firstAttribute="trailing" secondItem="z96-S7-cwO" secondAttribute="trailing" constant="-10" id="XAq-GD-L33"/>
                                                                                 <constraint firstItem="P98-KT-ymT" firstAttribute="top" secondItem="aJq-w3-xHl" secondAttribute="bottom" constant="10" id="bFe-Vt-iMu"/>
+                                                                                <constraint firstAttribute="bottom" secondItem="JcC-dV-dcC" secondAttribute="bottom" constant="10" id="bMM-Gw-LVa"/>
                                                                                 <constraint firstItem="byT-e7-soa" firstAttribute="leading" secondItem="z96-S7-cwO" secondAttribute="leading" constant="10" id="bYR-fl-fpb"/>
+                                                                                <constraint firstItem="JcC-dV-dcC" firstAttribute="leading" secondItem="z96-S7-cwO" secondAttribute="leading" constant="10" id="ecw-k8-qI6"/>
                                                                                 <constraint firstItem="s2J-km-9qr" firstAttribute="trailing" secondItem="z96-S7-cwO" secondAttribute="trailing" constant="-10" id="gVg-b3-8z8"/>
                                                                                 <constraint firstItem="aJq-w3-xHl" firstAttribute="leading" secondItem="z96-S7-cwO" secondAttribute="leading" constant="10" id="iuz-fU-sGa"/>
                                                                                 <constraint firstItem="P98-KT-ymT" firstAttribute="trailing" secondItem="z96-S7-cwO" secondAttribute="trailing" constant="-10" id="kGf-gs-UPe"/>
                                                                                 <constraint firstItem="s2J-km-9qr" firstAttribute="leading" secondItem="z96-S7-cwO" secondAttribute="leading" constant="10" id="l60-Pj-LPy"/>
                                                                                 <constraint firstItem="s2J-km-9qr" firstAttribute="top" secondItem="z96-S7-cwO" secondAttribute="top" constant="10" id="mBh-3V-T0q"/>
+                                                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" id="qQ9-y5-9Hh"/>
                                                                                 <constraint firstItem="ZYH-uF-oeJ" firstAttribute="trailing" secondItem="z96-S7-cwO" secondAttribute="trailing" constant="-10" id="rVm-FS-DTh"/>
                                                                                 <constraint firstItem="byT-e7-soa" firstAttribute="top" secondItem="ZYH-uF-oeJ" secondAttribute="bottom" constant="10" id="vAh-g5-IiB"/>
+                                                                                <constraint firstItem="JcC-dV-dcC" firstAttribute="top" secondItem="byT-e7-soa" secondAttribute="bottom" constant="10" id="wGH-o8-9kd"/>
                                                                                 <constraint firstItem="ZYH-uF-oeJ" firstAttribute="top" secondItem="P98-KT-ymT" secondAttribute="bottom" constant="10" id="yLb-gY-bOf"/>
                                                                                 <constraint firstItem="byT-e7-soa" firstAttribute="trailing" secondItem="z96-S7-cwO" secondAttribute="trailing" constant="-10" id="zhc-IG-IG0"/>
                                                                             </constraints>
@@ -2200,9 +2271,7 @@
                                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                     <constraints>
                                                                         <constraint firstItem="z96-S7-cwO" firstAttribute="top" secondItem="Ayn-gO-bkP" secondAttribute="top" id="3ey-0m-CqI"/>
-                                                                        <constraint firstItem="z96-S7-cwO" firstAttribute="trailing" secondItem="Ayn-gO-bkP" secondAttribute="trailing" id="Ick-ft-M6B"/>
-                                                                        <constraint firstItem="z96-S7-cwO" firstAttribute="leading" secondItem="Ayn-gO-bkP" secondAttribute="leading" id="JTH-Wo-niI"/>
-                                                                        <constraint firstItem="z96-S7-cwO" firstAttribute="bottom" secondItem="Ayn-gO-bkP" secondAttribute="bottom" id="ngG-dT-gIE"/>
+                                                                        <constraint firstItem="z96-S7-cwO" firstAttribute="centerX" secondItem="Ayn-gO-bkP" secondAttribute="centerX" id="xBy-Vt-vXO"/>
                                                                     </constraints>
                                                                 </collectionViewCellContentView>
                                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -2225,8 +2294,13 @@
                                                                     <outlet property="labelYourIban" destination="qfL-du-jmJ" id="Xhf-T9-Cky"/>
                                                                     <outlet property="nameButton" destination="xTD-Zh-UQp" id="9EH-va-mQV"/>
                                                                     <outlet property="nameView" destination="ZYH-uF-oeJ" id="6Nm-Aw-4Zd"/>
+                                                                    <outlet property="paymentModeButton" destination="8qC-up-TSN" id="K67-P0-ZF9"/>
+                                                                    <outlet property="paymentModeSpinner" destination="osA-an-rU1" id="iSM-An-fK0"/>
+                                                                    <outlet property="paymentModeSwitch" destination="292-FG-mpq" id="iSp-04-kmF"/>
+                                                                    <outlet property="paymentModeView" destination="JcC-dV-dcC" id="RrN-sd-QcI"/>
                                                                     <outlet property="titleOurIBAN" destination="rxf-2I-k7i" id="w0t-rm-hq6"/>
                                                                     <outlet property="titleOurName" destination="yV6-g6-Tb6" id="uQ1-Bt-BNh"/>
+                                                                    <outlet property="titlePaymentMode" destination="QBX-GJ-uO5" id="597-C8-OA1"/>
                                                                     <outlet property="titleYourCode" destination="RtL-nK-Qei" id="esl-49-vbM"/>
                                                                     <outlet property="titleYourEmail" destination="8HA-fi-IoU" id="VPR-vY-bB7"/>
                                                                     <outlet property="titleYourIBAN" destination="aOe-XW-GhA" id="TDL-m5-c8x"/>
@@ -4789,7 +4863,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="questionmark.circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="KOs-4g-DFg">
-                                                                <rect key="frame" x="292" y="15.666666666666666" width="16" height="14.66666666666667"/>
+                                                                <rect key="frame" x="292" y="15.666666666666664" width="16" height="14.666666666666671"/>
                                                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="16" id="Pn8-yh-hap"/>
@@ -5318,7 +5392,7 @@
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="questionmark.circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="dq2-SL-iU3">
-                                                                        <rect key="frame" x="81" y="15.666666666666664" width="16" height="14.666666666666671"/>
+                                                                        <rect key="frame" x="81" y="15.666666666666666" width="16" height="14.66666666666667"/>
                                                                         <color key="tintColor" red="0.96470588239999999" green="0.78039215689999997" blue="0.2666666667" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" constant="16" id="Ngv-Nw-Gml"/>
@@ -7860,7 +7934,7 @@
                                                     <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iuD-4J-AMA">
                                                         <rect key="frame" x="0.0" y="275" width="393" height="0.0"/>
                                                         <subviews>
-                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dWW-5N-9eX">
+                                                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dWW-5N-9eX">
                                                                 <rect key="frame" x="15" y="20" width="363" height="103"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Reminder" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W7o-EV-oGF">
@@ -8466,11 +8540,11 @@
                                                                 <collectionViewCell opaque="NO" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="LessonCell" id="bJT-XL-71f" customClass="LessonCollectionViewCell" customModule="bittr" customModuleProvider="target">
                                                                     <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                                    <collectionViewCellContentView key="contentView" opaque="NO" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="J7n-2u-shf">
+                                                                    <collectionViewCellContentView key="contentView" opaque="NO" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="J7n-2u-shf">
                                                                         <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                         <subviews>
-                                                                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="p4g-Q8-wrQ">
+                                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p4g-Q8-wrQ">
                                                                                 <rect key="frame" x="34" y="0.0" width="60" height="60"/>
                                                                                 <subviews>
                                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="QOD-e6-nHB">
@@ -8488,24 +8562,24 @@
                                                                                     <constraint firstAttribute="width" constant="60" id="nD7-cD-BaX"/>
                                                                                 </constraints>
                                                                             </view>
-                                                                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="iconcheck" translatesAutoresizingMaskIntoConstraints="NO" id="WRW-oV-d1f">
+                                                                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconcheck" translatesAutoresizingMaskIntoConstraints="NO" id="WRW-oV-d1f">
                                                                                 <rect key="frame" x="55" y="49" width="18" height="18"/>
                                                                                 <constraints>
                                                                                     <constraint firstAttribute="width" constant="18" id="HPV-z8-UXk"/>
                                                                                     <constraint firstAttribute="height" constant="18" id="bDj-Wj-Cbl"/>
                                                                                 </constraints>
                                                                             </imageView>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rkN-45-mAZ">
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rkN-45-mAZ">
                                                                                 <rect key="frame" x="0.0" y="73" width="128" height="55"/>
                                                                                 <fontDescription key="fontDescription" name="Gilroy-Bold" family="Gilroy-Bold" pointSize="15"/>
                                                                                 <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
-                                                                            <view alpha="0.0" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="arb-yg-aZ4">
+                                                                            <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="arb-yg-aZ4">
                                                                                 <rect key="frame" x="-2.6666666666666714" y="-10" width="133.33333333333337" height="148"/>
                                                                                 <color key="backgroundColor" red="0.89803921568627454" green="0.74117647058823533" blue="0.30980392156862746" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="displayP3"/>
                                                                             </view>
-                                                                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FyW-61-BPb">
+                                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FyW-61-BPb">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                                                 <state key="normal" title="Button"/>
                                                                                 <buttonConfiguration key="configuration" style="plain"/>
@@ -13808,7 +13882,7 @@
     <inferredMetricsTieBreakers>
         <segue reference="Owf-uB-9LO"/>
         <segue reference="RLJ-7Z-6Ld"/>
-        <segue reference="5NJ-vU-Ume"/>
+        <segue reference="ZiD-Cf-wZ5"/>
         <segue reference="7F8-Pl-5uy"/>
         <segue reference="ahR-EC-NqA"/>
         <segue reference="hX6-RE-pvS"/>
@@ -13880,10 +13954,10 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGreenColor">
-            <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemRedColor">
-            <color red="1" green="0.2196078431372549" blue="0.23529411764705882" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.21960784310000001" blue="0.23529411759999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/ios/bittr/Buy/BuyViewController.swift
+++ b/ios/bittr/Buy/BuyViewController.swift
@@ -113,7 +113,11 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
             cell.nameButton.boundString = thisIbanEntity.ourName
             cell.codeButton.boundString = thisIbanEntity.yourUniqueCode
             
+            // Reset the toggle to a settled, server-confirmed state. Re-enabling
+            // here is what clears the in-flight lock set in didChangePaymentModeSwitch
+            // (so a reload after success/failure makes the switch interactive again).
             cell.paymentModeSpinner.stopAnimating()
+            cell.paymentModeSwitch.isEnabled = true
             if thisIbanEntity.paymentMode != "onchain" {
                 cell.paymentModeSwitch.isOn = true
             } else {
@@ -240,6 +244,7 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
             // Entities received in expected format.
             var someDetailsHaveChanged = false
             var paymentModeChanged = false
+            var changedPaymentModeIndexPaths = [IndexPath]()
 
             guard
                 let depositCode = receivedEntity["deposit_code"] as? String,
@@ -279,6 +284,7 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
                     // Payout mode is tracked independently of the IBAN/SWIFT details above.
                     if let paymentMode = paymentMode, paymentMode != eachExistingEntity.paymentMode {
                         paymentModeChanged = true
+                        changedPaymentModeIndexPaths.append(IndexPath(item: index, section: 0))
                         self.allIbanEntities[index].paymentMode = paymentMode
                         for (walletIndex, eachWalletEntity) in self.coreVC!.bittrWallet.ibanEntities.enumerated() {
                             if eachWalletEntity.yourUniqueCode == depositCode {
@@ -296,8 +302,8 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
                 self.showAlert(presentingController: self, title: Language.getWord(withID: "buyvcupdatedetails"), message: Language.getWord(withID: "buyvcupdatedetails2"), buttons: [Language.getWord(withID: "okay")], actions: nil)
             } else if paymentModeChanged {
                 // Only the payout mode changed (e.g. toggled on another device) — refresh
-                // the toggle silently, no "details updated" alert.
-                self.ibanCollectionView.reloadData()
+                // just the affected card(s) silently, no "details updated" alert.
+                self.ibanCollectionView.reloadItems(at: changedPaymentModeIndexPaths)
             }
         } else {
             // Data received in wrong format.
@@ -315,7 +321,7 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
         // The lightning node must be running to sign the request.
         guard BitcoinManager.shared.ldkNode != nil, let pubkey = BitcoinManager.shared.nodeId() else {
             Log.info("Lightning not ready for payment mode update.")
-            self.ibanCollectionView.reloadData() // revert the optimistic toggle
+            self.reloadCard(for: entity) // revert the optimistic toggle
             self.showAlert(presentingController: self, title: Language.getWord(withID: "lightningnotready"), message: Language.getWord(withID: "syncingwallet2"), buttons: [Language.getWord(withID: "okay")], actions: nil)
             return
         }
@@ -324,16 +330,16 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
         let timestamp = Int(Date().timeIntervalSince1970)
         let message = "payment_mode:\(pubkey):\(depositCode):\(newMode):\(timestamp)"
 
-        self.updateDataSpinner.startAnimating()
-
+        // The per-card spinner next to the switch (started in the cell's
+        // didChangePaymentModeSwitch) is the only progress indicator; it's
+        // cleared when the card reloads with the server-confirmed value.
         Task {
             let signature: String
             do {
                 signature = try await BitcoinManager.shared.signMessage(message: message)
             } catch {
                 DispatchQueue.main.async {
-                    self.updateDataSpinner.stopAnimating()
-                    self.handlePaymentModeError(error.localizedDescription)
+                    self.handlePaymentModeError(error.localizedDescription, for: entity)
                 }
                 return
             }
@@ -350,7 +356,6 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
             Log.info("Will make payment mode update API call.")
             await CallsManager.makeApiCall(url: url, parameters: parameters, getOrPost: .patch) { result in
                 DispatchQueue.main.async {
-                    self.updateDataSpinner.stopAnimating()
 
                     switch result {
                     case .success(let receivedDictionary):
@@ -377,10 +382,10 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
                                 self.setPaymentMode(for: entity, newMode: newMode, isRetry: true)
                                 return
                             }
-                            self.handlePaymentModeError(serverError)
+                            self.handlePaymentModeError(serverError, for: entity)
                         }
                     case .failure(let error):
-                        self.handlePaymentModeError(error.localizedDescription)
+                        self.handlePaymentModeError(error.localizedDescription, for: entity)
                     }
                 }
             }
@@ -399,14 +404,24 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
             }
         }
         CacheManager.setPaymentMode(ibanID: entity.id, paymentMode: mode)
-        self.ibanCollectionView.reloadData()
+        self.reloadCard(for: entity)
     }
 
-    private func handlePaymentModeError(_ message: String) {
+    private func handlePaymentModeError(_ message: String, for entity: IbanEntity) {
         Log.info("Will handle payment mode error.")
         // Revert the optimistic toggle to the last server-confirmed value.
-        self.ibanCollectionView.reloadData()
+        self.reloadCard(for: entity)
         self.showAlert(presentingController: self, title: Language.getWord(withID: "paymentmodeupdateerror"), message: message, buttons: [Language.getWord(withID: "okay")], actions: nil)
+    }
+
+    /// Reload just the card for this deposit code (keeps the other cards + the
+    /// horizontal scroll position; falls back to a full reload if not found).
+    private func reloadCard(for entity: IbanEntity) {
+        if let index = self.allIbanEntities.firstIndex(where: { $0.yourUniqueCode == entity.yourUniqueCode }) {
+            self.ibanCollectionView.reloadItems(at: [IndexPath(item: index, section: 0)])
+        } else {
+            self.ibanCollectionView.reloadData()
+        }
     }
     
     @IBAction func paymentModeQuestionTapped(_ sender: UIButton) {

--- a/ios/bittr/Buy/BuyViewController.swift
+++ b/ios/bittr/Buy/BuyViewController.swift
@@ -109,13 +109,6 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
             cell.nameButton.boundString = self.allIbanEntities[indexPath.row].ourName
             cell.codeButton.boundString = self.allIbanEntities[indexPath.row].yourUniqueCode
 
-            // Payout-mode toggle for this deposit code.
-            let entity = self.allIbanEntities[indexPath.row]
-            cell.configurePaymentMode(entity.paymentMode)
-            cell.onPaymentModeChange = { [weak self] newMode in
-                self?.setPaymentMode(for: entity, newMode: newMode)
-            }
-
             return cell
         } else {
             return UICollectionViewCell()
@@ -151,9 +144,7 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
         
         let viewWidth = self.view.safeAreaLayoutGuide.layoutFrame.size.width
         let cellWidth = viewWidth - 30
-        // Height was 285; raised to fit the payout-mode toggle added below the
-        // deposit-code section. NOTE: verify the spacing visually in Xcode.
-        return CGSize(width: cellWidth, height: 365)
+        return CGSize(width: cellWidth, height: 285)
     }
     
     @IBAction func continueButtonTapped(_ sender: UIButton) {

--- a/ios/bittr/Buy/BuyViewController.swift
+++ b/ios/bittr/Buy/BuyViewController.swift
@@ -108,7 +108,14 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
             cell.ibanButton.boundString = self.allIbanEntities[indexPath.row].ourIbanNumber
             cell.nameButton.boundString = self.allIbanEntities[indexPath.row].ourName
             cell.codeButton.boundString = self.allIbanEntities[indexPath.row].yourUniqueCode
-            
+
+            // Payout-mode toggle for this deposit code.
+            let entity = self.allIbanEntities[indexPath.row]
+            cell.configurePaymentMode(entity.paymentMode)
+            cell.onPaymentModeChange = { [weak self] newMode in
+                self?.setPaymentMode(for: entity, newMode: newMode)
+            }
+
             return cell
         } else {
             return UICollectionViewCell()
@@ -144,7 +151,9 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
         
         let viewWidth = self.view.safeAreaLayoutGuide.layoutFrame.size.width
         let cellWidth = viewWidth - 30
-        return CGSize(width: cellWidth, height: 285)
+        // Height was 285; raised to fit the payout-mode toggle added below the
+        // deposit-code section. NOTE: verify the spacing visually in Xcode.
+        return CGSize(width: cellWidth, height: 365)
     }
     
     @IBAction func continueButtonTapped(_ sender: UIButton) {
@@ -228,7 +237,8 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
         if let receivedEntity = receivedDictionary["data"] as? NSDictionary {
             // Entities received in expected format.
             var someDetailsHaveChanged = false
-            
+            var paymentModeChanged = false
+
             guard
                 let depositCode = receivedEntity["deposit_code"] as? String,
                 let partnerIban = receivedEntity["iban"] as? String,
@@ -236,8 +246,9 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
             else {
                 return
             }
-            
+
             let lightningAddressUsername = receivedEntity["lightning_address_username"] as? String
+            let paymentMode = receivedEntity["payment_mode"] as? String
                 
             for (index, eachExistingEntity) in self.allIbanEntities.enumerated() {
                 if eachExistingEntity.yourUniqueCode == depositCode {
@@ -262,13 +273,29 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
                         // Update details in cache.
                         CacheManager.addBittrIban(ibanID: eachExistingEntity.id, ourIban: partnerIban, ourSwift: partnerSwift, yourCode: depositCode, lightningAddressUsername: lightningAddressUsername)
                     }
+
+                    // Payout mode is tracked independently of the IBAN/SWIFT details above.
+                    if let paymentMode = paymentMode, paymentMode != eachExistingEntity.paymentMode {
+                        paymentModeChanged = true
+                        self.allIbanEntities[index].paymentMode = paymentMode
+                        for (walletIndex, eachWalletEntity) in self.coreVC!.bittrWallet.ibanEntities.enumerated() {
+                            if eachWalletEntity.yourUniqueCode == depositCode {
+                                self.coreVC!.bittrWallet.ibanEntities[walletIndex].paymentMode = paymentMode
+                            }
+                        }
+                        CacheManager.setPaymentMode(ibanID: eachExistingEntity.id, paymentMode: paymentMode)
+                    }
                 }
             }
-            
+
             if someDetailsHaveChanged {
                 // Data has been updated.
                 self.parseIbanEntities(uponPageLaunch: false)
                 self.showAlert(presentingController: self, title: Language.getWord(withID: "buyvcupdatedetails"), message: Language.getWord(withID: "buyvcupdatedetails2"), buttons: [Language.getWord(withID: "okay")], actions: nil)
+            } else if paymentModeChanged {
+                // Only the payout mode changed (e.g. toggled on another device) — refresh
+                // the toggle silently, no "details updated" alert.
+                self.ibanCollectionView.reloadData()
             }
         } else {
             // Data received in wrong format.
@@ -279,8 +306,98 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
         }
     }
     
+    // MARK: - Payout mode (PATCH /customer/payment-mode)
+
+    func setPaymentMode(for entity: IbanEntity, newMode: String, isRetry: Bool = false) {
+
+        // The lightning node must be running to sign the request.
+        guard BitcoinManager.shared.ldkNode != nil, let pubkey = BitcoinManager.shared.nodeId() else {
+            self.ibanCollectionView.reloadData() // revert the optimistic toggle
+            // TODO: localize the title once the key is added to Language.swift.
+            self.showAlert(presentingController: self, title: "Lightning not ready", message: Language.getWord(withID: "syncingwallet2"), buttons: [Language.getWord(withID: "okay")], actions: nil)
+            return
+        }
+
+        let depositCode = entity.yourUniqueCode
+        let timestamp = Int(Date().timeIntervalSince1970)
+        let message = "payment_mode:\(pubkey):\(depositCode):\(newMode):\(timestamp)"
+
+        self.updateDataSpinner.startAnimating()
+
+        Task {
+            let signature: String
+            do {
+                signature = try await BitcoinManager.shared.signMessage(message: message)
+            } catch {
+                DispatchQueue.main.async {
+                    self.updateDataSpinner.stopAnimating()
+                    self.handlePaymentModeError(error.localizedDescription)
+                }
+                return
+            }
+
+            let url = "\(EnvironmentConfig.bittrAPIBaseURL)/customer/payment-mode"
+            let parameters: [String: Any] = [
+                "deposit_code": depositCode,
+                "payment_mode": newMode,
+                "pubkey": pubkey,
+                "signature": signature,
+                "timestamp": timestamp
+            ]
+
+            await CallsManager.makeApiCall(url: url, parameters: parameters, getOrPost: .patch) { result in
+                DispatchQueue.main.async {
+                    self.updateDataSpinner.stopAnimating()
+
+                    switch result {
+                    case .success(let receivedDictionary):
+                        // Success shape mirrors GET /deposit_code: { data: { payment_mode: ... } }
+                        if let data = receivedDictionary["data"] as? NSDictionary,
+                           let confirmedMode = data["payment_mode"] as? String {
+                            self.applyPaymentMode(confirmedMode, to: entity)
+                        } else {
+                            // Error envelope is { success: false, error: "..." }; some
+                            // signed endpoints use "message" instead, so check both.
+                            let serverError = (receivedDictionary["error"] as? String) ?? (receivedDictionary["message"] as? String) ?? "Unknown error"
+                            if serverError.lowercased().contains("expired timestamp"), !isRetry {
+                                // Stale timestamp — rebuild with a fresh one and retry once.
+                                self.setPaymentMode(for: entity, newMode: newMode, isRetry: true)
+                                return
+                            }
+                            self.handlePaymentModeError(serverError)
+                        }
+                    case .failure(let error):
+                        self.handlePaymentModeError(error.localizedDescription)
+                    }
+                }
+            }
+        }
+    }
+
+    private func applyPaymentMode(_ mode: String, to entity: IbanEntity) {
+
+        entity.paymentMode = mode
+        for (index, eachEntity) in self.allIbanEntities.enumerated() where eachEntity.yourUniqueCode == entity.yourUniqueCode {
+            self.allIbanEntities[index].paymentMode = mode
+        }
+        if let coreVC = self.coreVC {
+            for (index, eachEntity) in coreVC.bittrWallet.ibanEntities.enumerated() where eachEntity.yourUniqueCode == entity.yourUniqueCode {
+                coreVC.bittrWallet.ibanEntities[index].paymentMode = mode
+            }
+        }
+        CacheManager.setPaymentMode(ibanID: entity.id, paymentMode: mode)
+        self.ibanCollectionView.reloadData()
+    }
+
+    private func handlePaymentModeError(_ message: String) {
+        // Revert the optimistic toggle to the last server-confirmed value.
+        self.ibanCollectionView.reloadData()
+        // TODO: localize the title once the key is added to Language.swift.
+        self.showAlert(presentingController: self, title: "Couldn't update payout mode", message: message, buttons: [Language.getWord(withID: "okay")], actions: nil)
+    }
+
     func changeColors() {
-        
+
         self.view.backgroundColor = Colors.getColor("yelloworblue1")
         self.subtitleLabel.textColor = Colors.getColor("blackorwhite")
         self.emptyLabel.textColor = Colors.getColor("blackorwhite")

--- a/ios/bittr/Buy/BuyViewController.swift
+++ b/ios/bittr/Buy/BuyViewController.swift
@@ -99,15 +99,26 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
             
             cell.cardBackgroundViewWidth.constant = self.view.bounds.width - 30
             
-            cell.labelYourEmail.text = self.allIbanEntities[indexPath.row].yourEmail
-            cell.labelYourIban.text = self.allIbanEntities[indexPath.row].yourIbanNumber
-            cell.labelOurIban.text = self.allIbanEntities[indexPath.row].ourIbanNumber
-            cell.labelOurName.text = self.allIbanEntities[indexPath.row].ourName
-            cell.labelYourCode.text = self.allIbanEntities[indexPath.row].yourUniqueCode
+            let thisIbanEntity = self.allIbanEntities[indexPath.row]
+            cell.ibanEntity = thisIbanEntity
+            cell.buyVC = self
             
-            cell.ibanButton.boundString = self.allIbanEntities[indexPath.row].ourIbanNumber
-            cell.nameButton.boundString = self.allIbanEntities[indexPath.row].ourName
-            cell.codeButton.boundString = self.allIbanEntities[indexPath.row].yourUniqueCode
+            cell.labelYourEmail.text = thisIbanEntity.yourEmail
+            cell.labelYourIban.text = thisIbanEntity.yourIbanNumber
+            cell.labelOurIban.text = thisIbanEntity.ourIbanNumber
+            cell.labelOurName.text = thisIbanEntity.ourName
+            cell.labelYourCode.text = thisIbanEntity.yourUniqueCode
+            
+            cell.ibanButton.boundString = thisIbanEntity.ourIbanNumber
+            cell.nameButton.boundString = thisIbanEntity.ourName
+            cell.codeButton.boundString = thisIbanEntity.yourUniqueCode
+            
+            cell.paymentModeSpinner.stopAnimating()
+            if thisIbanEntity.paymentMode != "onchain" {
+                cell.paymentModeSwitch.isOn = true
+            } else {
+                cell.paymentModeSwitch.isOn = false
+            }
 
             return cell
         } else {
@@ -144,7 +155,7 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
         
         let viewWidth = self.view.safeAreaLayoutGuide.layoutFrame.size.width
         let cellWidth = viewWidth - 30
-        return CGSize(width: cellWidth, height: 285)
+        return CGSize(width: cellWidth, height: 340)
     }
     
     @IBAction func continueButtonTapped(_ sender: UIButton) {
@@ -303,9 +314,9 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
 
         // The lightning node must be running to sign the request.
         guard BitcoinManager.shared.ldkNode != nil, let pubkey = BitcoinManager.shared.nodeId() else {
+            Log.info("Lightning not ready for payment mode update.")
             self.ibanCollectionView.reloadData() // revert the optimistic toggle
-            // TODO: localize the title once the key is added to Language.swift.
-            self.showAlert(presentingController: self, title: "Lightning not ready", message: Language.getWord(withID: "syncingwallet2"), buttons: [Language.getWord(withID: "okay")], actions: nil)
+            self.showAlert(presentingController: self, title: Language.getWord(withID: "lightningnotready"), message: Language.getWord(withID: "syncingwallet2"), buttons: [Language.getWord(withID: "okay")], actions: nil)
             return
         }
 
@@ -336,6 +347,7 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
                 "timestamp": timestamp
             ]
 
+            Log.info("Will make payment mode update API call.")
             await CallsManager.makeApiCall(url: url, parameters: parameters, getOrPost: .patch) { result in
                 DispatchQueue.main.async {
                     self.updateDataSpinner.stopAnimating()
@@ -345,11 +357,21 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
                         // Success shape mirrors GET /deposit_code: { data: { payment_mode: ... } }
                         if let data = receivedDictionary["data"] as? NSDictionary,
                            let confirmedMode = data["payment_mode"] as? String {
+                            Log.info("Payment mode successfully updated.")
                             self.applyPaymentMode(confirmedMode, to: entity)
                         } else {
+                            Log.info("Did receive payment mode API server error.")
+                            
                             // Error envelope is { success: false, error: "..." }; some
                             // signed endpoints use "message" instead, so check both.
                             let serverError = (receivedDictionary["error"] as? String) ?? (receivedDictionary["message"] as? String) ?? "Unknown error"
+                            
+                            // Send to Sentry.
+                            SentrySDK.capture(message: "Error updating payment mode: \(serverError)") { scope in
+                                scope.setExtra(value: "BuyViewController row 367", key: "context")
+                            }
+                            
+                            // Retry.
                             if serverError.lowercased().contains("expired timestamp"), !isRetry {
                                 // Stale timestamp — rebuild with a fresh one and retry once.
                                 self.setPaymentMode(for: entity, newMode: newMode, isRetry: true)
@@ -381,12 +403,18 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
     }
 
     private func handlePaymentModeError(_ message: String) {
+        Log.info("Will handle payment mode error.")
         // Revert the optimistic toggle to the last server-confirmed value.
         self.ibanCollectionView.reloadData()
-        // TODO: localize the title once the key is added to Language.swift.
-        self.showAlert(presentingController: self, title: "Couldn't update payout mode", message: message, buttons: [Language.getWord(withID: "okay")], actions: nil)
+        self.showAlert(presentingController: self, title: Language.getWord(withID: "paymentmodeupdateerror"), message: message, buttons: [Language.getWord(withID: "okay")], actions: nil)
     }
-
+    
+    @IBAction func paymentModeQuestionTapped(_ sender: UIButton) {
+        self.view.endEditing(true)
+        
+        self.showAlert(presentingController: self, title: Language.getWord(withID: "buyvclightning"), message: Language.getWord(withID: "buyvclightningexplanation"), buttons: [Language.getWord(withID: "okay")], actions: nil)
+    }
+    
     func changeColors() {
 
         self.view.backgroundColor = Colors.getColor("yelloworblue1")

--- a/ios/bittr/Buy/IbanCollectionViewCell.swift
+++ b/ios/bittr/Buy/IbanCollectionViewCell.swift
@@ -17,7 +17,8 @@ class IbanCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var nameView: UIView!
     @IBOutlet weak var codeView: UIView!
     @IBOutlet weak var emailView: UIView!
-
+    @IBOutlet weak var paymentModeView: UIView!
+    
     // Dynamic labels
     @IBOutlet weak var labelYourEmail: UILabel!
     @IBOutlet weak var labelYourIban: UILabel!
@@ -31,16 +32,24 @@ class IbanCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var titleOurIBAN: UILabel!
     @IBOutlet weak var titleOurName: UILabel!
     @IBOutlet weak var titleYourCode: UILabel!
-
+    @IBOutlet weak var titlePaymentMode: UILabel!
+    
     // Buttons
     @IBOutlet weak var ibanButton: UIButton!
     @IBOutlet weak var nameButton: UIButton!
     @IBOutlet weak var codeButton: UIButton!
-
+    @IBOutlet weak var paymentModeButton: UIButton!
+    @IBOutlet weak var paymentModeSwitch: UISwitch!
+    @IBOutlet weak var paymentModeSpinner: UIActivityIndicatorView!
+    
     // Images
     @IBOutlet weak var copyIban: UIImageView!
     @IBOutlet weak var copyName: UIImageView!
     @IBOutlet weak var copyCode: UIImageView!
+    
+    // Variables
+    var ibanEntity:IbanEntity?
+    var buyVC:BuyViewController?
 
     override func awakeFromNib() {
 
@@ -55,6 +64,7 @@ class IbanCollectionViewCell: UICollectionViewCell {
         self.nameView.layer.cornerRadius = 13
         self.codeView.layer.cornerRadius = 13
         self.emailView.layer.cornerRadius = 13
+        self.paymentModeView.layer.cornerRadius = 13
 
         // Background card styling
         self.cardBackgroundView.setShadow()
@@ -63,12 +73,23 @@ class IbanCollectionViewCell: UICollectionViewCell {
         self.ibanButton.setTitle("", for: .normal)
         self.nameButton.setTitle("", for: .normal)
         self.codeButton.setTitle("", for: .normal)
+        self.paymentModeButton.setTitle("", for: .normal)
 
         // Colors and language
         self.changeColors()
         self.setWords()
     }
-
+    
+    @IBAction func didChangePaymentModeSwitch(_ sender: UISwitch) {
+        guard self.buyVC != nil, self.ibanEntity != nil else { return }
+        
+        let newMode = sender.isOn ? "lightning" : "onchain"
+        Log.info("Will switch payment mode to \(newMode).")
+        
+        self.paymentModeSpinner.startAnimating()
+        self.buyVC!.setPaymentMode(for: self.ibanEntity!, newMode: newMode)
+    }
+    
     func changeColors() {
 
         self.labelYourEmail.textColor = Colors.getColor("blackorwhite")
@@ -83,6 +104,8 @@ class IbanCollectionViewCell: UICollectionViewCell {
         self.nameView.backgroundColor = Colors.getColor("whiteorblue3")
         self.codeView.backgroundColor = Colors.getColor("whiteorblue3")
         self.emailView.backgroundColor = Colors.getColor("whiteorblue3")
+        self.paymentModeView.backgroundColor = Colors.getColor("whiteorblue3")
+        self.paymentModeSpinner.color = Colors.getColor("blackorwhite")
 
         self.copyIban.tintColor = Colors.getColor("blackorwhite")
         self.copyName.tintColor = Colors.getColor("blackorwhite")
@@ -96,5 +119,6 @@ class IbanCollectionViewCell: UICollectionViewCell {
         self.titleOurIBAN.text = Language.getWord(withID: "ouriban")
         self.titleOurName.text = Language.getWord(withID: "ourname")
         self.titleYourCode.text = Language.getWord(withID: "yourcode")
+        self.titlePaymentMode.text = Language.getWord(withID: "buyvclightning")
     }
 }

--- a/ios/bittr/Buy/IbanCollectionViewCell.swift
+++ b/ios/bittr/Buy/IbanCollectionViewCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 class IbanCollectionViewCell: UICollectionViewCell {
-    
+
     // Views
     @IBOutlet weak var cardBackgroundView: UIView!
     @IBOutlet weak var cardBackgroundViewWidth: NSLayoutConstraint!
@@ -17,43 +17,30 @@ class IbanCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var nameView: UIView!
     @IBOutlet weak var codeView: UIView!
     @IBOutlet weak var emailView: UIView!
-    
+
     // Dynamic labels
     @IBOutlet weak var labelYourEmail: UILabel!
     @IBOutlet weak var labelYourIban: UILabel!
     @IBOutlet weak var labelOurIban: UILabel!
     @IBOutlet weak var labelOurName: UILabel!
     @IBOutlet weak var labelYourCode: UILabel!
-    
+
     // Static labels
     @IBOutlet weak var titleYourEmail: UILabel!
     @IBOutlet weak var titleYourIBAN: UILabel!
     @IBOutlet weak var titleOurIBAN: UILabel!
     @IBOutlet weak var titleOurName: UILabel!
     @IBOutlet weak var titleYourCode: UILabel!
-    
+
     // Buttons
     @IBOutlet weak var ibanButton: UIButton!
     @IBOutlet weak var nameButton: UIButton!
     @IBOutlet weak var codeButton: UIButton!
-    
+
     // Images
     @IBOutlet weak var copyIban: UIImageView!
     @IBOutlet weak var copyName: UIImageView!
     @IBOutlet weak var copyCode: UIImageView!
-
-    // MARK: - Payment-mode toggle (built programmatically; the card is storyboard-based)
-
-    let paymentModeView = UIView()
-    let payoutTitleLabel = UILabel()
-    let lightningPill = UIButton(type: .system)
-    let onchainPill = UIButton(type: .system)
-
-    /// Current payout mode shown by the toggle ("lightning" / "onchain" / "" when unknown).
-    private(set) var currentPaymentMode = ""
-    /// Called when the user taps a different pill. The owning VC performs the PATCH and
-    /// re-configures the cell from the resulting (server-confirmed) state.
-    var onPaymentModeChange: ((String) -> Void)?
 
     override func awakeFromNib() {
 
@@ -68,119 +55,38 @@ class IbanCollectionViewCell: UICollectionViewCell {
         self.nameView.layer.cornerRadius = 13
         self.codeView.layer.cornerRadius = 13
         self.emailView.layer.cornerRadius = 13
-        
+
         // Background card styling
         self.cardBackgroundView.setShadow()
-        
+
         // Button titles
         self.ibanButton.setTitle("", for: .normal)
         self.nameButton.setTitle("", for: .normal)
         self.codeButton.setTitle("", for: .normal)
-
-        // Payment-mode toggle (must exist before changeColors/setWords style it)
-        self.setupPaymentModeToggle()
 
         // Colors and language
         self.changeColors()
         self.setWords()
     }
 
-    // MARK: - Payment-mode toggle
-
-    private func setupPaymentModeToggle() {
-
-        paymentModeView.translatesAutoresizingMaskIntoConstraints = false
-        paymentModeView.layer.cornerRadius = 13
-        cardBackgroundView.addSubview(paymentModeView)
-
-        payoutTitleLabel.translatesAutoresizingMaskIntoConstraints = false
-        payoutTitleLabel.font = self.titleYourCode.font
-        paymentModeView.addSubview(payoutTitleLabel)
-
-        let pillStack = UIStackView(arrangedSubviews: [lightningPill, onchainPill])
-        pillStack.translatesAutoresizingMaskIntoConstraints = false
-        pillStack.axis = .horizontal
-        pillStack.distribution = .fillEqually
-        pillStack.spacing = 8
-        paymentModeView.addSubview(pillStack)
-
-        for (tag, pill) in [lightningPill, onchainPill].enumerated() {
-            pill.tag = tag // 0 = lightning, 1 = onchain
-            pill.titleLabel?.font = self.labelYourCode.font
-            pill.layer.cornerRadius = 10
-            pill.addTarget(self, action: #selector(paymentPillTapped(_:)), for: .touchUpInside)
-        }
-
-        // Anchor the toggle below the deposit-code section. No bottom pin to the card
-        // (kept .defaultLow-free) so it can't conflict with the storyboard constraints;
-        // the cell height is enlarged in BuyViewController.sizeForItemAt to make room.
-        NSLayoutConstraint.activate([
-            paymentModeView.topAnchor.constraint(equalTo: codeView.bottomAnchor, constant: 12),
-            paymentModeView.leadingAnchor.constraint(equalTo: codeView.leadingAnchor),
-            paymentModeView.trailingAnchor.constraint(equalTo: codeView.trailingAnchor),
-            paymentModeView.heightAnchor.constraint(equalToConstant: 68),
-
-            payoutTitleLabel.topAnchor.constraint(equalTo: paymentModeView.topAnchor, constant: 8),
-            payoutTitleLabel.leadingAnchor.constraint(equalTo: paymentModeView.leadingAnchor, constant: 12),
-            payoutTitleLabel.trailingAnchor.constraint(equalTo: paymentModeView.trailingAnchor, constant: -12),
-
-            pillStack.leadingAnchor.constraint(equalTo: paymentModeView.leadingAnchor, constant: 12),
-            pillStack.trailingAnchor.constraint(equalTo: paymentModeView.trailingAnchor, constant: -12),
-            pillStack.bottomAnchor.constraint(equalTo: paymentModeView.bottomAnchor, constant: -8),
-            pillStack.topAnchor.constraint(equalTo: payoutTitleLabel.bottomAnchor, constant: 6)
-        ])
-    }
-
-    /// Set the toggle to reflect a server-confirmed mode ("lightning" / "onchain" / "").
-    func configurePaymentMode(_ mode: String) {
-        self.currentPaymentMode = mode
-        self.stylePills()
-    }
-
-    private func stylePills() {
-        let yellow = Colors.getColor("yellow")
-        let blackOrWhite = Colors.getColor("blackorwhite")
-
-        let lightningSelected = (currentPaymentMode == "lightning")
-        let onchainSelected = (currentPaymentMode == "onchain")
-
-        lightningPill.backgroundColor = lightningSelected ? yellow : .clear
-        onchainPill.backgroundColor = onchainSelected ? yellow : .clear
-        lightningPill.setTitleColor(blackOrWhite, for: .normal)
-        onchainPill.setTitleColor(blackOrWhite, for: .normal)
-    }
-
-    @objc private func paymentPillTapped(_ sender: UIButton) {
-        let newMode = sender.tag == 0 ? "lightning" : "onchain"
-        if newMode == currentPaymentMode { return }
-        // Optimistically reflect the tap; the VC re-configures us from the server result
-        // (and reverts on failure) once the PATCH completes.
-        configurePaymentMode(newMode)
-        onPaymentModeChange?(newMode)
-    }
-    
     func changeColors() {
-        
+
         self.labelYourEmail.textColor = Colors.getColor("blackorwhite")
         self.labelYourIban.textColor = Colors.getColor("blackorwhite")
         self.labelOurIban.textColor = Colors.getColor("blackorwhite")
         self.labelOurName.textColor = Colors.getColor("blackorwhite")
         self.labelYourCode.textColor = Colors.getColor("blackorwhite")
-        
+
         self.cardBackgroundView.backgroundColor = Colors.getColor("yelloworblue2")
         self.yourIbanView.backgroundColor = Colors.getColor("whiteorblue3")
         self.ibanView.backgroundColor = Colors.getColor("whiteorblue3")
         self.nameView.backgroundColor = Colors.getColor("whiteorblue3")
         self.codeView.backgroundColor = Colors.getColor("whiteorblue3")
         self.emailView.backgroundColor = Colors.getColor("whiteorblue3")
-        
+
         self.copyIban.tintColor = Colors.getColor("blackorwhite")
         self.copyName.tintColor = Colors.getColor("blackorwhite")
         self.copyCode.tintColor = Colors.getColor("blackorwhite")
-
-        self.paymentModeView.backgroundColor = Colors.getColor("whiteorblue3")
-        self.payoutTitleLabel.textColor = Colors.getColor("blackorwhite")
-        self.stylePills()
     }
 
     func setWords() {
@@ -190,11 +96,5 @@ class IbanCollectionViewCell: UICollectionViewCell {
         self.titleOurIBAN.text = Language.getWord(withID: "ouriban")
         self.titleOurName.text = Language.getWord(withID: "ourname")
         self.titleYourCode.text = Language.getWord(withID: "yourcode")
-
-        // TODO: localize these via Language.getWord once the keys are added to Language.swift
-        // (kept as literals here to avoid a blind multi-language edit in this PR).
-        self.payoutTitleLabel.text = "Payout to"
-        self.lightningPill.setTitle("⚡ Lightning", for: .normal)
-        self.onchainPill.setTitle("⛓ On-chain", for: .normal)
     }
 }

--- a/ios/bittr/Buy/IbanCollectionViewCell.swift
+++ b/ios/bittr/Buy/IbanCollectionViewCell.swift
@@ -56,6 +56,8 @@ class IbanCollectionViewCell: UICollectionViewCell {
         self.labelYourCode.accessibilityIdentifier = TestID.Buy.yourCode
         self.labelYourEmail.accessibilityIdentifier = TestID.Buy.yourEmail
         self.labelYourIban.accessibilityIdentifier = TestID.Buy.yourIban
+        self.paymentModeSwitch.accessibilityIdentifier = TestID.Buy.paymentModeSwitch
+        self.paymentModeButton.accessibilityIdentifier = TestID.Buy.paymentModeButton
 
         // Corner radii
         self.cardBackgroundView.layer.cornerRadius = 20
@@ -85,7 +87,12 @@ class IbanCollectionViewCell: UICollectionViewCell {
         
         let newMode = sender.isOn ? "lightning" : "onchain"
         Log.info("Will switch payment mode to \(newMode).")
-        
+
+        // Disable the switch + show the spinner while the PATCH is in flight so a
+        // second flip can't fire a concurrent, racing request. cellForItemAt
+        // re-enables it (and stops the spinner) when the cell is reloaded with the
+        // server-confirmed value, on both success and failure.
+        sender.isEnabled = false
         self.paymentModeSpinner.startAnimating()
         self.buyVC!.setPaymentMode(for: self.ibanEntity!, newMode: newMode)
     }

--- a/ios/bittr/Buy/IbanCollectionViewCell.swift
+++ b/ios/bittr/Buy/IbanCollectionViewCell.swift
@@ -41,7 +41,20 @@ class IbanCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var copyIban: UIImageView!
     @IBOutlet weak var copyName: UIImageView!
     @IBOutlet weak var copyCode: UIImageView!
-    
+
+    // MARK: - Payment-mode toggle (built programmatically; the card is storyboard-based)
+
+    let paymentModeView = UIView()
+    let payoutTitleLabel = UILabel()
+    let lightningPill = UIButton(type: .system)
+    let onchainPill = UIButton(type: .system)
+
+    /// Current payout mode shown by the toggle ("lightning" / "onchain" / "" when unknown).
+    private(set) var currentPaymentMode = ""
+    /// Called when the user taps a different pill. The owning VC performs the PATCH and
+    /// re-configures the cell from the resulting (server-confirmed) state.
+    var onPaymentModeChange: ((String) -> Void)?
+
     override func awakeFromNib() {
 
         self.labelYourCode.accessibilityIdentifier = TestID.Buy.yourCode
@@ -63,10 +76,87 @@ class IbanCollectionViewCell: UICollectionViewCell {
         self.ibanButton.setTitle("", for: .normal)
         self.nameButton.setTitle("", for: .normal)
         self.codeButton.setTitle("", for: .normal)
-        
+
+        // Payment-mode toggle (must exist before changeColors/setWords style it)
+        self.setupPaymentModeToggle()
+
         // Colors and language
         self.changeColors()
         self.setWords()
+    }
+
+    // MARK: - Payment-mode toggle
+
+    private func setupPaymentModeToggle() {
+
+        paymentModeView.translatesAutoresizingMaskIntoConstraints = false
+        paymentModeView.layer.cornerRadius = 13
+        cardBackgroundView.addSubview(paymentModeView)
+
+        payoutTitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        payoutTitleLabel.font = self.titleYourCode.font
+        paymentModeView.addSubview(payoutTitleLabel)
+
+        let pillStack = UIStackView(arrangedSubviews: [lightningPill, onchainPill])
+        pillStack.translatesAutoresizingMaskIntoConstraints = false
+        pillStack.axis = .horizontal
+        pillStack.distribution = .fillEqually
+        pillStack.spacing = 8
+        paymentModeView.addSubview(pillStack)
+
+        for (tag, pill) in [lightningPill, onchainPill].enumerated() {
+            pill.tag = tag // 0 = lightning, 1 = onchain
+            pill.titleLabel?.font = self.labelYourCode.font
+            pill.layer.cornerRadius = 10
+            pill.addTarget(self, action: #selector(paymentPillTapped(_:)), for: .touchUpInside)
+        }
+
+        // Anchor the toggle below the deposit-code section. No bottom pin to the card
+        // (kept .defaultLow-free) so it can't conflict with the storyboard constraints;
+        // the cell height is enlarged in BuyViewController.sizeForItemAt to make room.
+        NSLayoutConstraint.activate([
+            paymentModeView.topAnchor.constraint(equalTo: codeView.bottomAnchor, constant: 12),
+            paymentModeView.leadingAnchor.constraint(equalTo: codeView.leadingAnchor),
+            paymentModeView.trailingAnchor.constraint(equalTo: codeView.trailingAnchor),
+            paymentModeView.heightAnchor.constraint(equalToConstant: 68),
+
+            payoutTitleLabel.topAnchor.constraint(equalTo: paymentModeView.topAnchor, constant: 8),
+            payoutTitleLabel.leadingAnchor.constraint(equalTo: paymentModeView.leadingAnchor, constant: 12),
+            payoutTitleLabel.trailingAnchor.constraint(equalTo: paymentModeView.trailingAnchor, constant: -12),
+
+            pillStack.leadingAnchor.constraint(equalTo: paymentModeView.leadingAnchor, constant: 12),
+            pillStack.trailingAnchor.constraint(equalTo: paymentModeView.trailingAnchor, constant: -12),
+            pillStack.bottomAnchor.constraint(equalTo: paymentModeView.bottomAnchor, constant: -8),
+            pillStack.topAnchor.constraint(equalTo: payoutTitleLabel.bottomAnchor, constant: 6)
+        ])
+    }
+
+    /// Set the toggle to reflect a server-confirmed mode ("lightning" / "onchain" / "").
+    func configurePaymentMode(_ mode: String) {
+        self.currentPaymentMode = mode
+        self.stylePills()
+    }
+
+    private func stylePills() {
+        let yellow = Colors.getColor("yellow")
+        let blackOrWhite = Colors.getColor("blackorwhite")
+
+        let lightningSelected = (currentPaymentMode == "lightning")
+        let onchainSelected = (currentPaymentMode == "onchain")
+
+        lightningPill.backgroundColor = lightningSelected ? yellow : .clear
+        onchainPill.backgroundColor = onchainSelected ? yellow : .clear
+        lightningPill.setTitleColor(blackOrWhite, for: .normal)
+        onchainPill.setTitleColor(blackOrWhite, for: .normal)
+    }
+
+    @objc private func paymentPillTapped(_ sender: UIButton) {
+        let newMode = sender.tag == 0 ? "lightning" : "onchain"
+        if newMode == currentPaymentMode { return }
+        // Optimistically reflect the tap; the VC re-configures us from the server result
+        // (and reverts on failure) once the PATCH completes.
+        configurePaymentMode(newMode)
+        onPaymentModeChange?(newMode)
     }
     
     func changeColors() {
@@ -87,14 +177,24 @@ class IbanCollectionViewCell: UICollectionViewCell {
         self.copyIban.tintColor = Colors.getColor("blackorwhite")
         self.copyName.tintColor = Colors.getColor("blackorwhite")
         self.copyCode.tintColor = Colors.getColor("blackorwhite")
+
+        self.paymentModeView.backgroundColor = Colors.getColor("whiteorblue3")
+        self.payoutTitleLabel.textColor = Colors.getColor("blackorwhite")
+        self.stylePills()
     }
-    
+
     func setWords() {
-        
+
         self.titleYourEmail.text = Language.getWord(withID: "youremail")
         self.titleYourIBAN.text = Language.getWord(withID: "youriban")
         self.titleOurIBAN.text = Language.getWord(withID: "ouriban")
         self.titleOurName.text = Language.getWord(withID: "ourname")
         self.titleYourCode.text = Language.getWord(withID: "yourcode")
+
+        // TODO: localize these via Language.getWord once the keys are added to Language.swift
+        // (kept as literals here to avoid a blind multi-language edit in this PR).
+        self.payoutTitleLabel.text = "Payout to"
+        self.lightningPill.setTitle("⚡ Lightning", for: .normal)
+        self.onchainPill.setTitle("⛓ On-chain", for: .normal)
     }
 }

--- a/ios/bittr/Buy/IbanEntity.swift
+++ b/ios/bittr/Buy/IbanEntity.swift
@@ -19,4 +19,7 @@ class IbanEntity: NSObject {
     var emailToken = ""
     var ourSwift = ""
     var lightningAddressUsername = ""
+    // Payout mode for this deposit code: "lightning" or "onchain".
+    // Empty until the backend reports it (registration / deposit_code / payment-mode endpoints).
+    var paymentMode = ""
 }

--- a/ios/bittr/CacheManager.swift
+++ b/ios/bittr/CacheManager.swift
@@ -73,7 +73,10 @@ class CacheManager: NSObject {
                             if let actualOurSwift = ibanDataDict["ourswift"] as? String {
                                 iban.ourSwift = actualOurSwift
                             }
-                            
+                            if let actualPaymentMode = ibanDataDict["paymentmode"] as? String {
+                                iban.paymentMode = actualPaymentMode
+                            }
+
                             ibansInClient += [iban]
                         }
                     }
@@ -114,7 +117,7 @@ class CacheManager: NSObject {
             
             let ibansDict = NSMutableDictionary()
             for existingIban in bittrWallet.ibanEntities {
-                ibansDict.setObject(["order":existingIban.order,"youriban":existingIban.yourIbanNumber, "youremail":existingIban.yourEmail, "yourcode":existingIban.yourUniqueCode, "ouriban":existingIban.ourIbanNumber, "ourname":existingIban.ourName, "token":existingIban.emailToken, "ourswift":existingIban.ourSwift], forKey: existingIban.id as NSCopying)
+                ibansDict.setObject(["order":existingIban.order,"youriban":existingIban.yourIbanNumber, "youremail":existingIban.yourEmail, "yourcode":existingIban.yourUniqueCode, "ouriban":existingIban.ourIbanNumber, "ourname":existingIban.ourName, "token":existingIban.emailToken, "ourswift":existingIban.ourSwift, "paymentmode":existingIban.paymentMode], forKey: existingIban.id as NSCopying)
             }
             let updatedClientsDict = NSMutableDictionary()
             updatedClientsDict.setObject(["ibans":ibansDict], forKey: "bittrwallet" as NSCopying)
@@ -145,7 +148,7 @@ class CacheManager: NSObject {
             
             let ibansDict = NSMutableDictionary()
             for eachIbanEntity in bittrWallet.ibanEntities {
-                ibansDict.setObject(["order":eachIbanEntity.order,"youriban":eachIbanEntity.yourIbanNumber, "youremail":eachIbanEntity.yourEmail, "yourcode":eachIbanEntity.yourUniqueCode, "ouriban":eachIbanEntity.ourIbanNumber, "ourname":eachIbanEntity.ourName, "token":eachIbanEntity.emailToken, "ourswift":eachIbanEntity.ourSwift, "lightningaddressusername":eachIbanEntity.lightningAddressUsername], forKey: eachIbanEntity.id as NSCopying)
+                ibansDict.setObject(["order":eachIbanEntity.order,"youriban":eachIbanEntity.yourIbanNumber, "youremail":eachIbanEntity.yourEmail, "yourcode":eachIbanEntity.yourUniqueCode, "ouriban":eachIbanEntity.ourIbanNumber, "ourname":eachIbanEntity.ourName, "token":eachIbanEntity.emailToken, "ourswift":eachIbanEntity.ourSwift, "lightningaddressusername":eachIbanEntity.lightningAddressUsername, "paymentmode":eachIbanEntity.paymentMode], forKey: eachIbanEntity.id as NSCopying)
             }
             let updatedClientsDict = NSMutableDictionary()
             updatedClientsDict.setObject(["ibans":ibansDict], forKey: "bittrwallet" as NSCopying)
@@ -154,6 +157,31 @@ class CacheManager: NSObject {
         }
     }
     
+    static func setPaymentMode(ibanID:String, paymentMode:String) {
+
+        let envKey = EnvironmentConfig.deviceCacheKey
+
+        if let clientsDict = UserDefaults.standard.value(forKey: envKey) as? NSDictionary {
+
+            let bittrWallet = self.parseDevice(deviceDict: clientsDict)
+
+            for eachIbanEntity in bittrWallet.ibanEntities {
+                if eachIbanEntity.id == ibanID {
+                    eachIbanEntity.paymentMode = paymentMode
+                }
+            }
+
+            let ibansDict = NSMutableDictionary()
+            for eachIbanEntity in bittrWallet.ibanEntities {
+                ibansDict.setObject(["order":eachIbanEntity.order,"youriban":eachIbanEntity.yourIbanNumber, "youremail":eachIbanEntity.yourEmail, "yourcode":eachIbanEntity.yourUniqueCode, "ouriban":eachIbanEntity.ourIbanNumber, "ourname":eachIbanEntity.ourName, "token":eachIbanEntity.emailToken, "ourswift":eachIbanEntity.ourSwift, "lightningaddressusername":eachIbanEntity.lightningAddressUsername, "paymentmode":eachIbanEntity.paymentMode], forKey: eachIbanEntity.id as NSCopying)
+            }
+            let updatedClientsDict = NSMutableDictionary()
+            updatedClientsDict.setObject(["ibans":ibansDict], forKey: "bittrwallet" as NSCopying)
+            UserDefaults.standard.set(updatedClientsDict, forKey: envKey)
+            UserDefaults.standard.synchronize()
+        }
+    }
+
     static func addBittrIban(ibanID:String, ourIban:String, ourSwift:String, yourCode:String, lightningAddressUsername:String?) {
         
         let envKey = EnvironmentConfig.deviceCacheKey
@@ -173,7 +201,7 @@ class CacheManager: NSObject {
             
             let ibansDict = NSMutableDictionary()
             for eachIbanEntity in bittrWallet.ibanEntities {
-                ibansDict.setObject(["order":eachIbanEntity.order,"youriban":eachIbanEntity.yourIbanNumber, "youremail":eachIbanEntity.yourEmail, "yourcode":eachIbanEntity.yourUniqueCode, "ouriban":eachIbanEntity.ourIbanNumber, "ourname":eachIbanEntity.ourName, "token":eachIbanEntity.emailToken, "ourswift":eachIbanEntity.ourSwift, "lightningaddressusername":eachIbanEntity.lightningAddressUsername], forKey: eachIbanEntity.id as NSCopying)
+                ibansDict.setObject(["order":eachIbanEntity.order,"youriban":eachIbanEntity.yourIbanNumber, "youremail":eachIbanEntity.yourEmail, "yourcode":eachIbanEntity.yourUniqueCode, "ouriban":eachIbanEntity.ourIbanNumber, "ourname":eachIbanEntity.ourName, "token":eachIbanEntity.emailToken, "ourswift":eachIbanEntity.ourSwift, "lightningaddressusername":eachIbanEntity.lightningAddressUsername, "paymentmode":eachIbanEntity.paymentMode], forKey: eachIbanEntity.id as NSCopying)
             }
             let updatedClientsDict = NSMutableDictionary()
             updatedClientsDict.setObject(["ibans":ibansDict], forKey: "bittrwallet" as NSCopying)

--- a/ios/bittr/CallsManager.swift
+++ b/ios/bittr/CallsManager.swift
@@ -26,6 +26,7 @@ class CallsManager: NSObject {
             switch getOrPost {
             case .get: return "GET"
             case .post: return "POST"
+            case .patch: return "PATCH"
             }
         }()
         
@@ -98,4 +99,5 @@ class CallsManager: NSObject {
 enum CallType {
     case get
     case post
+    case patch
 }

--- a/ios/bittr/Helpers/TestIDs.swift
+++ b/ios/bittr/Helpers/TestIDs.swift
@@ -17,6 +17,8 @@ enum TestID {
         static let yourCode = "buy.yourCode"
         static let yourEmail = "buy.yourEmail"
         static let yourIban = "buy.yourIban"
+        static let paymentModeSwitch = "buy.paymentModeSwitch"
+        static let paymentModeButton = "buy.paymentModeButton"
     }
     enum Device {
         enum Darkmode {

--- a/ios/bittr/Language.swift
+++ b/ios/bittr/Language.swift
@@ -556,7 +556,11 @@ class Language: NSObject {
             "lnauth2": "You've been successfully signed in.",
             "lnauth3": "We could not sign you in. Please try again.",
             "removewallet": "Remove wallet",
-            "settings": "Settings"
+            "settings": "Settings",
+            "buyvclightning": "Lightning",
+            "buyvclightningexplanation": "Bittr purchases between 20 and 100 € go into your lightning connection. With lightning, you can send and receive instant payments against low fees.\n\nSwitch this off to receive all bittr purchases into the regular (on-chain) part of your wallet.",
+            "lightningnotready": "Lightning not ready",
+            "paymentmodeupdateerror": "Couldn't update payout mode"
             
         ]
         

--- a/ios/bittr/Language.swift
+++ b/ios/bittr/Language.swift
@@ -558,7 +558,7 @@ class Language: NSObject {
             "removewallet": "Remove wallet",
             "settings": "Settings",
             "buyvclightning": "Lightning",
-            "buyvclightningexplanation": "Bittr purchases between 20 and 100 € go into your lightning connection. With lightning, you can send and receive instant payments against low fees.\n\nSwitch this off to receive all bittr purchases into the regular (on-chain) part of your wallet.",
+            "buyvclightningexplanation": "Purchases up to 100 EUR/CHF go into your Lightning connection. Spend and receive instantly, with very low fees.\n\nTurn this off to receive your bittr purchases on-chain instead, in the regular part of your wallet.",
             "lightningnotready": "Lightning not ready",
             "paymentmodeupdateerror": "Couldn't update payout mode"
             

--- a/shared/flows/README.md
+++ b/shared/flows/README.md
@@ -49,6 +49,11 @@ shared/flows/
                           running. Requires an active channel with outbound
                           capacity.
     swap.yaml             Lightning ↔ onchain, both directions.
+    payment_mode.yaml     The lightning/onchain payout-mode toggle on the Buy
+                          card (PATCH /customer/payment-mode). Self-provisions:
+                          restores a wallet if none and creates an order
+                          (buy_signup) if there's no deposit code, then toggles
+                          the switch and asserts the server-confirmed state.
     forgot_pin.yaml       Forgot-PIN recovery from the unlock screen — types
                           the cached mnemonic and resets the PIN. Requires
                           the MNEMONIC env var (see Running below).

--- a/shared/flows/features/payment_mode.yaml
+++ b/shared/flows/features/payment_mode.yaml
@@ -22,11 +22,17 @@ appId: com.bittr.bittr-regtest
 ---
 - launchApp
 
-# 1) Ensure a wallet and reach Home (restore if none exists, else unlock).
+# 1) Ensure a wallet and reach Home, WITHOUT wiping an existing wallet:
+#    - Restore only if there's genuinely no wallet, i.e. the app launched to the
+#      create-wallet signup screen. (Gating on "unlock screen not visible" was
+#      wrong: when a wallet exists but the app opens straight to Home, that also
+#      has no unlock screen, so it wrongly restored and wiped the wallet each run.)
+#    - Otherwise, if it launched to the locked PIN screen, unlock.
+#    - Otherwise it's already on Home (a still-unlocked session) — proceed.
 - runFlow:
     when:
-      notVisible:
-        id: "unlock.topLabel"
+      visible:
+        id: "signup.create.start.createWalletButton"
     file: ../onboarding/restore_wallet.yaml
 - runFlow:
     when:

--- a/shared/flows/features/payment_mode.yaml
+++ b/shared/flows/features/payment_mode.yaml
@@ -1,0 +1,116 @@
+# Feature test: the lightning/onchain payout-mode toggle on the Buy card.
+# Switches the deposit code's payout mode via PATCH /customer/payment-mode and
+# verifies the switch reflects the server-confirmed value.
+#
+# Self-provisioning (runs standalone): restores a wallet if there isn't one, and
+# creates a bittr order (buy_signup) if the Buy card has no deposit code. Orders
+# are created as lightning orders, so the switch starts ON. The test then toggles
+# to onchain, asserts, and toggles back to lightning.
+#
+# Switching to lightning needs a connected lightning node on file — buy_signup
+# registers the node (lightning_pubkey), so no open channel is required, just an
+# order.
+#
+# NOTE: the on/off assertions use Maestro's `checked` selector against the
+# UISwitch (buy.paymentModeSwitch). If `checked` doesn't read the switch state
+# on iOS in your Maestro version, drop the `checked:` lines and rely on the
+# screenshots instead.
+#
+# Run: maestro test shared/flows/features/payment_mode.yaml
+
+appId: com.bittr.bittr-regtest
+---
+- launchApp
+
+# 1) Ensure a wallet and reach Home (restore if none exists, else unlock).
+- runFlow:
+    when:
+      notVisible:
+        id: "unlock.topLabel"
+    file: ../onboarding/restore_wallet.yaml
+- runFlow:
+    when:
+      visible:
+        id: "unlock.topLabel"
+    file: ../helpers/unlock.yaml
+- assertVisible:
+    id: "home.headerLabel"
+- extendedWaitUntil:
+    notVisible:
+      id: "home.headerSpinner"
+    timeout: 120000
+
+# 2) Open Buy and let getDepositCodeData (updateDataSpinner) settle so an
+#    existing order's card has rendered before we test for it.
+- tapOn:
+    id: "home.buyButton"
+- assertVisible:
+    id: "buy.headerLabel"
+- waitForAnimationToEnd:
+    timeout: 30000
+
+# 3) Ensure an order exists. No deposit code on the card => no bittr account yet
+#    => sign up (buy_signup ends on Home), then reopen Buy.
+- runFlow:
+    when:
+      notVisible:
+        id: "buy.yourCode"
+    file: buy_signup.yaml
+- runFlow:
+    when:
+      visible:
+        id: "home.buyButton"
+    commands:
+      - tapOn:
+          id: "home.buyButton"
+      - assertVisible:
+          id: "buy.headerLabel"
+      - waitForAnimationToEnd:
+          timeout: 30000
+
+# 4) The card + toggle are present. Orders are created as lightning, so the
+#    switch starts ON.
+- assertVisible:
+    id: "buy.yourCode"
+- assertVisible:
+    id: "buy.paymentModeSwitch"
+- takeScreenshot: shared/docs/screenshots/payment_mode/01_card
+
+# 4b) Tap the "?" help button next to the toggle and verify the Lightning
+#     explanation alert appears (buyvclightningexplanation), then dismiss it.
+- tapOn:
+    id: "buy.paymentModeButton"
+- assertVisible:
+    text: "very low fees"
+- takeScreenshot: shared/docs/screenshots/payment_mode/01b_explanation
+- tapOn:
+    id: "alert.button.0"
+
+# 5) Toggle to onchain. Tapping fires the PATCH; the switch is disabled + a
+#    spinner shows until the server-confirmed value reloads. Wait until the
+#    switch settles to off (a failed PATCH would revert it to on -> timeout).
+- tapOn:
+    id: "buy.paymentModeSwitch"
+- extendedWaitUntil:
+    visible:
+      id: "buy.paymentModeSwitch"
+      checked: false
+    timeout: 60000
+- takeScreenshot: shared/docs/screenshots/payment_mode/02_onchain
+
+# 6) Toggle back to lightning.
+- tapOn:
+    id: "buy.paymentModeSwitch"
+- extendedWaitUntil:
+    visible:
+      id: "buy.paymentModeSwitch"
+      checked: true
+    timeout: 60000
+- takeScreenshot: shared/docs/screenshots/payment_mode/03_lightning
+
+# 7) Close Buy -> Home.
+- tapOn:
+    id: "buy.downButton"
+- assertVisible:
+    id: "home.headerLabel"
+- takeScreenshot: shared/docs/screenshots/payment_mode/04_home

--- a/shared/flows/features/payment_mode.yaml
+++ b/shared/flows/features/payment_mode.yaml
@@ -78,10 +78,12 @@ appId: com.bittr.bittr-regtest
 
 # 4b) Tap the "?" help button next to the toggle and verify the Lightning
 #     explanation alert appears (buyvclightningexplanation), then dismiss it.
+#     Maestro's `text` is a regex matched against the element's WHOLE text, so
+#     the substring needs .* wildcards to match within the long message label.
 - tapOn:
     id: "buy.paymentModeButton"
 - assertVisible:
-    text: "very low fees"
+    text: ".*very low fees.*"
 - takeScreenshot: shared/docs/screenshots/payment_mode/01b_explanation
 - tapOn:
     id: "alert.button.0"

--- a/shared/test-ids/test-ids.json
+++ b/shared/test-ids/test-ids.json
@@ -139,7 +139,9 @@
     "continueButton": null,
     "yourCode": null,
     "yourEmail": null,
-    "yourIban": null
+    "yourIban": null,
+    "paymentModeSwitch": null,
+    "paymentModeButton": null
   },
   "question": {
     "yellowCard": null,


### PR DESCRIPTION
## What

Adds a per-deposit-code **payout-mode toggle** to each card on the Buy screen — a `UISwitch` (on = ⚡ lightning, off = ⛓ on-chain) with a "?" explanation — that switches how future payouts are delivered via the signed `PATCH /customer/payment-mode` endpoint. Part 2 of `customer-payment-mode-ios.md`.

## How it works

- **Read:** the existing `GET /deposit_code` refresh parses `data.payment_mode`, so the switch reflects the server's current mode on load.
- **Write:** flipping the switch signs `payment_mode:{pubkey}:{deposit_code}:{mode}:{timestamp}` with the lightning node and PATCHes it; on success it applies the **server-confirmed** mode, persists it, and reloads just that card.
- **Robustness:** the switch is disabled (with a spinner next to it) while the request is in flight, so a second flip can't race a concurrent PATCH; auto-retries once on `expired timestamp`; reverts + alerts on other errors; a node-readiness guard; failures captured in Sentry.

## Files
`CallsManager` (`.patch`), `IbanEntity.paymentMode`, `CacheManager` persistence, `BuyViewController` (PATCH + parse + reloads), `IbanCollectionViewCell` (switch + spinner + "?"), `Main.storyboard`, `Language.swift` (explanation copy), test IDs, and a `payment_mode.yaml` Maestro flow.

## Testing
`shared/flows/features/payment_mode.yaml` — self-provisioning (restores a wallet + creates an order if needed), toggles lightning↔onchain asserting the server-confirmed state, and checks the "?" explanation.

⚠️ Not compiled in CI here — needs an Xcode build. The test's switch-state assertions use Maestro's `checked` selector (drop to screenshots if unsupported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)