### PR TITLE
New forgot_pin_remove_wallet.yaml test and associated updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ maestro test shared/flows/features/swap.yaml
 maestro test shared/flows/features/send_lightning.yaml
 
 maestro test shared/flows/features/remove_wallet.yaml
+maestro test shared/flows/features/forgot_pin_remove_wallet.yaml
 maestro test shared/flows/features/wrong_pin.yaml
 maestro test shared/flows/features/bitcoin_value.yaml
 maestro test shared/flows/features/bitcoin_map.yaml

--- a/ios/bittr/CacheManager.swift
+++ b/ios/bittr/CacheManager.swift
@@ -977,7 +977,25 @@ class CacheManager: NSObject {
         let defaults = UserDefaults.standard
         defaults.set(0, forKey: envKey)
     }
-    
+
+    // MARK: - Wallet removal in progress
+
+    static func setWalletRemovalInProgress(_ inProgress: Bool) {
+
+        let envKey = EnvironmentConfig.cacheKey(for: "walletremovalinprogress")
+
+        let defaults = UserDefaults.standard
+        defaults.set(inProgress, forKey: envKey)
+    }
+
+    static func walletRemovalIsInProgress() -> Bool {
+
+        let envKey = EnvironmentConfig.cacheKey(for: "walletremovalinprogress")
+
+        let defaults = UserDefaults.standard
+        return defaults.bool(forKey: envKey)
+    }
+
     // MARK: - Event handling
     
     static func didHandleEvent(event:String) {

--- a/ios/bittr/Core/CoreViewController.swift
+++ b/ios/bittr/Core/CoreViewController.swift
@@ -209,6 +209,9 @@ class CoreViewController: UIViewController {
                 Task {
                     await self.startWallet()
                 }
+            } else if CacheManager.walletRemovalIsInProgress() {
+                Log.info("A wallet removal was left in progress — offering to resume it on launch.")
+                self.showAlert(presentingController: self, title: Language.getWord(withID: "removewalletfromdevice"), message: Language.getWord(withID: "removalinprogress"), buttons: [Language.getWord(withID: "cancel"), Language.getWord(withID: "removewalletfromdevice")], actions: [#selector(self.cancelWalletRemoval), #selector(self.resumeWalletRemoval)])
             }
         } else {
             self.signupContainerView.alpha = 1

--- a/ios/bittr/Core/ResetApp.swift
+++ b/ios/bittr/Core/ResetApp.swift
@@ -71,7 +71,6 @@ extension CoreViewController {
                 if !self.removingWalletForIncorrectPin {
                     self.genericSpinner.stopAnimating()
                     self.fullViewCover.alpha = 0
-                    CacheManager.setWalletRemovalInProgress(true)
                 }
                 
                 if BitcoinManager.shared.listChannels().getActiveChannel() != nil {
@@ -91,6 +90,10 @@ extension CoreViewController {
                         // User is locked out. Show "Try again" button, as only available user action.
                         self.showAlert(presentingController: self, title: Language.getWord(withID: "removewallet"), message: Language.getWord(withID: "stillclosing"), buttons: [Language.getWord(withID: "tryagain")], actions: [#selector(self.startWalletInBackground)])
                     } else {
+                        // Manual removal is deferred until the close settles — remember it
+                        // so the next launch can offer to resume (covers a channel closed
+                        // out from under us as well as our own coop close).
+                        CacheManager.setWalletRemovalInProgress(true)
                         self.showAlert(presentingController: self, title: Language.getWord(withID: "removewallet"), message: Language.getWord(withID: "stillclosing"), buttons: [Language.getWord(withID: "okay")], actions: nil)
                     }
                 }
@@ -147,10 +150,17 @@ extension CoreViewController {
     
     @objc func closeChannelConfirmed() {
         self.hideAlert()
-        
+
         self.fullViewCover.alpha = 0.8
         self.genericSpinner.startAnimating()
-        
+
+        // The user has confirmed the close, so the manual removal is now committed.
+        // Mark it in progress so it resumes on the next launch if it doesn't finish
+        // this session. (The incorrect-PIN lockout has its own resume path.)
+        if !self.removingWalletForIncorrectPin {
+            CacheManager.setWalletRemovalInProgress(true)
+        }
+
         guard isConnectedToPeer() else {
             Task {
                 let didConnectToPeer = await BitcoinManager.shared.connectToLightningPeer()
@@ -227,6 +237,10 @@ extension CoreViewController {
         // force-close attempt until a terminal alert appears.
         self.fullViewCover.alpha = 0.8
         self.genericSpinner.startAnimating()
+
+        // Force close is a manual-only path; the removal is committed, so mark it
+        // in progress to resume on the next launch if it doesn't finish.
+        CacheManager.setWalletRemovalInProgress(true)
 
         if let closingChannel = BitcoinManager.shared.listChannels().getActiveChannel() {
             // Try force close (unilateral closure)

--- a/ios/bittr/Core/ResetApp.swift
+++ b/ios/bittr/Core/ResetApp.swift
@@ -148,6 +148,9 @@ extension CoreViewController {
     @objc func closeChannelConfirmed() {
         self.hideAlert()
         
+        self.fullViewCover.alpha = 0.8
+        self.genericSpinner.startAnimating()
+        
         guard isConnectedToPeer() else {
             Task {
                 let didConnectToPeer = await BitcoinManager.shared.connectToLightningPeer()
@@ -186,6 +189,8 @@ extension CoreViewController {
                         self.genericSpinner.stopAnimating()
                         self.showAlert(presentingController: self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "closeretrylater"), buttons: [Language.getWord(withID: "okay")], actions: nil)
                     } else {
+                        self.genericSpinner.stopAnimating()
+                        self.fullViewCover.alpha = 0
                         self.showAlert(presentingController: self, title: Language.getWord(withID: "closechannel6"), message: Language.getWord(withID: "closechannel7"), buttons: [Language.getWord(withID: "cancel"), Language.getWord(withID: "forceclose")], actions: [nil, #selector(self.forceCloseChannel)])
                     }
                 }
@@ -217,7 +222,12 @@ extension CoreViewController {
 
     @objc func forceCloseChannel() {
         self.hideAlert()
-        
+
+        // Same as closeChannelConfirmed: keep the cover + spinner up during the
+        // force-close attempt until a terminal alert appears.
+        self.fullViewCover.alpha = 0.8
+        self.genericSpinner.startAnimating()
+
         if let closingChannel = BitcoinManager.shared.listChannels().getActiveChannel() {
             // Try force close (unilateral closure)
             Log.info("Attempting force close for channel.")
@@ -232,6 +242,8 @@ extension CoreViewController {
                         scope.setExtra(value: "ResetApp row 213", key: "context")
                     }
                     if !self.removingWalletForIncorrectPin {
+                        self.genericSpinner.stopAnimating()
+                        self.fullViewCover.alpha = 0
                         self.showAlert(presentingController: self, title: Language.getWord(withID: "closechannel"), message: Language.getWord(withID: "forceclose3"), buttons: [Language.getWord(withID: "okay")], actions: nil)
                     }
                 }

--- a/ios/bittr/Core/ResetApp.swift
+++ b/ios/bittr/Core/ResetApp.swift
@@ -71,6 +71,7 @@ extension CoreViewController {
                 if !self.removingWalletForIncorrectPin {
                     self.genericSpinner.stopAnimating()
                     self.fullViewCover.alpha = 0
+                    CacheManager.setWalletRemovalInProgress(true)
                 }
                 
                 if BitcoinManager.shared.listChannels().getActiveChannel() != nil {
@@ -120,7 +121,20 @@ extension CoreViewController {
             await self.startWallet()
         }
     }
-    
+
+    @objc func resumeWalletRemoval() {
+        Log.info("Resume wallet removal.")
+        self.hideAlert()
+        self.resettingPin = true
+        self.startWalletInBackground()
+    }
+
+    @objc func cancelWalletRemoval() {
+        Log.info("Cancel wallet removal.")
+        self.hideAlert()
+        CacheManager.setWalletRemovalInProgress(false)
+    }
+
     @objc func walletRestoreAlert() {
         self.hideAlert()
         self.showAlert(presentingController: self, title: Language.getWord(withID: "removewallet"), message: Language.getWord(withID: "restorewallet3"), buttons: [Language.getWord(withID: "cancel"), Language.getWord(withID: "remove")], actions: [nil, #selector(self.performWalletReset)])
@@ -250,6 +264,9 @@ extension CoreViewController {
         // Reset PIN reset state
         self.resettingPin = false
         self.removingWalletForIncorrectPin = false
+        
+        // Removal finished — clear the resume-on-launch flag.
+        CacheManager.setWalletRemovalInProgress(false)
         
         // Clear mnemonic from cache
         CacheManager.deleteClientInfo()

--- a/ios/bittr/Helpers/TestIDs.swift
+++ b/ios/bittr/Helpers/TestIDs.swift
@@ -258,6 +258,7 @@ enum TestID {
             enum PinSet {
                 static let topLabel = "signup.restore.pinSet.topLabel"
             }
+            static let removeWalletButton = "signup.restore.removeWalletButton"
             static let topLabel = "signup.restore.topLabel"
         }
     }

--- a/ios/bittr/Language.swift
+++ b/ios/bittr/Language.swift
@@ -370,6 +370,7 @@ class Language: NSObject {
             "swapid": "Swap ID",
             "removewalletfromdevice": "Remove wallet",
             "removewallet1": "Are you sure you want to remove this wallet from your device?\n\nYou can restore the wallet using your recovery phrase.",
+            "removalinprogress": "It looks like you started removing this wallet from your device, but it wasn't finished — a Lightning connection may still have been closing.\n\nWould you like to try removing it again?",
             "swapquestion": "Swap status",
             "swapquestionswapcreated0": "We've initiated the swap of your funds from onchain to lightning, but no funds have been moved yet.",
             "swapquestionswapcreated1": "We've initiated the swap of your funds from lightning to onchain, but no funds have been moved yet.",

--- a/ios/bittr/Signup/Restore Wallet/RestoreViewController.swift
+++ b/ios/bittr/Signup/Restore Wallet/RestoreViewController.swift
@@ -85,6 +85,7 @@ class RestoreViewController: UIViewController, UITextFieldDelegate {
         self.mnemonic10.accessibilityIdentifier = TestID.Signup.Restore.field10
         self.mnemonic11.accessibilityIdentifier = TestID.Signup.Restore.field11
         self.mnemonic12.accessibilityIdentifier = TestID.Signup.Restore.field12
+        self.removeWalletButton.accessibilityIdentifier = TestID.Signup.Restore.removeWalletButton
 
         // Corner radii
         self.mnemonicView.layer.cornerRadius = 13

--- a/shared/flows/README.md
+++ b/shared/flows/README.md
@@ -58,6 +58,11 @@ shared/flows/
     remove_wallet.yaml    Settings → Device details → Remove wallet. Handles
                           both branches (active channel → close → mine →
                           re-trigger; no channel → direct confirm).
+    forgot_pin_remove_wallet.yaml
+                          Forgot PIN → Reset → RestoreVC → Remove wallet. The
+                          resettingPin removal, same two branches as
+                          remove_wallet.yaml. Destructive (drops to Signup1);
+                          no MNEMONIC env var needed.
     wrong_pin.yaml        PIN lockout from the unlock screen — ten wrong
                           PINs wipe the wallet and drop back to Signup1
                           (run onboarding/restore_wallet.yaml first).
@@ -126,7 +131,7 @@ Don't run `maestro test shared/flows/` to get the whole suite: a folder run
 executes flows in alphabetical order with no dependency awareness, but the
 feature flows deliberately share wallet state and several are destructive
 (`send_onchain_all` drains the onchain balance; `wrong_pin` / `remove_wallet`
-wipe the wallet). `suite.yaml` is a hand-ordered orchestrator that runs them so
+/ `forgot_pin_remove_wallet` wipe the wallet). `suite.yaml` is a hand-ordered orchestrator that runs them so
 dependencies hold and the wipes come last; `test_suite.sh` wraps it, starting
 the `push`/`clipboard` helper servers (which Maestro can't start itself) and
 passing the `MNEMONIC` env that `forgot_pin` needs. A failure aborts the suite

--- a/shared/flows/features/forgot_pin_remove_wallet.yaml
+++ b/shared/flows/features/forgot_pin_remove_wallet.yaml
@@ -23,12 +23,14 @@
 # alert (alert.button.1) is showing — the same structural test remove_wallet.yaml
 # relies on, since Maestro reads the attributed-text alert body unreliably.
 #
-# Prerequisite: an existing wallet on the simulator. The flow preserves state
-# (no clearState / clearKeychain) — same starting style as remove_wallet.yaml /
-# forgot_pin.yaml. The simulator may have an open channel (e.g. after
-# buy_incoming.yaml) or none (after restore_wallet.yaml); the conditional
-# close-channel arc handles both. Unlike forgot_pin.yaml this needs no MNEMONIC
-# env var — it removes the wallet rather than verifying the recovery phrase.
+# Self-provisioning: if the device has no wallet (the app launches to the
+# create-wallet signup screen), the flow creates one WITH an open Lightning
+# channel — via helpers/create_wallet_with_channel.yaml (happy_path onboarding +
+# buy_incoming) — so the removal exercises the channel-close + resume arc. If a
+# wallet already exists it's used as-is (it may or may not have a channel; the
+# conditional close-channel arc handles both). The flow otherwise preserves
+# state (no clearState / clearKeychain). Unlike forgot_pin.yaml this needs no
+# MNEMONIC env var — it removes the wallet rather than verifying the phrase.
 #
 # This flow is destructive: it removes the wallet and drops back to Signup1.
 #
@@ -38,9 +40,17 @@ appId: com.bittr.bittr-regtest
 ---
 - launchApp
 
-# Wallet was set up previously, so launch lands on the PIN unlock screen
-# (PinVC in .core embedding). Fail loudly otherwise — there'd be no wallet
-# to remove.
+# Self-provision a wallet WITH a Lightning channel if there's none — i.e. the
+# app launched to the create-wallet signup screen. Skipped if a wallet exists.
+- runFlow:
+    when:
+      visible:
+        id: "signup.create.start.createWalletButton"
+    file: ../helpers/create_wallet_with_channel.yaml
+
+# Land on the locked PIN unlock screen (relaunch — a freshly-provisioned or an
+# existing wallet both lock on launch). Fail loudly otherwise: no wallet to remove.
+- launchApp
 - assertVisible:
     id: "unlock.topLabel"
 - takeScreenshot: shared/docs/screenshots/forgot_pin_remove_wallet/01_unlock

--- a/shared/flows/features/forgot_pin_remove_wallet.yaml
+++ b/shared/flows/features/forgot_pin_remove_wallet.yaml
@@ -1,0 +1,172 @@
+# Feature test: removing the wallet via the Forgot-PIN path.
+#
+#   Unlock screen → Forgot PIN → Reset → RestoreVC (Restore1) → Remove wallet
+#   → confirm Remove wallet → wallet wipes → Signup1.
+#
+# This is the resettingPin removal (RestoreVC.removeWalletButtonTapped →
+# ResetApp.restoreWalletTapped), as opposed to remove_wallet.yaml which drives
+# the same reset from Settings → Device details while signed in. Covers both
+# branches of restoreWalletTapped:
+#   • No active Lightning channel — confirm + reset straight to Signup1
+#     (always the tail of this flow).
+#   • Active Lightning channel — close the connection on-chain first, mine to
+#     confirm, dismiss the .channelClosed QuestionVC, acknowledge the
+#     "still closing" alert, then fully close and reopen the app. The deferred
+#     removal persisted CacheManager.walletRemovalInProgress, so the relaunch
+#     surfaces the "try removing again?" prompt (showPinOrSignup); tapping
+#     Remove wallet resumes it and lands on Signup1.
+#
+# Branch detection: after confirming Remove wallet the wipe syncs behind the
+# full-screen genericSpinner, then lands on either the restorewallet4
+# "close your connection(s)" alert (channel) or Signup1 (no channel). We let
+# the spinner settle (waitForAnimationToEnd) and branch on whether a two-button
+# alert (alert.button.1) is showing — the same structural test remove_wallet.yaml
+# relies on, since Maestro reads the attributed-text alert body unreliably.
+#
+# Prerequisite: an existing wallet on the simulator. The flow preserves state
+# (no clearState / clearKeychain) — same starting style as remove_wallet.yaml /
+# forgot_pin.yaml. The simulator may have an open channel (e.g. after
+# buy_incoming.yaml) or none (after restore_wallet.yaml); the conditional
+# close-channel arc handles both. Unlike forgot_pin.yaml this needs no MNEMONIC
+# env var — it removes the wallet rather than verifying the recovery phrase.
+#
+# This flow is destructive: it removes the wallet and drops back to Signup1.
+#
+# Run: maestro test shared/flows/features/forgot_pin_remove_wallet.yaml
+
+appId: com.bittr.bittr-regtest
+---
+- launchApp
+
+# Wallet was set up previously, so launch lands on the PIN unlock screen
+# (PinVC in .core embedding). Fail loudly otherwise — there'd be no wallet
+# to remove.
+- assertVisible:
+    id: "unlock.topLabel"
+- takeScreenshot: shared/docs/screenshots/forgot_pin_remove_wallet/01_unlock
+
+# Tap "Forgot PIN".
+- tapOn:
+    id: "pin.restoreButton"
+
+# In-app alert: [Cancel, Reset]. Tap Reset (index 1) → startPinReset sets
+# resettingPin and opens RestoreVC on the recovery-phrase page.
+- assertVisible:
+    id: "alert.button.1"
+- takeScreenshot: shared/docs/screenshots/forgot_pin_remove_wallet/02_reset_alert
+- tapOn:
+    id: "alert.button.1"
+
+# RestoreVC (Restore1). In resettingPin mode it shows the "Remove wallet"
+# button beneath the mnemonic fields. We remove the wallet instead of typing
+# the phrase.
+- assertVisible:
+    id: "signup.restore.topLabel"
+- takeScreenshot: shared/docs/screenshots/forgot_pin_remove_wallet/03_restore
+- tapOn:
+    id: "signup.restore.removeWalletButton"
+
+# Confirmation alert (removewallet1): [Cancel, Remove wallet]. Tap Remove
+# wallet (index 1) → startWalletInBackground syncs the wallet behind the
+# genericSpinner, then restoreWalletTapped decides the branch.
+- assertVisible:
+    id: "alert.button.1"
+- takeScreenshot: shared/docs/screenshots/forgot_pin_remove_wallet/04_remove_confirm
+- tapOn:
+    id: "alert.button.1"
+
+# The wipe runs behind the full-screen yellow cover + genericSpinner. The
+# spinner animates for the whole sync, so wait for the screen to settle into
+# whichever state comes next — the channel-close alert, or Signup1.
+- waitForAnimationToEnd:
+    timeout: 120000
+
+# Channel-close arc — only when an active Lightning channel made the wipe
+# defer (a two-button alert is showing). When there's no channel this whole
+# block is skipped and we fall through to the Signup1 wait below.
+- runFlow:
+    when:
+      visible:
+        id: "alert.button.1"
+    commands:
+      # Alert 1 — restorewallet4 ("Please close your lightning connection(s)
+      # before restoring a wallet…"). Tap "Close connection(s)" (alert.button.1).
+      - takeScreenshot: shared/docs/screenshots/forgot_pin_remove_wallet/05_close_channel_warning
+      - tapOn:
+          id: "alert.button.1"
+
+      # Alert 2 — closechannel2 ("…funds will be deposited back into your
+      # wallet…"). Tap "Close connection(s)" again. This kicks off
+      # closeChannelConfirmed → BitcoinManager.closeChannel.
+      - extendedWaitUntil:
+          visible:
+            id: "alert.button.1"
+          timeout: 10000
+      - takeScreenshot: shared/docs/screenshots/forgot_pin_remove_wallet/06_funds_warning
+      - tapOn:
+          id: "alert.button.1"
+
+      # LDK processes the .channelClosed event and presents a QuestionVC over
+      # Core (launchQuestion fires for the manual reset — it's only suppressed
+      # for the incorrect-PIN wipe). Wait for it, then dismiss via the shared
+      # header down button.
+      - extendedWaitUntil:
+          visible:
+            id: "question.yellowCard"
+          timeout: 90000
+      # Let the QuestionVC finish sliding in so its text is fully rendered
+      # before the screenshot (the visibility check fires as soon as the card
+      # is detectable, mid-animation).
+      - waitForAnimationToEnd:
+          timeout: 3000
+      - takeScreenshot: shared/docs/screenshots/forgot_pin_remove_wallet/07_channel_closed_popup
+      - tapOn:
+          id: "header.downButton"
+
+      # Underneath the QuestionVC is the "still closing" alert (stillclosing,
+      # single Okay button) shown by closeChannelConfirmed after broadcasting
+      # the cooperative close. Acknowledge it; this leaves us back on RestoreVC.
+      - extendedWaitUntil:
+          visible:
+            id: "alert.button.0"
+          timeout: 10000
+      - takeScreenshot: shared/docs/screenshots/forgot_pin_remove_wallet/08_still_closing
+      - tapOn:
+          id: "alert.button.0"
+
+      # Mine 6 blocks so the channel-close transaction confirms on-chain —
+      # same count as the channel-open/close confirmation elsewhere.
+      - evalScript: ${output.blocksToMine = 6}
+      - runScript: ../scripts/mine_blocks.js
+
+      # Fully close and reopen the app instead of re-tapping in-session. The
+      # deferred removal persisted CacheManager.walletRemovalInProgress, so on
+      # relaunch showPinOrSignup proactively asks whether to resume. Relaunch
+      # also forces a fresh full sync, so the node sees the just-mined close
+      # confirmation.
+      - stopApp
+      - launchApp
+
+      # Resume prompt (removalinprogress): [Cancel, Remove wallet]. Tap Remove
+      # wallet (index 1) → resumeWalletRemoval re-syncs and, with the close now
+      # confirmed and funds settled, performWalletReset finishes the wipe.
+      - extendedWaitUntil:
+          visible:
+            id: "alert.button.1"
+          timeout: 30000
+      # Let the resume alert finish sliding in so its text is fully rendered
+      # before the screenshot.
+      - waitForAnimationToEnd:
+          timeout: 3000
+      - takeScreenshot: shared/docs/screenshots/forgot_pin_remove_wallet/09_resume_prompt
+      - tapOn:
+          id: "alert.button.1"
+
+# performWalletReset clears state, stops the node, and after a ~1s delay
+# relaunches signup on page 3 (Signup1). Allow generous slack for the sync +
+# node teardown.
+- extendedWaitUntil:
+    visible:
+      id: "signup.create.start.createWalletButton"
+    timeout: 120000
+- takeScreenshot: shared/docs/screenshots/forgot_pin_remove_wallet/10_signup1

--- a/shared/flows/helpers/create_wallet_with_channel.yaml
+++ b/shared/flows/helpers/create_wallet_with_channel.yaml
@@ -1,0 +1,15 @@
+# Reusable subflow: provisions a fresh wallet WITH an open Lightning channel,
+# by running the create-wallet onboarding (happy_path, which also completes the
+# bittr signup) and then opening a channel (buy_incoming). Assumes the app is
+# already launched and on Signup1 (no wallet present) — the caller gates this on
+# the create-wallet button being visible. Ends on Home.
+#
+# Used by forgot_pin_remove_wallet.yaml to self-provision the channel arc when
+# the device has no wallet.
+
+appId: com.bittr.bittr-regtest
+---
+- runFlow:
+    file: ../onboarding/happy_path.yaml
+- runFlow:
+    file: ../features/buy_incoming.yaml

--- a/shared/test-ids/test-ids.json
+++ b/shared/test-ids/test-ids.json
@@ -243,6 +243,7 @@
       "field11": null,
       "field12": null,
       "nextButton": null,
+      "removeWalletButton": null,
       "pinSet": {
         "topLabel": null
       },


### PR DESCRIPTION
These updates concern the RestoreViewController:

1. User opens the app.
2. User clicks "Forgot PIN".
3. In the RestoreViewController, the user taps "Remove wallet.

**Updates**
- Since app removal may now take a while, the app now caches when the user has attempted to remove their app through the RemoveViewController.
- When relaunching the app later, the app asks immediately whether the user would like to retry app deletion. If no, the app won't ask again.
- There's now a new test forgot_pin_remove_wallet.yaml to test this flow.