### PR TITLE
Recover existing deposit code on bittr signup (order recovery)

### DIFF
--- a/ios/bittr/Signup/Bittr Signup/Transfer2ViewController.swift
+++ b/ios/bittr/Signup/Bittr Signup/Transfer2ViewController.swift
@@ -177,10 +177,18 @@ class Transfer2ViewController: UIViewController, UITextFieldDelegate, UNUserNoti
             if eachIbanEntity.id == currentIbanID {
                 
                 // Send email and verification code to bittr API.
-                let parameters: [String: Any] = [
+                // Include the lightning node pubkey so the backend can recognise a
+                // returning customer (recovery): the restore fields (deposit_code +
+                // original signed message) are only returned when BOTH the email and
+                // the pubkey match an existing record. If the node isn't up yet we omit
+                // it and the backend treats this as a new registration.
+                var parameters: [String: Any] = [
                     "email_address": eachIbanEntity.yourEmail,
                     "token_2fa": self.codeTextField.text!.trimmingCharacters(in: .whitespacesAndNewlines)
                 ]
+                if let lightningPubKey = BitcoinManager.shared.nodeId() {
+                    parameters["lightning_pubkey"] = lightningPubKey
+                }
                 
                 let envUrl = "\(EnvironmentConfig.bittrAPIBaseURL)/verify/email/check2fa"
                 
@@ -204,9 +212,16 @@ class Transfer2ViewController: UIViewController, UITextFieldDelegate, UNUserNoti
                                     
                                     // Update the in-memory IBAN entity with the new email token
                                     self.coreVC!.bittrWallet.ibanEntities[index].emailToken = actualEmailToken
-                                    
+
+                                    // Recovery: a returning customer (email + pubkey matched) gets back
+                                    // their existing deposit code and the original signed message. When
+                                    // both are present we reuse the deposit code and sign that message
+                                    // verbatim instead of rebuilding it.
+                                    let restoreDepositCode = receivedDictionary["deposit_code"] as? String
+                                    let restoreMessage = receivedDictionary["message"] as? String
+
                                     // Get wallet address.
-                                    self.gatherParameters(ibanEntity: eachIbanEntity)
+                                    self.gatherParameters(ibanEntity: eachIbanEntity, restoreDepositCode: restoreDepositCode, restoreMessage: restoreMessage)
                                 } else if let actualErrorMessage = errorMessage as? String {
                                     if actualErrorMessage == "Invalid 2FA verification token provided" {
                                         self.showAlert(presentingController: self.signupVC?.coreVC ?? self.signupVC ?? self.ibanVC ?? self, title: Language.getWord(withID: "oops"), message: Language.getWord(withID: "verificationfail"), buttons: [Language.getWord(withID: "okay")], actions: nil)
@@ -230,10 +245,14 @@ class Transfer2ViewController: UIViewController, UITextFieldDelegate, UNUserNoti
     }
     
     
-    func gatherParameters(ibanEntity:IbanEntity) {
-        
+    func gatherParameters(ibanEntity:IbanEntity, restoreDepositCode: String? = nil, restoreMessage: String? = nil) {
+
         // Generate message and signature.
-        let message = "I confirm I'm the sole owner of the bitcoin address I provided and I will be sending my own funds to bittr. Order: \(ibanEntity.emailToken.prefix(32)). IBAN: \(ibanEntity.yourIbanNumber)"
+        // On recovery, sign the backend's stored registration message verbatim — do NOT
+        // rebuild it. The IBAN embedded in that message may differ from the IBAN being
+        // submitted now (the backend verifies the signature against the stored message
+        // but persists the new IBAN), so rebuilding would break signature verification.
+        let message = restoreMessage ?? "I confirm I'm the sole owner of the bitcoin address I provided and I will be sending my own funds to bittr. Order: \(ibanEntity.emailToken.prefix(32)). IBAN: \(ibanEntity.yourIbanNumber)"
         let signingPath = BitcoinManager.shared.defaultBip84SigningPath()
         let signature = try! BitcoinManager.shared.signMessageForPath(path: signingPath, message: message)
         
@@ -278,7 +297,7 @@ class Transfer2ViewController: UIViewController, UITextFieldDelegate, UNUserNoti
             let xpub = BitcoinManager.shared.xpub
             
             // Gather parameters.
-            let parameters: [String: Any] = [
+            var parameters: [String: Any] = [
                 "email": ibanEntity.yourEmail,
                 "email_token": ibanEntity.emailToken,
                 "bitcoin_address": firstAddress,
@@ -295,7 +314,13 @@ class Transfer2ViewController: UIViewController, UITextFieldDelegate, UNUserNoti
                 "skip_xpub_usage_check": "true",
                 "ios_device_token": CacheManager.getRegistrationToken() ?? ""
             ]
-            
+            // Recovery: reuse the existing deposit code so the backend updates the
+            // existing customer instead of creating a new order. lightning_pubkey
+            // (above) must match the one sent in check2fa and stored on the customer.
+            if let restoreDepositCode = restoreDepositCode {
+                parameters["deposit_code"] = restoreDepositCode
+            }
+
             // Send details to Bittr.
             self.createBittrAccount(ibanEntity: ibanEntity, parameters: parameters)
         }


### PR DESCRIPTION
## What

Implements **Part 1** of `customer-payment-mode-ios.md` — order recovery. A returning customer who reinstalls or restores their wallet on a new device gets their **existing deposit code** back by going through bittr signup again, identified by **email + lightning pubkey together**.

(Part 2, the payout-mode toggle, is PR #21 — kept independent of this one.)

## How it works (all in `Transfer2ViewController`)

1. **`check2fa`** now sends `lightning_pubkey` (from `BitcoinManager.shared.nodeId()`). The backend only returns restore fields when **both** the email and the pubkey match an existing customer.
2. When the `check2fa` response includes `deposit_code` + `message` (returning customer), those are captured and passed into `gatherParameters`.
3. **`gatherParameters`** signs the returned `message` **verbatim** (not rebuilt) and adds `deposit_code` to `POST /customer`, so the backend **updates the existing customer** and reuses the code instead of creating a new order.

A restored wallet reproduces the same lightning node pubkey, so this "just works" once the user re-enters their email during signup.

## Why sign the message verbatim

The spec is explicit: on restore the IBAN may change, but the **originally signed registration message stays on file** and signatures are verified against it. Rebuilding the message client-side (with a possibly-different IBAN) would fail verification — so when `message` is returned, we sign exactly that.

## Review notes / caveats

⚠️ **Not built in-sandbox** — please **build in Xcode** and manually test: restore a wallet (or reinstall), go through bittr signup with the same email, and confirm the original deposit code comes back (no new order, no registration email).

- **Answer to the LDK-readiness question:** recovery needs the lightning node up at the `check2fa` step so `nodeId()` is available. It reliably is — the node is started during wallet create/restore, well before this screen, and the subsequent `POST /customer` step already guards on `nodeId()`. If for some reason it isn't up, `lightning_pubkey` is omitted and the user is treated as a *new* signup rather than recovered (graceful degradation, not a crash).
- **IBAN** is taken from what the user types in Transfer1 (not pre-filled from the `check2fa` response). The signed message still carries the original IBAN — intended per spec.
- Does **not** persist `payment_mode` from the response (that's PR #21's concern; the Buy-screen `GET /deposit_code` populates it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)