### PR TITLE
Various app updates and Maestro test additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ maestro test shared/flows/features/buy_signup.yaml
 # fallback). Requires an existing wallet without a bittr account (run
 # fresh_install_skip_signup.yaml first) — it only unlocks, no auto-create.
 # launchApp's permissions config makes Maestro auto-deny the iOS notification
-# dialog; at the denied-notifications gate the test taps "Continue" to finish
-# signup on-chain, ending on Buy with the payout-mode switch OFF:
+# dialog. It enters a wrong OTP first (incorrect-code alert), then the correct
+# one; at each denied-notifications gate it taps "Continue" to finish signup
+# on-chain, ending on Buy with the payout-mode switch OFF:
 maestro test shared/flows/features/buy_signup_no_notifications.yaml
 
 # Then a feature test on the resulting wallet — opens the lightning channel:

--- a/README.md
+++ b/README.md
@@ -72,11 +72,12 @@ maestro test shared/flows/onboarding/fresh_install_skip_signup.yaml
 maestro test shared/flows/onboarding/restore_wallet.yaml
 maestro test shared/flows/features/buy_signup.yaml
 
-# Buy-signup validation + notification-gate test (unhappy path). Requires an
-# existing wallet without a bittr account (run fresh_install_skip_signup.yaml
-# first) — it only unlocks, no auto-create. launchApp's permissions config
-# makes Maestro auto-deny the iOS notification dialog so the OTP step drives
-# the denied-notification UX through to the "authorize in Settings" gate:
+# Buy-signup validation + notification-gate test (unhappy path, then on-chain
+# fallback). Requires an existing wallet without a bittr account (run
+# fresh_install_skip_signup.yaml first) — it only unlocks, no auto-create.
+# launchApp's permissions config makes Maestro auto-deny the iOS notification
+# dialog; at the denied-notifications gate the test taps "Continue" to finish
+# signup on-chain, ending on Buy with the payout-mode switch OFF:
 maestro test shared/flows/features/buy_signup_no_notifications.yaml
 
 # Then a feature test on the resulting wallet — opens the lightning channel:

--- a/ios/bittr/Buy/BuyViewController.swift
+++ b/ios/bittr/Buy/BuyViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import Sentry
+import UserNotifications
 
 class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
 
@@ -316,8 +317,31 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
     
     // MARK: - Payout mode (PATCH /customer/payment-mode)
 
-    func setPaymentMode(for entity: IbanEntity, newMode: String, isRetry: Bool = false) {
-
+    func setPaymentMode(for entity: IbanEntity, newMode: String) {
+        if newMode == "lightning" {
+            self.hasAcceptedPushNotifications { hasAccepted in
+                if hasAccepted {
+                    self.proceedWithApiCall(for: entity, newMode: newMode)
+                } else {
+                    Log.info("Notifications not authorized; blocking switch to lightning.")
+                    self.reloadCard(for: entity)
+                    self.showAlert(presentingController: self, title: Language.getWord(withID: "receivenotifications"), message: Language.getWord(withID: "lightningneedsnotifications"), buttons: [Language.getWord(withID: "okay")], actions: nil)
+                }
+            }
+        } else {
+            self.proceedWithApiCall(for: entity, newMode: newMode)
+        }
+    }
+    
+    func hasAcceptedPushNotifications(completion: @escaping (Bool) -> Void) {
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            DispatchQueue.main.async {
+                completion(settings.authorizationStatus == .authorized)
+            }
+        }
+    }
+    
+    func proceedWithApiCall(for entity: IbanEntity, newMode: String, isRetry: Bool = false) {
         // The lightning node must be running to sign the request.
         guard BitcoinManager.shared.ldkNode != nil, let pubkey = BitcoinManager.shared.nodeId() else {
             Log.info("Lightning not ready for payment mode update.")
@@ -325,7 +349,7 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
             self.showAlert(presentingController: self, title: Language.getWord(withID: "lightningnotready"), message: Language.getWord(withID: "syncingwallet2"), buttons: [Language.getWord(withID: "okay")], actions: nil)
             return
         }
-
+        
         let depositCode = entity.yourUniqueCode
         let timestamp = Int(Date().timeIntervalSince1970)
         let message = "payment_mode:\(pubkey):\(depositCode):\(newMode):\(timestamp)"
@@ -379,7 +403,7 @@ class BuyViewController: UIViewController, UITextFieldDelegate, UICollectionView
                             // Retry.
                             if serverError.lowercased().contains("expired timestamp"), !isRetry {
                                 // Stale timestamp — rebuild with a fresh one and retry once.
-                                self.setPaymentMode(for: entity, newMode: newMode, isRetry: true)
+                                self.proceedWithApiCall(for: entity, newMode: newMode, isRetry: true)
                                 return
                             }
                             self.handlePaymentModeError(serverError, for: entity)

--- a/ios/bittr/Extensions/UIViewController.swift
+++ b/ios/bittr/Extensions/UIViewController.swift
@@ -174,7 +174,7 @@ extension UIViewController {
                                 }
                             }
                         }
-                    }   
+                    }
 
                 case .authorized, .provisional, .ephemeral:
                     // Already authorized in some form — register and let
@@ -195,13 +195,16 @@ extension UIViewController {
             }
         }
     }
+}
+
+extension CoreViewController {
     
-    func getCorrectBitcoinValue(coreVC:CoreViewController) -> BitcoinValue {
+    func getCorrectBitcoinValue() -> BitcoinValue {
         
         let bitcoinValue = BitcoinValue()
-        bitcoinValue.currentValue = coreVC.bittrWallet.valueInEUR ?? 0.0
+        bitcoinValue.currentValue = self.bittrWallet.valueInEUR ?? 0.0
         if UserDefaults.standard.value(forKey: "currency") as? String == "CHF" {
-            bitcoinValue.currentValue = coreVC.bittrWallet.valueInCHF ?? 0.0
+            bitcoinValue.currentValue = self.bittrWallet.valueInCHF ?? 0.0
             bitcoinValue.chosenCurrency = "CHF"
             bitcoinValue.apiUrl = "https://getbittr.com/api/price/btc/historical/chf"
         }

--- a/ios/bittr/Helpers/TestIDs.swift
+++ b/ios/bittr/Helpers/TestIDs.swift
@@ -272,6 +272,7 @@ enum TestID {
     enum SwapStatus {
         static let confirmCard = "swapStatus.confirmCard"
         static let confirmStatusLabel = "swapStatus.confirmStatusLabel"
+        static let refreshButton = "swapStatus.refreshButton"
     }
     enum Transaction {
         static let labelAmount = "transaction.labelAmount"

--- a/ios/bittr/Helpers/TestIDs.swift
+++ b/ios/bittr/Helpers/TestIDs.swift
@@ -14,11 +14,11 @@ enum TestID {
         static let continueButton = "buy.continueButton"
         static let downButton = "buy.downButton"
         static let headerLabel = "buy.headerLabel"
+        static let paymentModeButton = "buy.paymentModeButton"
+        static let paymentModeSwitch = "buy.paymentModeSwitch"
         static let yourCode = "buy.yourCode"
         static let yourEmail = "buy.yourEmail"
         static let yourIban = "buy.yourIban"
-        static let paymentModeSwitch = "buy.paymentModeSwitch"
-        static let paymentModeButton = "buy.paymentModeButton"
     }
     enum Device {
         enum Darkmode {
@@ -33,10 +33,8 @@ enum TestID {
             static let devicetoken = "device.row.devicetoken"
             static let language = "device.row.language"
             static let lightningchannels = "device.row.lightningchannels"
-            static let notification = "device.row.notification"
             static let pendingpayouts = "device.row.pendingpayouts"
             static let publickey = "device.row.publickey"
-            static let purchases = "device.row.purchases"
             static let restore = "device.row.restore"
         }
     }

--- a/ios/bittr/Home/HistoryTable.swift
+++ b/ios/bittr/Home/HistoryTable.swift
@@ -52,7 +52,7 @@ extension HomeViewController {
             cell.satsLabel.text = "\(plusSymbol) \(String(thisTransaction.received - thisTransaction.sent - thisTransaction.fee).addSpaces().replacingOccurrences(of: "-", with: "")) sats".replacingOccurrences(of: "  ", with: " ")
             
             // Conversion
-            let bitcoinValue = self.getCorrectBitcoinValue(coreVC: self.coreVC!)
+            let bitcoinValue = self.coreVC!.getCorrectBitcoinValue()
             let transactionValue = (thisTransaction.received - thisTransaction.sent - thisTransaction.fee).inBTC()
             var balanceValue = String(Int((transactionValue*bitcoinValue.currentValue).rounded()))
             balanceValue = balanceValue.addSpaces().replacingOccurrences(of: "-", with: "")

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -371,7 +371,7 @@ extension HomeViewController {
         if self.coreVC == nil { return "" }
         
         // Use preferred currency.
-        let bitcoinValue = self.getCorrectBitcoinValue(coreVC: self.coreVC!)
+        let bitcoinValue = self.coreVC!.getCorrectBitcoinValue()
         
         // Converted balance string.
         let balanceValue = String(Int((btcValue*bitcoinValue.currentValue).rounded())).addSpaces()
@@ -439,7 +439,7 @@ extension HomeViewController {
         var accumulatedCurrentValue = 0
 
         // Get preferred currency.
-        let bitcoinValue = self.getCorrectBitcoinValue(coreVC: self.coreVC!)
+        let bitcoinValue = self.coreVC!.getCorrectBitcoinValue()
 
         // Total profit over every Bittr purchase currently on screen. Derive the
         // set straight from visibleTransactions instead of bittrTransactions.count:

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -43,7 +43,7 @@ extension HomeViewController {
         
         Task {
             // Check whether transactions were Bittr purchases.
-            _ = await self.getBittrTransactionDetails(sendAll: false)
+            _ = await self.getBittrTransactionDetails()
             
             DispatchQueue.main.async {
                 self.updateTransactionHistory()
@@ -129,8 +129,7 @@ extension HomeViewController {
     }
     
     
-    func getBittrTransactionDetails(sendAll:Bool) async -> Bool {
-        
+    func getBittrTransactionDetails() async -> Bool {
         // Check if transactions were Bittr purchases with the Bittr API.
         
         // Get this user's unique Bittr codes.
@@ -146,30 +145,22 @@ extension HomeViewController {
         }
         
         // Create array of transaction IDs to send to Bittr.
+        // Only send new transaction IDs to Bittr.
         var sendableTxIDs = [String]()
-        if sendAll {
-            // Send all transaction IDs to Bittr again.
-            for eachTransaction in self.visibleTransactions {
-                sendableTxIDs += [eachTransaction.id]
-            }
-        } else {
-            // Only send new transaction IDs to Bittr.
             
-            // Add all lightning payment IDs.
-            for eachPayment in self.coreVC!.bittrWallet.allTransactions {
-                let txID = eachPayment.kind.transactionID ?? eachPayment.id
-                if eachPayment.status == .succeeded, eachPayment.direction == .inbound, !CacheManager.getSentToBittr().contains(txID) {
-                    sendableTxIDs += [txID]
-                }
+        // Add all lightning payment IDs.
+        for eachPayment in self.coreVC!.bittrWallet.allTransactions {
+            let txID = eachPayment.kind.transactionID ?? eachPayment.id
+            if eachPayment.status == .succeeded, eachPayment.direction == .inbound, !CacheManager.getSentToBittr().contains(txID) {
+                sendableTxIDs += [txID]
             }
-            
-            // Add funding transaction ID.
-            if
-                let cachedFundingTxID = CacheManager.getTxoID(),
-                !(CacheManager.getSentToBittr().contains(cachedFundingTxID) &&
-                self.visibleTransactions.contains(where: { transaction in transaction.id == cachedFundingTxID})) {
-                sendableTxIDs += [cachedFundingTxID]
-            }
+        }
+        
+        // Add funding transaction ID.
+        if let cachedFundingTxID = CacheManager.getTxoID(),
+            !(CacheManager.getSentToBittr().contains(cachedFundingTxID) &&
+            self.visibleTransactions.contains(where: { transaction in transaction.id == cachedFundingTxID})) {
+            sendableTxIDs += [cachedFundingTxID]
         }
         
         // Add previously cached transactions to Bittr transactions array.
@@ -208,52 +199,18 @@ extension HomeViewController {
             return false
         }
         
-        // There are Bittr transactions.
-        // Check if any information is new.
-        var newTransactionsWereFound = false
-        
         for eachTransaction in bittrApiTransactions {
             self.bittrTransactions.updateValue(eachTransaction, forKey: eachTransaction.txId)
             
             if let cachedFundingTxID = CacheManager.getTxoID(), eachTransaction.txId == cachedFundingTxID {
                 // This is a channel funding transaction.
                 let thisTransaction = eachTransaction.createTransaction(coreVC: self.coreVC, isFundingTransaction: true)
-                
-                newTransactionsWereFound = true
                 self.newTransactions += [thisTransaction]
                 CacheManager.storeLightningTransaction(thisTransaction: thisTransaction)
-                
-            } else if sendAll {
-                // Check transactions that were previously not recognized.
-                for eachExistingTransaction in self.visibleTransactions {
-                    if eachExistingTransaction.id == eachTransaction.txId {
-                        newTransactionsWereFound = true
-                        eachExistingTransaction.isBittr = true
-                        eachExistingTransaction.fiatNetAmount = eachTransaction.fiatNetAmount.toNumber()
-                        eachExistingTransaction.fiatGrossAmount = eachTransaction.fiatGrossAmount.toNumber()
-                        eachExistingTransaction.currency = eachTransaction.currency
-                        let transferFee = eachTransaction.transferFee.toNumber().inSatoshis()
-                        eachExistingTransaction.transferFee = CGFloat(transferFee)
-                        eachExistingTransaction.surcharge = eachTransaction.surcharge.toNumber()
-                        eachExistingTransaction.bittrFee = eachTransaction.bittrFee.toNumber()
-                        eachExistingTransaction.historicalExchangeRate = eachTransaction.historicalExchangeRate.toNumber()
-                        if eachExistingTransaction.isLightning {
-                            CacheManager.storeLightningTransaction(thisTransaction: eachExistingTransaction)
-                        }
-                    }
-                }
             }
         }
         
-        if sendAll {
-            if newTransactionsWereFound {
-                CacheManager.updateCachedData(data: self.visibleTransactions, key: "transactions")
-                self.homeTableView.reloadData()
-            }
-            return newTransactionsWereFound
-        } else {
-            return true
-        }
+        return true
     }
     
     

--- a/ios/bittr/Language.swift
+++ b/ios/bittr/Language.swift
@@ -223,6 +223,8 @@ class Language: NSObject {
             "bittrnotificationfail": "Something went wrong processing the notification we sent to you. Please contact support@getbittr.com if you have any questions.",
             "pinlock": "You've entered an incorrect PIN too many times. Please restore your wallet.",
             "incorrectpin2": "Please enter your correct PIN. If you've forgotten it, please restore your wallet.",
+            "pinattemptsleft": "You have <attempts> attempts left.",
+            "pinattemptleft": "You have 1 attempt left.",
             "restorewallet2": "Are you sure you'd like to remove this wallet from your device?\n\nOnly remove your wallet if you're sure you've properly backed up your wallet.",
             "restore": "Restore",
             "restorewallet3": "Are you sure you want to remove your wallet from this device?",

--- a/ios/bittr/Language.swift
+++ b/ios/bittr/Language.swift
@@ -276,6 +276,7 @@ class Language: NSObject {
             "receivenotifications": "Receive notifications",
             "receivenotifications2": "To receive instant bitcoin payments, you must allow notifications.\n\nWithout notifications, you cannot receive payments to your wallet.",
             "receivenotifications3": "To receive instant bitcoin payments, you must allow notifications.\n\nOn your device, go to Settings > Notifications > bittr to authorize our notifications.\n\nYou're free to continue without notifications, but then all your purchases will be paid into the regular (on-chain) part of your wallet.",
+            "lightningneedsnotifications": "Lightning payouts are delivered via push notifications, so you must allow notifications to switch to lightning.\n\nOn your device, go to Settings > Notifications > bittr to authorize our notifications, then try again.",
             "verificationfail": "Please enter the correct verification code.",
             "bittrsignupfail": "Something went wrong creating your account. Please try again.",
             "bittrsignupfail2": "The IBAN you've entered appears to be invalid. Please enter a valid IBAN.",

--- a/ios/bittr/Language.swift
+++ b/ios/bittr/Language.swift
@@ -275,7 +275,7 @@ class Language: NSObject {
             "screenshot3": "We couldn't save your screenshot. Try taking a screenshot manually.",
             "receivenotifications": "Receive notifications",
             "receivenotifications2": "To receive instant bitcoin payments, you must allow notifications.\n\nWithout notifications, you cannot receive payments to your wallet.",
-            "receivenotifications3": "To receive instant bitcoin payments, you must allow notifications.\n\nOn your device, go to Settings > Notifications > bittr to authorize our notifications.",
+            "receivenotifications3": "To receive instant bitcoin payments, you must allow notifications.\n\nOn your device, go to Settings > Notifications > bittr to authorize our notifications.\n\nYou're free to continue without notifications, but then all your purchases will be paid into the regular (on-chain) part of your wallet.",
             "verificationfail": "Please enter the correct verification code.",
             "bittrsignupfail": "Something went wrong creating your account. Please try again.",
             "bittrsignupfail2": "The IBAN you've entered appears to be invalid. Please enter a valid IBAN.",

--- a/ios/bittr/Move, Send, Receive/MoveVC/MoveViewController.swift
+++ b/ios/bittr/Move, Send, Receive/MoveVC/MoveViewController.swift
@@ -74,7 +74,7 @@ class MoveViewController: UIViewController {
         // Calculate balance values.
         let correctBtcBalance:CGFloat = self.coreVC!.bittrWallet.satoshisOnchain.inBTC()
         let correctBtclnBalance:CGFloat = self.coreVC!.bittrWallet.satoshisLightning.inBTC()
-        let bitcoinValue = self.getCorrectBitcoinValue(coreVC: self.coreVC!)
+        let bitcoinValue = self.coreVC!.getCorrectBitcoinValue()
         let balanceValue = String(Int(((correctBtcBalance+correctBtclnBalance)*bitcoinValue.currentValue).rounded())).addSpaces()
         let btcBalanceValue = String(Int(((correctBtcBalance)*bitcoinValue.currentValue).rounded())).addSpaces()
         let btclnBalanceValue = String(Int(((correctBtclnBalance)*bitcoinValue.currentValue).rounded())).addSpaces()

--- a/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveViewController.swift
+++ b/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveViewController.swift
@@ -197,7 +197,7 @@ class ReceiveViewController: UIViewController, UITextFieldDelegate, UIContextMen
                     return self.bothAmountTextField.text!.trimmingCharacters(in: .whitespacesAndNewlines).toNumber()
                 } else if self.selectedCurrency == .currency {
                     let fiatAmount = self.bothAmountTextField.text!.trimmingCharacters(in: .whitespacesAndNewlines).toNumber()
-                    let bitcoinValue = self.getCorrectBitcoinValue(coreVC: self.coreVC!)
+                    let bitcoinValue = self.coreVC!.getCorrectBitcoinValue()
                     let btcAmount = fiatAmount / bitcoinValue.currentValue
                     
                     // Safety check for invalid values
@@ -583,7 +583,7 @@ class ReceiveViewController: UIViewController, UITextFieldDelegate, UIContextMen
         let satsOption = UIAlertAction(title: "Satoshis", style: .default) { (action) in
             self.selectSatsCurrency()
         }
-        let bitcoinValue = self.getCorrectBitcoinValue(coreVC: self.coreVC!)
+        let bitcoinValue = self.coreVC!.getCorrectBitcoinValue()
         let currencyOption = UIAlertAction(title: bitcoinValue.chosenCurrency, style: .default) { (action) in
             self.selectFiatCurrency()
         }

--- a/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveViewController.swift
+++ b/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveViewController.swift
@@ -274,7 +274,9 @@ class ReceiveViewController: UIViewController, UITextFieldDelegate, UIContextMen
                 self.lowerAddressLabel.text = ""
                 qrCode = "bitcoin:\(onchainAddress)\(amountText)".uppercased().toBigQRCode()!
                 self.hideLowerAddress()
-                self.currentCopyableText = "bitcoin:\(onchainAddress)\(amountText)"
+                self.currentCopyableText = amountText.isEmpty
+                    ? onchainAddress
+                    : "bitcoin:\(onchainAddress)\(amountText)"
             case .lightning:
                 self.addressTitle.text = Language.getWord(withID: "invoice")
                 self.addressLabel.text = ""

--- a/ios/bittr/Move, Send, Receive/SendVC/Confirm/ConfirmSendViewController.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/Confirm/ConfirmSendViewController.swift
@@ -118,7 +118,7 @@ class ConfirmSendViewController: UIViewController {
         // Amount
         self.amountLabel.text = self.sendVC!.confirmSatoshis.inBTC().formattedBitcoin() + " BTC"
         // Fiat amount
-        let bitcoinValue = self.getCorrectBitcoinValue(coreVC: self.coreVC!)
+        let bitcoinValue = self.coreVC!.getCorrectBitcoinValue()
         self.amountFiatLabel.text = self.formattedFiatAmount()
         
         // Fees
@@ -184,34 +184,20 @@ class ConfirmSendViewController: UIViewController {
         case .custom: satsPerVbyte = customFees ?? 0
         }
         let satsValue = CGFloat(satsPerVbyte*transactionSize)
-        let bitcoinValue = self.getCorrectBitcoinValue(coreVC: self.coreVC!)
-        // satsText is dot-decimal here (Swift Double interpolation), so pad a
-        // single trailing decimal digit to two (e.g. "0.5" -> "0.50").
-        var satsText = "\(CGFloat(Int((satsValue.inBTC()*bitcoinValue.currentValue)*100))/100)"
-        if String(satsText.split(separator: ".")[1]).count == 1 {
-            satsText = satsText + "0"
-        }
-        // Localize the decimal separator to match the rest of the app (e.g.
-        // "0,50" in comma locales) — same fix as formattedFiatAmount().
-        return satsText.fixDecimals()
+        let bitcoinValue = self.coreVC!.getCorrectBitcoinValue()
+        // Fiat fee, rounded to two decimals and formatted with the device's
+        // decimal separator (e.g. "0,50" in comma locales).
+        let fiatValue = satsValue.inBTC() * bitcoinValue.currentValue
+        return fiatValue.twoDecimals().toString()
     }
 
     // Formats the fiat send amount with two decimals, e.g. "4.99 €" (or "4,99 €"
-    // in comma locales — see the fixDecimals() note below).
+    // in comma locales). twoDecimals() rounds to 2 places and toString() formats
+    // with the device's decimal separator, padded to two decimals.
     func formattedFiatAmount() -> String {
-        let bitcoinValue = self.getCorrectBitcoinValue(coreVC: self.coreVC!)
-        let fiatValue = CGFloat(self.sendVC!.confirmSatoshis.inBTC() * bitcoinValue.currentValue)
-        // fiatText is dot-decimal here (Swift's Double interpolation always uses
-        // "."), so pad a single trailing decimal digit to two (e.g. "4.9" -> "4.90").
-        var fiatText = "\(CGFloat(Int(fiatValue * 100)) / 100)"
-        if String(fiatText.split(separator: ".")[1]).count == 1 {
-            fiatText = fiatText + "0"
-        }
-        // Convert the "." to the device locale's decimal separator so the amount
-        // matches how the rest of the app formats numbers (e.g. "4,99" in comma
-        // locales). Previously the raw dot-decimal string was returned, so the
-        // confirm screen showed "4.99" regardless of locale.
-        return "\(fiatText.fixDecimals()) \(bitcoinValue.chosenCurrency)"
+        let bitcoinValue = self.coreVC!.getCorrectBitcoinValue()
+        let fiatValue = self.sendVC!.confirmSatoshis.inBTC() * bitcoinValue.currentValue
+        return "\(fiatValue.twoDecimals().toString()) \(bitcoinValue.chosenCurrency)"
     }
 
     @IBAction func feeButtonTapped(_ sender: UIButton) {

--- a/ios/bittr/Move, Send, Receive/SendVC/Send/SendViewController.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/Send/SendViewController.swift
@@ -483,7 +483,7 @@ class SendViewController: UIViewController, UITextFieldDelegate {
         // Use the shared custom alert (same component as ReceiveViewController's
         // More type picker) rather than a standard iOS action sheet.
         // Buttons: [Cancel, Bitcoin, Satoshis, <fiat currency>].
-        let bitcoinValue = self.getCorrectBitcoinValue(coreVC: self.coreVC!)
+        let bitcoinValue = self.coreVC!.getCorrectBitcoinValue()
         self.showAlert(presentingController: self, title: Language.getWord(withID: "selectcurrency"), message: Language.getWord(withID: "selectcurrencymessage"), buttons: [Language.getWord(withID: "cancel"), "Bitcoin", "Satoshis", bitcoinValue.chosenCurrency], actions: [nil, #selector(self.tappedBitcoinCurrency), #selector(self.tappedSatsCurrency), #selector(self.tappedFiatCurrency)])
     }
 

--- a/ios/bittr/Move, Send, Receive/SendVC/SendLNURL.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/SendLNURL.swift
@@ -38,7 +38,7 @@ extension SendViewController {
             enteredAmount = amountText.toNumber().inSatoshis() * 1000 // Convert to millisatoshis
         } else { // .currency (fiat)
             let fiatAmount = amountText.toNumber()
-            let bitcoinValue = self.getCorrectBitcoinValue(coreVC: self.coreVC!)
+            let bitcoinValue = self.coreVC!.getCorrectBitcoinValue()
             let btcAmount = fiatAmount / bitcoinValue.currentValue
             
             // Safety check for invalid values

--- a/ios/bittr/Move, Send, Receive/SendVC/SendLightning.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/SendLightning.swift
@@ -29,7 +29,7 @@ extension SendViewController {
             return btcAmount.inSatoshis()
         case .currency:
             let fiatAmount = enteredAmount.toNumber()
-            let bitcoinValue = self.getCorrectBitcoinValue(coreVC: self.coreVC!)
+            let bitcoinValue = self.coreVC!.getCorrectBitcoinValue()
             let btcAmount = fiatAmount / bitcoinValue.currentValue
             
             guard btcAmount.isFinite && !btcAmount.isNaN && bitcoinValue.currentValue > 0 else {

--- a/ios/bittr/Move, Send, Receive/SendVC/SendOnchain.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/SendOnchain.swift
@@ -43,7 +43,7 @@ extension SendViewController {
         switch self.selectedCurrency {
         case .bitcoin: divideBy = 1
         case .satoshis: divideBy = 100000000
-        case .currency: divideBy = self.getCorrectBitcoinValue(coreVC: self.coreVC!).currentValue
+        case .currency: divideBy = self.coreVC!.getCorrectBitcoinValue().currentValue
         }
         self.onchainAmountInSatoshis = (enteredAmount/divideBy).inSatoshis()
         

--- a/ios/bittr/Pin/PinViewController.swift
+++ b/ios/bittr/Pin/PinViewController.swift
@@ -221,17 +221,24 @@ class PinViewController: UIViewController, UITextFieldDelegate, UICollectionView
                         self.removeWallet()
                         return
                     }
-                    
+
+                    // Tell the user how many tries remain before the 10-attempt
+                    // wipe (singular wording for the final attempt).
+                    let attemptsLeft = 10 - CacheManager.getFailedPinAttempts()
+                    let attemptsMessage = attemptsLeft == 1
+                        ? Language.getWord(withID: "pinattemptleft")
+                        : Language.getWord(withID: "pinattemptsleft").replacingOccurrences(of: "<attempts>", with: "\(attemptsLeft)")
+
                     // Warn well before the 10-attempt wipe and steer anyone who
                     // still has their recovery phrase to the non-destructive
                     // Forgot PIN flow — the wipe can cost them their Lightning
                     // funds, so we want them recovering by mnemonic instead.
                     if CacheManager.getFailedPinAttempts() == 3 {
-                        self.showAlert(presentingController: self.coreVC ?? self, title: Language.getWord(withID: "pinwarning"), message: Language.getWord(withID: "pinwarning2"), buttons: [Language.getWord(withID: "okay"), Language.getWord(withID: "forgotpin")], actions: [nil, #selector(self.startPinReset)])
+                        self.showAlert(presentingController: self.coreVC ?? self, title: Language.getWord(withID: "pinwarning"), message: Language.getWord(withID: "pinwarning2") + "\n\n" + attemptsMessage, buttons: [Language.getWord(withID: "okay"), Language.getWord(withID: "forgotpin")], actions: [nil, #selector(self.startPinReset)])
                         return
                     }
 
-                    self.showAlert(presentingController: self.coreVC ?? self, title: Language.getWord(withID: "incorrectpin"), message: Language.getWord(withID: "incorrectpin2"), buttons: [Language.getWord(withID: "okay")], actions: [#selector(self.clearPinField)])
+                    self.showAlert(presentingController: self.coreVC ?? self, title: Language.getWord(withID: "incorrectpin"), message: Language.getWord(withID: "incorrectpin2") + "\n\n" + attemptsMessage, buttons: [Language.getWord(withID: "okay")], actions: [#selector(self.clearPinField)])
                 }
             } else {
                 // No pin found in storage.

--- a/ios/bittr/Profits/ProfitViewController.swift
+++ b/ios/bittr/Profits/ProfitViewController.swift
@@ -46,7 +46,7 @@ class ProfitViewController: UIViewController {
         self.totalValueLabel.accessibilityIdentifier = TestID.Profits.totalValueLabel
         self.totalProfitLabel.accessibilityIdentifier = TestID.Profits.totalProfitLabel
 
-        let bitcoinValue = self.getCorrectBitcoinValue(coreVC: self.coreVC!)
+        let bitcoinValue = self.coreVC!.getCorrectBitcoinValue()
 
         self.totalInvestmentLabel.text = "\(bitcoinValue.chosenCurrency) \(self.totalInvestments)"
         self.totalValueLabel.text = "\(bitcoinValue.chosenCurrency) \(self.totalValue)"

--- a/ios/bittr/Settings/DeviceTableViewCell.swift
+++ b/ios/bittr/Settings/DeviceTableViewCell.swift
@@ -66,11 +66,6 @@ class DeviceTableViewCell: UITableViewCell {
         case "bittrpeer":
             self.deviceVC?.tappedCell = self
             self.deviceVC?.checkPeerConnection()
-        case "purchases":
-            self.deviceVC?.tappedCell = self
-            self.deviceVC?.checkPurchases()
-        case "notification":
-            self.deviceVC?.checkNotification()
         case "lightningchannels":
             self.deviceVC?.checkChannels()
         case "cache":

--- a/ios/bittr/Settings/DeviceViewController.swift
+++ b/ios/bittr/Settings/DeviceViewController.swift
@@ -23,8 +23,6 @@ class DeviceViewController: UIViewController, UNUserNotificationCenterDelegate, 
         ["id":"devicetoken", "label":Language.getWord(withID: "devicetoken"), "button":Language.getWord(withID: "fetch"), "icon":"iphone"],
         ["id":"publickey", "label":Language.getWord(withID: "publickey"), "button":Language.getWord(withID: "fetch"), "icon":"key.horizontal.fill"],
         ["id":"bittrpeer", "label":Language.getWord(withID: "bittrpeer"), "button":Language.getWord(withID: "check"), "icon":"point.topleft.down.to.point.bottomright.curvepath.fill"],
-        ["id":"purchases", "label":Language.getWord(withID: "bittrpurchases"), "button":Language.getWord(withID: "check"), "icon":"banknote.fill"],
-        ["id":"notification", "label":Language.getWord(withID: "bittrnotification"), "button":Language.getWord(withID: "retry"), "icon":"envelope.fill"],
         ["id":"pendingpayouts", "label":Language.getWord(withID: "bittrpendingpayout"), "button":Language.getWord(withID: "check"), "icon":"hourglass"],
         ["id":"lightningchannels", "label":Language.getWord(withID: "lightningchannels2"), "button":"", "icon":"bolt.fill"],
         ["id":"restore", "label":Language.getWord(withID: "removewallet"), "button":"", "icon":"trash.fill"]
@@ -203,42 +201,6 @@ class DeviceViewController: UIViewController, UNUserNotificationCenterDelegate, 
             _ = await BitcoinManager.shared.didEstablishPeerConnection()
             self.checkPeerConnection()
         }
-    }
-    
-    func checkPurchases() {
-        
-        if self.homeVC != nil {
-            self.showAlert(presentingController: self, title: Language.getWord(withID: "bittrtransactions"), message: Language.getWord(withID: "bittrtransactions2"), buttons: [Language.getWord(withID: "check"), Language.getWord(withID: "close")], actions: [#selector(self.checkBittrTransactions), nil])
-        }
-    }
-    
-    @objc func checkBittrTransactions() {
-        self.hideAlert()
-        
-        self.tappedCell?.animateCell()
-        
-        Task {
-            let didReceiveNewInformation = await self.homeVC!.getBittrTransactionDetails(sendAll: true)
-            DispatchQueue.main.async {
-                self.tappedCell?.stopAnimating()
-                self.showAlert(presentingController: self, title: Language.getWord(withID: "bittrtransactions"), message: Language.getWord(withID: didReceiveNewInformation ? "bittrtransactions3" : "bittrtransactions4"), buttons: [Language.getWord(withID: "okay")], actions: nil)
-            }
-        }
-    }
-    
-    func checkNotification() {
-        if self.homeVC?.coreVC != nil, CacheManager.getLastNotification() != nil {
-            Log.info("Notification found for retrying.")
-            self.homeVC!.coreVC!.newNotification()
-            self.dismiss(animated: true)
-        } else {
-            Log.info("No notification available for retrying.")
-            self.showNotificationAlert()
-        }
-    }
-    
-    func showNotificationAlert() {
-        self.showAlert(presentingController: self, title: Language.getWord(withID: "bittrnotification"), message: Language.getWord(withID: "bittrnotification2"), buttons: [Language.getWord(withID: "okay")], actions: nil)
     }
     
     func checkChannels() {

--- a/ios/bittr/Settings/DeviceViewController.swift
+++ b/ios/bittr/Settings/DeviceViewController.swift
@@ -95,7 +95,7 @@ class DeviceViewController: UIViewController, UNUserNotificationCenterDelegate, 
                     cell.buttonLabel.text = "English"
                 }
             case "currency":
-                cell.buttonLabel.text = self.getCorrectBitcoinValue(coreVC: self.coreVC!).chosenCurrency
+                cell.buttonLabel.text = self.coreVC!.getCorrectBitcoinValue().chosenCurrency
             case "lightningchannels":
                 if self.channelsCount == nil {
                     self.syncChannels()

--- a/ios/bittr/Signup/Bittr Signup/Transfer2ViewController.swift
+++ b/ios/bittr/Signup/Bittr Signup/Transfer2ViewController.swift
@@ -136,7 +136,7 @@ class Transfer2ViewController: UIViewController, UITextFieldDelegate, UNUserNoti
                 // Notifications have been rejected. The user can still continue —
                 // their purchases just get paid out on-chain instead of via lightning.
                 DispatchQueue.main.async {
-                    self.showAlert(presentingController: self.signupVC?.coreVC ?? self.signupVC ?? self.ibanVC ?? self, title: Language.getWord(withID: "receivenotifications"), message: Language.getWord(withID: "receivenotifications3"), buttons: [Language.getWord(withID: "continue"), Language.getWord(withID: "okay")], actions: [#selector(self.proceedWithoutNotifications), #selector(self.cancelLoading)])
+                    self.showAlert(presentingController: self.signupVC?.coreVC ?? self.signupVC ?? self.ibanVC ?? self, title: Language.getWord(withID: "receivenotifications"), message: Language.getWord(withID: "receivenotifications3"), buttons: [Language.getWord(withID: "cancel"), Language.getWord(withID: "continue")], actions: [#selector(self.cancelLoading), #selector(self.proceedWithoutNotifications)])
                 }
             } else if CacheManager.getRegistrationToken() == nil {
                 Log.info("Notifications preference has been set but token hasn't been cached.")
@@ -536,12 +536,17 @@ class Transfer2ViewController: UIViewController, UITextFieldDelegate, UNUserNoti
         // Check if we should auto-trigger after text changes
         if textField == self.codeTextField {
             let trimmedText = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            
+
             if trimmedText.count >= 6 && self.nextView.backgroundColor == UIColor.black && !self.hasAutoTriggered {
                 self.hasAutoTriggered = true
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                     self.nextButtonTapped(UIButton())
                 }
+            } else if trimmedText.count < 6 {
+                // Re-arm auto-submit once the code drops below 6 digits, so a
+                // corrected code (e.g. after a wrong-code error) auto-triggers
+                // again on its 6th keystroke.
+                self.hasAutoTriggered = false
             }
         }
     }

--- a/ios/bittr/Signup/Bittr Signup/Transfer2ViewController.swift
+++ b/ios/bittr/Signup/Bittr Signup/Transfer2ViewController.swift
@@ -382,13 +382,22 @@ class Transfer2ViewController: UIViewController, UITextFieldDelegate, UNUserNoti
                             let lightningAddressUsername = actualDataItems["lightning_address_username"] as? String ?? ""
                             
                             CacheManager.addBittrIban(ibanID: ibanEntity.id, ourIban: dataOurIban, ourSwift: dataSwift, yourCode: dataCode, lightningAddressUsername: lightningAddressUsername)
+
+                            // If the user proceeded without notifications, the account was
+                            // registered on-chain, so persist that locally too.
+                            if self.notificationsDenied {
+                                CacheManager.setPaymentMode(ibanID: ibanEntity.id, paymentMode: "onchain")
+                            }
                             for (index, eachIbanEntity) in self.coreVC!.bittrWallet.ibanEntities.enumerated() {
                                 if eachIbanEntity.id == ibanEntity.id {
                                     self.coreVC!.bittrWallet.ibanEntities[index].ourIbanNumber = dataOurIban
                                     self.coreVC!.bittrWallet.ibanEntities[index].ourSwift = dataSwift
                                     self.coreVC!.bittrWallet.ibanEntities[index].yourUniqueCode = dataCode
                                     self.coreVC!.bittrWallet.ibanEntities[index].lightningAddressUsername = lightningAddressUsername
-                                    
+                                    if self.notificationsDenied {
+                                        self.coreVC!.bittrWallet.ibanEntities[index].paymentMode = "onchain"
+                                    }
+
                                     self.coreVC!.buyVC?.parseIbanEntities(uponPageLaunch: false)
                                 }
                             }

--- a/ios/bittr/Signup/Bittr Signup/Transfer2ViewController.swift
+++ b/ios/bittr/Signup/Bittr Signup/Transfer2ViewController.swift
@@ -42,6 +42,7 @@ class Transfer2ViewController: UIViewController, UITextFieldDelegate, UNUserNoti
     // Variables
     var start2Fa = false
     var hasAutoTriggered = false
+    var notificationsDenied = false
     var coreVC:CoreViewController?
     var signupVC:SignupViewController?
     var ibanVC:RegisterIbanViewController?
@@ -132,9 +133,10 @@ class Transfer2ViewController: UIViewController, UITextFieldDelegate, UNUserNoti
                     self.showAlert(presentingController: self.signupVC?.coreVC ?? self.signupVC ?? self.ibanVC ?? self, title: Language.getWord(withID: "receivenotifications"), message: Language.getWord(withID: "receivenotifications2"), buttons: [Language.getWord(withID: "okay")], actions: [#selector(self.askForPushNotifications)])
                 }
             } else if settings.authorizationStatus != .authorized {
-                // Notifications have been rejected..
+                // Notifications have been rejected. The user can still continue —
+                // their purchases just get paid out on-chain instead of via lightning.
                 DispatchQueue.main.async {
-                    self.showAlert(presentingController: self.signupVC?.coreVC ?? self.signupVC ?? self.ibanVC ?? self, title: Language.getWord(withID: "receivenotifications"), message: Language.getWord(withID: "receivenotifications3"), buttons: [Language.getWord(withID: "okay")], actions: [#selector(self.cancelLoading)])
+                    self.showAlert(presentingController: self.signupVC?.coreVC ?? self.signupVC ?? self.ibanVC ?? self, title: Language.getWord(withID: "receivenotifications"), message: Language.getWord(withID: "receivenotifications3"), buttons: [Language.getWord(withID: "continue"), Language.getWord(withID: "okay")], actions: [#selector(self.proceedWithoutNotifications), #selector(self.cancelLoading)])
                 }
             } else if CacheManager.getRegistrationToken() == nil {
                 Log.info("Notifications preference has been set but token hasn't been cached.")
@@ -159,6 +161,16 @@ class Transfer2ViewController: UIViewController, UITextFieldDelegate, UNUserNoti
             self.nextButtonArrow.alpha = 1
             self.nextButtonActivityIndicator.stopAnimating()
         }
+    }
+
+
+    @objc func proceedWithoutNotifications() {
+        // User chose to continue without push notifications. Flag it so that
+        // gatherParameters registers them with on-chain payouts, then carry on
+        // with signup (the Next-button spinner keeps running).
+        self.hideAlert()
+        self.notificationsDenied = true
+        self.sendCodeToBittr()
     }
     
     
@@ -316,6 +328,12 @@ class Transfer2ViewController: UIViewController, UITextFieldDelegate, UNUserNoti
                 "skip_xpub_usage_check": "true",
                 "ios_device_token": CacheManager.getRegistrationToken() ?? ""
             ]
+            // Without push notifications the user can't receive instant lightning
+            // payouts, so register them with on-chain payouts instead of lightning.
+            if self.notificationsDenied {
+                parameters["payment_mode"] = "onchain"
+            }
+
             // Recovery: reuse the existing deposit code so the backend updates the
             // existing customer instead of creating a new order. lightning_pubkey
             // (above) must match the one sent in check2fa and stored on the customer.

--- a/ios/bittr/Swaps/SwapStatusVC/SwapStatusViewController.swift
+++ b/ios/bittr/Swaps/SwapStatusVC/SwapStatusViewController.swift
@@ -57,6 +57,7 @@ class SwapStatusViewController: UIViewController {
 
         self.confirmCard.accessibilityIdentifier = TestID.SwapStatus.confirmCard
         self.confirmStatusLabel.accessibilityIdentifier = TestID.SwapStatus.confirmStatusLabel
+        self.confirmStatusButton.accessibilityIdentifier = TestID.SwapStatus.refreshButton
 
         // Button titles
         self.confirmStatusButton.setTitle("", for: .normal)

--- a/ios/bittr/Swaps/SwapVC/SwapViewController.swift
+++ b/ios/bittr/Swaps/SwapVC/SwapViewController.swift
@@ -227,17 +227,16 @@ class SwapViewController: UIViewController, UITextFieldDelegate, UNUserNotificat
         
         guard self.thisSwap != nil else { return }
         
-        let bitcoinValue = self.getCorrectBitcoinValue(coreVC: self.coreVC!)
+        let bitcoinValue = self.coreVC!.getCorrectBitcoinValue()
         
         // Calculate total fees including claim transaction fee for lightning-to-onchain swaps
         // For lightning-to-onchain swaps, the claim transaction fee is included in the on-chain amount
         // so the user receives exactly what they input
         let totalFees = self.thisSwap!.onchainFees! + self.thisSwap!.lightningFees! + (self.thisSwap!.claimTransactionFee ?? 0)
         
-        var convertedFees = "\(CGFloat(Int(totalFees.inBTC()*bitcoinValue.currentValue*100))/100)".replacingOccurrences(of: ".", with: ",")
-        if convertedFees.split(separator: ",")[1].count == 1 {
-            convertedFees = convertedFees + "0"
-        }
+        // Fiat fee, rounded to two decimals and formatted with the device's
+        // decimal separator (e.g. "0,50" in comma locales).
+        let convertedFees = (totalFees.inBTC() * bitcoinValue.currentValue).twoDecimals().toString()
         let convertedAmount = "\(Int((self.thisSwap!.satoshisAmount.inBTC()*bitcoinValue.currentValue).rounded()))"
         
         let message = Language.getWord(withID: "swapfunds3").replacingOccurrences(of: "<feesamount>", with: "\(totalFees)".addSpaces()).replacingOccurrences(of: "<convertedfees>", with: "\(bitcoinValue.chosenCurrency) \(convertedFees)").replacingOccurrences(of: "<amount>", with: "\(self.thisSwap!.satoshisAmount)".addSpaces()).replacingOccurrences(of: "<convertedamount>", with: "\(bitcoinValue.chosenCurrency) \(convertedAmount)")

--- a/ios/bittr/Transaction/TransactionViewController.swift
+++ b/ios/bittr/Transaction/TransactionViewController.swift
@@ -437,7 +437,7 @@ class TransactionViewController: UIViewController {
         }
         
         // Value
-        let bitcoinValue = self.getCorrectBitcoinValue(coreVC: self.coreVC!)
+        let bitcoinValue = self.coreVC!.getCorrectBitcoinValue()
         let transactionValue:CGFloat = {
             if self.tappedTransaction.isSwap {
                 return (self.tappedTransaction.sent - self.tappedTransaction.received + self.tappedTransaction.fee).inBTC()

--- a/ios/bittr/Value/GraphView.swift
+++ b/ios/bittr/Value/GraphView.swift
@@ -135,7 +135,7 @@ class GraphView: UIView, UIGestureRecognizerDelegate {
             priceLabel.translatesAutoresizingMaskIntoConstraints = false
             priceLabel.accessibilityIdentifier = TestID.Value.graphValueLabel
             priceLabel.font = UIFont(name: "Gilroy-Bold", size: 12)
-            let currency = self.valueVC!.getCorrectBitcoinValue(coreVC: self.valueVC!.homeVC!.coreVC!).chosenCurrency
+            let currency = self.valueVC!.homeVC!.coreVC!.getCorrectBitcoinValue().chosenCurrency
             priceLabel.text = currency + " " + self.valueVC!.formatEuroValue("\(Int(thisDataPoint["price"] as! CGFloat))")
             priceLabel.textColor = .black
             thisCard.addSubview(priceLabel)

--- a/ios/bittr/Value/ValueViewController.swift
+++ b/ios/bittr/Value/ValueViewController.swift
@@ -123,17 +123,18 @@ class ValueViewController: UIViewController {
         // Get latest value
         Task {
             do {
-                let eurUrl = URL(string: self.getCorrectBitcoinValue(coreVC: self.homeVC!.coreVC!).apiUrl)!
+                let bitcoinValue = self.homeVC!.coreVC!.getCorrectBitcoinValue()
+                let eurUrl = URL(string: bitcoinValue.apiUrl)!
                 var eurData = Data()
-                if self.getCorrectBitcoinValue(coreVC: self.homeVC!.coreVC!).chosenCurrency == "CHF", self.homeVC?.chfData != nil, (self.homeVC?.chfDataFetched!)! > Calendar.current.date(byAdding: .minute, value: -15, to: Date())! {
+                if bitcoinValue.chosenCurrency == "CHF", self.homeVC?.chfData != nil, (self.homeVC?.chfDataFetched!)! > Calendar.current.date(byAdding: .minute, value: -15, to: Date())! {
                     
                     eurData = self.homeVC!.chfData!
-                } else if self.getCorrectBitcoinValue(coreVC: self.homeVC!.coreVC!).chosenCurrency != "CHF", self.homeVC?.eurData != nil, (self.homeVC?.eurDataFetched!)! > Calendar.current.date(byAdding: .minute, value: -15, to: Date())! {
+                } else if bitcoinValue.chosenCurrency != "CHF", self.homeVC?.eurData != nil, (self.homeVC?.eurDataFetched!)! > Calendar.current.date(byAdding: .minute, value: -15, to: Date())! {
                     
                     eurData = self.homeVC!.eurData!
                 } else {
                     (eurData, _) = try await URLSession.shared.data(from: eurUrl)
-                    if self.getCorrectBitcoinValue(coreVC: self.homeVC!.coreVC!).chosenCurrency == "CHF" {
+                    if bitcoinValue.chosenCurrency == "CHF" {
                         self.homeVC?.chfData = eurData
                         self.homeVC?.chfDataFetched = Date()
                     } else {
@@ -238,7 +239,7 @@ class ValueViewController: UIViewController {
                             self.currentValue = actualEurValue.toNumber()
                             var preferredCurrency = "€"
                             var valueToDisplay = formattedEurValue
-                            if self.getCorrectBitcoinValue(coreVC: self.homeVC!.coreVC!).chosenCurrency == "CHF" {
+                            if bitcoinValue.chosenCurrency == "CHF" {
                                 preferredCurrency = "CHF"
                                 valueToDisplay = formattedChfValue
                                 self.currentValue = actualChfValue.toNumber()

--- a/shared/flows/README.md
+++ b/shared/flows/README.md
@@ -74,12 +74,15 @@ shared/flows/
                           notification gate (Receive-notifications prompt →
                           iOS system dialog, which Maestro auto-denies via
                           launchApp permissions notifications:deny → the
-                          authorize-in-Settings gate). Requires an existing
-                          wallet without a bittr account (run
+                          denied-notifications gate). At that gate it taps
+                          "Continue" to finish signup via the on-chain
+                          fallback (payment_mode=onchain), reusing
+                          buy_signup's tail, and ends on the Buy page with the
+                          new cell and the payout-mode switch OFF. Requires an
+                          existing wallet without a bittr account (run
                           onboarding/fresh_install_skip_signup.yaml first) —
                           it only unlocks, since auto-creating a wallet would
-                          wipe the permissions config. Ends at the
-                          notification gate (see the flow header).
+                          wipe the permissions config.
     remove_wallet.yaml    Settings → Device details → Remove wallet. Handles
                           both branches (active channel → close → mine →
                           re-trigger; no channel → direct confirm).

--- a/shared/flows/README.md
+++ b/shared/flows/README.md
@@ -122,9 +122,8 @@ shared/flows/
                           Privacy / Terms (WebsiteViewController), then every
                           Device-details row: dark-mode toggle, language,
                           currency (EUR↔CHF, verified on Home), device token,
-                          public key, Bittr peer / purchases / notification /
-                          pending payout, and Lightning connections
-                          (QuestionViewController).
+                          public key, Bittr peer / pending payout, and
+                          Lightning connections (QuestionViewController).
   helpers/         Reusable subflows invoked via runFlow.
     unlock.yaml           Enters PIN 1234 on the unlock screen.
     wrong_pin_until_lockout.yaml  Enters the wrong PIN ten times on the unlock

--- a/shared/flows/README.md
+++ b/shared/flows/README.md
@@ -70,12 +70,13 @@ shared/flows/
     buy_signup_no_notifications.yaml
                           The unhappy-path counterpart to buy_signup: walks
                           the "I don't have an IBAN" alert, the invalid-IBAN
-                          and invalid-email validation alerts, and the OTP
-                          notification gate (Receive-notifications prompt →
-                          iOS system dialog, which Maestro auto-denies via
-                          launchApp permissions notifications:deny → the
-                          denied-notifications gate). At that gate it taps
-                          "Continue" to finish signup via the on-chain
+                          and invalid-email validation alerts, a wrong OTP
+                          (incorrect-code alert), and the OTP notification gate
+                          (Receive-notifications prompt → iOS system dialog,
+                          which Maestro auto-denies via launchApp permissions
+                          notifications:deny → the denied-notifications gate).
+                          It then re-enters the correct OTP and, at each gate,
+                          taps "Continue" to finish signup via the on-chain
                           fallback (payment_mode=onchain), reusing
                           buy_signup's tail, and ends on the Buy page with the
                           new cell and the payout-mode switch OFF. Requires an

--- a/shared/flows/features/buy_signup_no_notifications.yaml
+++ b/shared/flows/features/buy_signup_no_notifications.yaml
@@ -25,11 +25,13 @@
 #   5. Fix the IBAN, then drop ".com" from the email → Verify → the
 #      "enter your IBAN and email" alert (invalid email).
 #   6. Fix the email → Verify → advance to the OTP screen.
-#   7. Enter a WRONG code first (111111). Notification permission is
-#      undetermined, so: the in-app "Receive notifications" prompt (Alert A)
-#      → Okay → the iOS system dialog, which Maestro auto-denies → the
-#      denied-notifications gate (Alert B, [Cancel, Continue]). Tap Continue;
-#      the code is submitted and check2fa rejects it → incorrect-code alert.
+#   7. Enter a WRONG code first (111111). At the first notification gate the
+#      app shows EITHER the in-app prompt (Alert A) → Okay → iOS system dialog
+#      (auto-denied) → the denied gate (Alert B) when permission was still
+#      undetermined, OR jumps straight to the denied gate (Alert B) if
+#      notifications were already denied. The test handles both. Either way,
+#      tap Continue on Alert B → the WRONG code is submitted and check2fa
+#      rejects it → incorrect-code alert.
 #   8. Re-enter the correct code (123456). Erasing re-arms the auto-submit, so
 #      the 6th keystroke auto-triggers again. Permission is now .denied (no
 #      in-app prompt / system dialog this round) → straight to the denied gate
@@ -37,8 +39,12 @@
 #   9. Signup proceeds, registering the customer for on-chain payouts. Reuse
 #      buy_signup.yaml's clean-path tail — Transfer3 success → Transfer4 info
 #      cards → "Open your banking app" modal → back on Buy with the new cell.
-#  10. END on the Buy page: assert the new cell rendered AND that the
+#  10. Back on the Buy page: assert the new cell rendered AND that the
 #      payout-mode switch is OFF (on-chain), reflecting the denied path.
+#  11. Try to flip the payout-mode switch to lightning. Lightning needs push
+#      notifications (denied), so the switch is blocked: it reverts and shows
+#      the "lightningneedsnotifications" alert → tap Okay → switch back OFF.
+#      END.
 #
 # Run: maestro test shared/flows/features/buy_signup_no_notifications.yaml
 
@@ -185,28 +191,43 @@ appId: com.bittr.bittr-regtest
 # Transfer2 (OTP). The code field auto-focuses and auto-submits once 6
 # digits are entered. We enter a WRONG code first (111111) to exercise the
 # invalid-code path. The submit path checks notification permission BEFORE
-# validating the code: it's undetermined, so the app shows its "Receive
-# notifications" prompt, then the iOS system dialog — which Maestro auto-denies
-# (the launchApp permissions: notifications: deny config taps "Don't Allow").
+# validating the code, so the next step handles whichever notification gate
+# appears (see below) — depending on whether permission is still undetermined
+# or was already denied.
 - extendedWaitUntil:
     visible:
       id: "signup.bittr.otp.codeTextField"
     timeout: 30000
 - inputText: "111111"
 
-# Alert A: the in-app "Receive notifications" prompt. Okay fires the iOS
-# system permission dialog, which Maestro auto-denies.
+# First notification gate. What shows depends on the OS permission state:
+#   - .notDetermined: the in-app "Receive notifications" prompt (Alert A,
+#     single Okay button) appears first → Okay fires the iOS system dialog
+#     (Maestro auto-denies) → then the denied gate (Alert B).
+#   - already .denied (e.g. a previous run denied them): NO Alert A and NO
+#     system dialog — the app jumps straight to the denied gate (Alert B).
+# Wait for whichever alert appears first (both have an Okay/Cancel button.0).
 - extendedWaitUntil:
     visible:
       id: "alert.button.0"
     timeout: 20000
-- takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/05_notifications_prompt
-- tapOn:
-    id: "alert.button.0"
 
-# Alert B: after the system dialog is denied, the app shows the
-# denied-notifications gate. It offers two buttons — [Cancel (button.0),
-# Continue (button.1)]. Tap Continue (button.1) to proceed without
+# Distinguish the two cases by the presence of a "Continue" button (Alert B
+# has one; Alert A doesn't). If it's Alert A (no Continue), tap Okay to fire
+# the system dialog (auto-denied). When notifications were already denied this
+# block is skipped, because Alert B is shown directly.
+- runFlow:
+    when:
+      notVisible:
+        text: "Continue"
+    commands:
+      - takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/05_notifications_prompt
+      - tapOn:
+          id: "alert.button.0"
+
+# Alert B: the denied-notifications gate, [Cancel (button.0), Continue
+# (button.1)] — reached either after the system dialog (undetermined case) or
+# directly (already-denied case). Tap Continue (button.1) to proceed without
 # notifications: the signup submits the entered code (still the WRONG 111111)
 # and registers the customer for on-chain payouts rather than being blocked.
 - extendedWaitUntil:
@@ -296,3 +317,24 @@ appId: com.bittr.bittr-regtest
     id: "buy.paymentModeSwitch"
     checked: false
 - takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/11_buy_onchain
+
+# Now try to switch the payout mode to lightning. Lightning payouts are
+# delivered via push notifications, which the user denied, so setPaymentMode
+# blocks the switch: it reverts the toggle and shows the
+# "lightningneedsnotifications" alert (single Okay button) rather than sending
+# the PATCH.
+- tapOn:
+    id: "buy.paymentModeSwitch"
+- extendedWaitUntil:
+    visible:
+      id: "alert.button.0"
+    timeout: 20000
+- takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/12_lightning_blocked
+- tapOn:
+    id: "alert.button.0"
+
+# The blocked switch reverts to OFF (on-chain). End of test.
+- assertVisible:
+    id: "buy.paymentModeSwitch"
+    checked: false
+- takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/13_end

--- a/shared/flows/features/buy_signup_no_notifications.yaml
+++ b/shared/flows/features/buy_signup_no_notifications.yaml
@@ -1,7 +1,9 @@
 # Feature test: the bittr signup from the Buy page, exercising the IBAN /
 # email validation alerts and the notification-permission gate on the OTP
-# screen. A companion to buy_signup.yaml that walks the *unhappy* branches
-# rather than the clean path.
+# screen, then proceeding WITHOUT notifications. A companion to buy_signup.yaml
+# that walks the *unhappy* branches and then completes signup via the on-chain
+# fallback: declining notifications no longer blocks the user — it registers
+# them for on-chain payouts (payment_mode=onchain) and lets them finish.
 #
 # Prerequisite: a wallet must ALREADY exist on the device, WITHOUT a
 # completed bittr signup (e.g. run onboarding/fresh_install_skip_signup.yaml
@@ -23,13 +25,16 @@
 #   5. Fix the IBAN, then drop ".com" from the email → Verify → the
 #      "enter your IBAN and email" alert (invalid email).
 #   6. Fix the email → Verify → advance to the OTP screen.
-#   7. Enter a code (123456 — never actually submitted/checked, since the
-#      gate blocks it). Notification permission is undetermined, so: the
-#      in-app "Receive notifications" prompt (Alert A) → Okay → the iOS
-#      system dialog, which Maestro auto-denies → the "authorize
-#      notifications in Settings" gate (Alert B) → Okay.
-#   8. END at the notification gate. We don't continue to the
-#      enter-correct-code path — that would need notifications enabled.
+#   7. Enter the code (123456). Notification permission is undetermined, so:
+#      the in-app "Receive notifications" prompt (Alert A) → Okay → the iOS
+#      system dialog, which Maestro auto-denies → the denied-notifications
+#      gate (Alert B), which now offers [Continue, Okay].
+#   8. Tap Continue: the signup proceeds, registering the customer for
+#      on-chain payouts. Reuse buy_signup.yaml's clean-path tail from here —
+#      Transfer3 success → Transfer4 info cards → "Open your banking app"
+#      modal → back on Buy with the new IBAN cell.
+#   9. END on the Buy page: assert the new cell rendered AND that the
+#      payout-mode switch is OFF (on-chain), reflecting the denied path.
 #
 # Run: maestro test shared/flows/features/buy_signup_no_notifications.yaml
 
@@ -194,18 +199,65 @@ appId: com.bittr.bittr-regtest
 - tapOn:
     id: "alert.button.0"
 
-# Alert B: after the system dialog is denied, the app shows the "...go to
-# Settings > Notifications > bittr to authorize..." gate. Tap Okay to dismiss
-# it (the app just stops the spinner).
+# Alert B: after the system dialog is denied, the app shows the
+# denied-notifications gate. It offers two buttons — [Continue (button.0),
+# Okay (button.1)]. Tap Continue to proceed without notifications: the signup
+# carries on but registers the customer for on-chain payouts
+# (payment_mode=onchain) instead of being blocked.
 - extendedWaitUntil:
     visible:
       id: "alert.button.0"
     timeout: 20000
-- takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/06_authorize_notifications
+- takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/06_notification_gate
 - tapOn:
     id: "alert.button.0"
 
-# Both gates dismissed → back on the OTP screen. End of test.
+# Proceeding re-submits the still-entered 123456 code (check2fa accepts it in
+# test mode), then createBittrAccount runs the long async chain. From here the
+# flow mirrors buy_signup.yaml's clean-path tail — the only difference is the
+# on-chain payout mode asserted at the end.
+
+# Transfer3: bittr signup success. Generous timeout for the async chain.
+- extendedWaitUntil:
+    visible:
+      id: "signup.bittr.success.topLabelOne"
+    timeout: 90000
+- takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/07_bittr_success
+- tapOn:
+    id: "signup.bittr.success.nextButton"
+
+# Transfer4: 4 explanation cards + "Let's go" at the bottom.
 - assertVisible:
-    id: "signup.bittr.otp.codeTextField"
-- takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/07_end
+    id: "signup.bittr.transferInfo.amountTitle"
+- scrollUntilVisible:
+    element:
+      id: "signup.bittr.transferInfo.nextButton"
+- takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/08_transfer_info
+- tapOn:
+    id: "signup.bittr.transferInfo.nextButton"
+
+# "Open your banking app" modal — Done dismisses both the alert and the
+# RegisterIban modal; Buy reappears underneath with the new cell.
+- tapOn:
+    id: "alert.button.0"
+
+# Back on Buy — the new IBAN cell renders on the next layout pass after
+# parseIbanEntities, so allow a small grace period.
+- extendedWaitUntil:
+    visible:
+      id: "buy.yourCode"
+    timeout: 20000
+- assertVisible:
+    id: "buy.yourEmail"
+- assertVisible:
+    id: "buy.yourIban"
+
+# Because the user proceeded without notifications, the account was registered
+# on-chain, so the payout-mode switch renders OFF (paymentMode == "onchain").
+# NOTE: same `checked` caveat as payment_mode.yaml — if your Maestro version
+# doesn't read UISwitch state on iOS, drop the `checked:` line and rely on the
+# screenshot.
+- assertVisible:
+    id: "buy.paymentModeSwitch"
+    checked: false
+- takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/09_buy_onchain

--- a/shared/flows/features/buy_signup_no_notifications.yaml
+++ b/shared/flows/features/buy_signup_no_notifications.yaml
@@ -25,15 +25,19 @@
 #   5. Fix the IBAN, then drop ".com" from the email → Verify → the
 #      "enter your IBAN and email" alert (invalid email).
 #   6. Fix the email → Verify → advance to the OTP screen.
-#   7. Enter the code (123456). Notification permission is undetermined, so:
-#      the in-app "Receive notifications" prompt (Alert A) → Okay → the iOS
-#      system dialog, which Maestro auto-denies → the denied-notifications
-#      gate (Alert B), which now offers [Continue, Okay].
-#   8. Tap Continue: the signup proceeds, registering the customer for
-#      on-chain payouts. Reuse buy_signup.yaml's clean-path tail from here —
-#      Transfer3 success → Transfer4 info cards → "Open your banking app"
-#      modal → back on Buy with the new IBAN cell.
-#   9. END on the Buy page: assert the new cell rendered AND that the
+#   7. Enter a WRONG code first (111111). Notification permission is
+#      undetermined, so: the in-app "Receive notifications" prompt (Alert A)
+#      → Okay → the iOS system dialog, which Maestro auto-denies → the
+#      denied-notifications gate (Alert B, [Cancel, Continue]). Tap Continue;
+#      the code is submitted and check2fa rejects it → incorrect-code alert.
+#   8. Re-enter the correct code (123456). Erasing re-arms the auto-submit, so
+#      the 6th keystroke auto-triggers again. Permission is now .denied (no
+#      in-app prompt / system dialog this round) → straight to the denied gate
+#      (Alert B) again → Continue. check2fa accepts 123456.
+#   9. Signup proceeds, registering the customer for on-chain payouts. Reuse
+#      buy_signup.yaml's clean-path tail — Transfer3 success → Transfer4 info
+#      cards → "Open your banking app" modal → back on Buy with the new cell.
+#  10. END on the Buy page: assert the new cell rendered AND that the
 #      payout-mode switch is OFF (on-chain), reflecting the denied path.
 #
 # Run: maestro test shared/flows/features/buy_signup_no_notifications.yaml
@@ -179,15 +183,16 @@ appId: com.bittr.bittr-regtest
     id: "signup.bittr.start.nextButton"
 
 # Transfer2 (OTP). The code field auto-focuses and auto-submits once 6
-# digits are entered. The submit path checks notification permission first;
-# it's undetermined, so the app shows its "Receive notifications" prompt,
-# then the iOS system dialog — which Maestro auto-denies (the launchApp
-# permissions: notifications: deny config taps "Don't Allow" for us).
+# digits are entered. We enter a WRONG code first (111111) to exercise the
+# invalid-code path. The submit path checks notification permission BEFORE
+# validating the code: it's undetermined, so the app shows its "Receive
+# notifications" prompt, then the iOS system dialog — which Maestro auto-denies
+# (the launchApp permissions: notifications: deny config taps "Don't Allow").
 - extendedWaitUntil:
     visible:
       id: "signup.bittr.otp.codeTextField"
     timeout: 30000
-- inputText: "123456"
+- inputText: "111111"
 
 # Alert A: the in-app "Receive notifications" prompt. Okay fires the iOS
 # system permission dialog, which Maestro auto-denies.
@@ -200,29 +205,59 @@ appId: com.bittr.bittr-regtest
     id: "alert.button.0"
 
 # Alert B: after the system dialog is denied, the app shows the
-# denied-notifications gate. It offers two buttons — [Continue (button.0),
-# Okay (button.1)]. Tap Continue to proceed without notifications: the signup
-# carries on but registers the customer for on-chain payouts
-# (payment_mode=onchain) instead of being blocked.
+# denied-notifications gate. It offers two buttons — [Cancel (button.0),
+# Continue (button.1)]. Tap Continue (button.1) to proceed without
+# notifications: the signup submits the entered code (still the WRONG 111111)
+# and registers the customer for on-chain payouts rather than being blocked.
 - extendedWaitUntil:
     visible:
-      id: "alert.button.0"
+      id: "alert.button.1"
     timeout: 20000
 - takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/06_notification_gate
 - tapOn:
+    id: "alert.button.1"
+
+# check2fa rejects 111111 → the "Oops" incorrect-code alert (verificationfail,
+# single Okay button). Dismiss it and try again with the correct code.
+- extendedWaitUntil:
+    visible:
+      id: "alert.button.0"
+    timeout: 30000
+- takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/07_wrong_code
+- tapOn:
     id: "alert.button.0"
 
-# Proceeding re-submits the still-entered 123456 code (check2fa accepts it in
-# test mode), then createBittrAccount runs the long async chain. From here the
-# flow mirrors buy_signup.yaml's clean-path tail — the only difference is the
-# on-chain payout mode asserted at the end.
+# Re-enter the code with the correct value. Erasing drops the field below 6
+# digits, which re-arms the auto-submit, so typing 123456 auto-triggers again
+# on the 6th keystroke — same as the first attempt, no manual Confirm needed.
+- tapOn:
+    id: "signup.bittr.otp.codeTextField"
+- eraseText: 6
+- inputText: "123456"
+
+# The submit path re-checks notification permission every time. It's now
+# .denied (not .notDetermined), so there's NO in-app prompt and NO system
+# dialog this round — it goes straight to the denied-notifications gate again.
+# Tap Continue (button.1) once more to proceed; this time check2fa accepts
+# 123456.
+- extendedWaitUntil:
+    visible:
+      id: "alert.button.1"
+    timeout: 20000
+- takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/08_notification_gate_retry
+- tapOn:
+    id: "alert.button.1"
+
+# Proceeding submits 123456 (accepted in test mode), then createBittrAccount
+# runs the long async chain. From here the flow mirrors buy_signup.yaml's
+# clean-path tail — the only difference is the on-chain payout mode at the end.
 
 # Transfer3: bittr signup success. Generous timeout for the async chain.
 - extendedWaitUntil:
     visible:
       id: "signup.bittr.success.topLabelOne"
     timeout: 90000
-- takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/07_bittr_success
+- takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/09_bittr_success
 - tapOn:
     id: "signup.bittr.success.nextButton"
 
@@ -232,7 +267,7 @@ appId: com.bittr.bittr-regtest
 - scrollUntilVisible:
     element:
       id: "signup.bittr.transferInfo.nextButton"
-- takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/08_transfer_info
+- takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/10_transfer_info
 - tapOn:
     id: "signup.bittr.transferInfo.nextButton"
 
@@ -260,4 +295,4 @@ appId: com.bittr.bittr-regtest
 - assertVisible:
     id: "buy.paymentModeSwitch"
     checked: false
-- takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/09_buy_onchain
+- takeScreenshot: shared/docs/screenshots/buy_signup_no_notifications/11_buy_onchain

--- a/shared/flows/features/settings.yaml
+++ b/shared/flows/features/settings.yaml
@@ -204,13 +204,13 @@ appId: com.bittr.bittr-regtest
       - takeScreenshot: shared/docs/screenshots/settings/12_peer_disconnected
       - tapOn:
           id: "alert.button.1"
+      # The two-button connect alert is replaced by a single-button result
+      # alert ("connected" or a failure) — both have alert.button.0, so wait
+      # for the Connect button (alert.button.1) to disappear instead, then the
+      # tap below dismisses whatever result alert came back.
       - extendedWaitUntil:
           notVisible:
-            id: "alert.button.0"
-          timeout: 10000
-      - extendedWaitUntil:
-          visible:
-            id: "alert.button.0"
+            id: "alert.button.1"
           timeout: 30000
 - tapOn:
     id: "alert.button.0"

--- a/shared/flows/features/settings.yaml
+++ b/shared/flows/features/settings.yaml
@@ -21,11 +21,6 @@
 #   • Bittr peer (Check): the peer may or may not already be connected. If a
 #     Connect button is present we retry, then dismiss whatever result alert
 #     comes back.
-#   • Bittr notification (Retry): the alert is either "no alert available for
-#     handling" (single Okay) or, if a payment notification is cached,
-#     "You're receiving a new payment!". The latter navigates out of Device
-#     details and shows a follow-up "already processed" alert; both that extra
-#     alert and reopening Device details are handled via optional taps.
 #
 # Colour changes from the dark-mode toggle can't be asserted in Maestro, so
 # they're captured as before/after screenshots for visual review.
@@ -220,51 +215,6 @@ appId: com.bittr.bittr-regtest
 - tapOn:
     id: "alert.button.0"
 
-# Bittr purchases (Check): first alert offers Check / Close — tap Check
-# (alert.button.0) to fetch transactions, wait for the result alert, then
-# tap Okay (alert.button.0).
-- tapOn:
-    id: "device.row.purchases"
-- extendedWaitUntil:
-    visible:
-      id: "alert.button.0"
-    timeout: 10000
-- tapOn:
-    id: "alert.button.0"
-- extendedWaitUntil:
-    visible:
-      id: "alert.button.0"
-    timeout: 30000
-- takeScreenshot: shared/docs/screenshots/settings/13_purchases_result
-- tapOn:
-    id: "alert.button.0"
-
-# Bittr notification (Retry): the resulting alert is one of two. Usually it's
-# the "no alert available for handling" alert (single Okay). But if a payment
-# notification happens to be cached, it instead reads "You're receiving a new
-# payment! ...". Both are dismissed with Okay.
-- tapOn:
-    id: "device.row.notification"
-- extendedWaitUntil:
-    visible:
-      id: "alert.button.0"
-    timeout: 10000
-- tapOn:
-    id: "alert.button.0"
-
-# In the "receiving a new payment" case, handling it navigates out of Device
-# details and a second alert reports "This payment has already been
-# processed." Dismiss it, then reopen Device details so we can continue to
-# Pending payout. Both steps are optional: in the common "no alert available"
-# case there's no second alert and we never left Device details (settings.row.device
-# isn't visible from inside it), so they're skipped.
-- tapOn:
-    id: "alert.button.0"
-    optional: true
-- tapOn:
-    id: "settings.row.device"
-    optional: true
-
 # Pending payout (Check): signs a message and calls the notifications API
 # (async). The resulting alert is dismissed by alert.button.0 (Okay when
 # there's no payout, Cancel when there is).
@@ -274,7 +224,7 @@ appId: com.bittr.bittr-regtest
     visible:
       id: "alert.button.0"
     timeout: 30000
-- takeScreenshot: shared/docs/screenshots/settings/14_pendingpayout
+- takeScreenshot: shared/docs/screenshots/settings/13_pendingpayout
 - tapOn:
     id: "alert.button.0"
 
@@ -284,7 +234,7 @@ appId: com.bittr.bittr-regtest
     id: "device.row.lightningchannels"
 - assertVisible:
     id: "question.yellowCard"
-- takeScreenshot: shared/docs/screenshots/settings/15_lightning_question
+- takeScreenshot: shared/docs/screenshots/settings/14_lightning_question
 - tapOn:
     id: "header.downButton"
 - assertVisible:
@@ -299,4 +249,4 @@ appId: com.bittr.bittr-regtest
     id: "header.downButton"
 - assertVisible:
     id: "home.headerLabel"
-- takeScreenshot: shared/docs/screenshots/settings/16_home
+- takeScreenshot: shared/docs/screenshots/settings/15_home

--- a/shared/flows/features/swap.yaml
+++ b/shared/flows/features/swap.yaml
@@ -2,25 +2,42 @@
 #
 # Prerequisite: buy_incoming.yaml has been run at least once on this app
 # install — that's what creates and confirms the lightning channel that the
-# swap pulls from. This flow does NOT clearState, so the wallet + channel
-# survive across runs of this test.
+# swap pulls from. The flow normally preserves state (wallet + channel survive
+# across runs).
+#
+# Notifications: swaps require an APNs device token (SwapManager blocks with a
+# "notifications required" alert otherwise). If a prior run denied notifications
+# (e.g. buy_signup_no_notifications.yaml) the token is gone and — because iOS
+# won't let you re-enable notifications via Settings once denied — the only way
+# back is a reinstall. So if the first swap leg hits that gate, this flow
+# reprovisions a fresh wallet with notifications allowed (helpers/
+# reprovision_for_swap.yaml: clearState reinstall → onboarding → buy_incoming)
+# and retries. That recovery path has the same prereqs as buy_incoming.yaml
+# (push helper running, hosted e2e endpoints) and is heavy, so it only runs when
+# actually blocked; the happy path skips it entirely.
 #
 # Flow:
-#   1. Launch (preserve state). Unlock with PIN if locked.
-#   2. Tap the big balance card → MoveVC.
-#   3. Tap the swap (exchange) button → SwapVC.
-#   4. Type 50000 sats, tap Next → fees alert appears.
-#   5. Tap Proceed (alert button index 1).
-#   6. Wait for "Swap complete" status.
-#   7. Mine 1 block.
-#   8. Swipe down twice (SwapVC, then MoveVC) to land back on Home.
-#   9. Verify Home with the new swap row in the transaction list.
+#   1. Launch (preserve state, notifications allowed). Unlock with PIN if locked.
+#   2. First leg (helpers/swap_leg1.yaml): balance card → MoveVC → SwapVC, type
+#      75000 sats, Next. (Next is where the APNs-token check runs.)
+#   3. Next shows the fees alert, OR the "notifications required" gate if there's
+#      no token. On the gate: reprovision + re-run leg 1. Then Proceed on the
+#      fees alert.
+#   4. Wait for "Swap complete" status, mine 1 block, return Home.
+#   5. Reverse leg (onchain → lightning, 50000 sats) the same way.
+#   6. Verify Home with the new swap rows in the transaction list.
 #
 # Run: maestro test shared/flows/features/swap.yaml
 
 appId: com.bittr.bittr-regtest
 ---
-- launchApp
+# Swaps require notifications (the app blocks swapping with a "notifications
+# required" alert otherwise). Explicitly allow them at launch so this test is
+# unaffected by a prior run that denied notifications (e.g.
+# buy_signup_no_notifications.yaml) — permissions is applied on every launch.
+- launchApp:
+    permissions:
+      notifications: allow
 
 # If app launched into the PIN unlock screen, enter it.
 - runFlow:
@@ -44,38 +61,45 @@ appId: com.bittr.bittr-regtest
     timeout: 60000
 - takeScreenshot: shared/docs/screenshots/swap/01_home
 
-# Tap the big balance card → MoveVC.
-# Note: profitButton overlays the lower half of the balance card. Tapping
-# balanceCardButton's center routes the tap to profitButton (HomeToProfit).
-# Point offset 50%,20% lands in the upper half (the big balance numbers).
-- tapOn:
-    id: "home.balanceCardButton"
-    point: "50%,20%"
-- assertVisible:
-    id: "move.subtitleLabel"
-- takeScreenshot: shared/docs/screenshots/swap/02_move
+# First swap leg (lightning → onchain), extracted to a helper so it can be
+# re-run after a reprovision. It stops at Next, where the app shows either the
+# fees alert OR — if notifications were denied on a prior run, so there's no
+# APNs device token — the "notifications required" gate (SwapManager's
+# deviceToken check).
+- runFlow: ../helpers/swap_leg1.yaml
 
-# Tap the exchange icon between regular and instant balances → SwapVC.
-- tapOn:
-    id: "move.swapButton"
-- assertVisible:
-    id: "swap.amountTextField"
-- takeScreenshot: shared/docs/screenshots/swap/03_swap_initial
+# Tapping Next surfaces one of two alerts: the fees alert (APNs token present) or
+# the "notifications required" gate (token absent). Both have alert.button.0, so
+# wait for one to appear before deciding.
+- extendedWaitUntil:
+    visible:
+      id: "alert.button.0"
+    timeout: 30000
 
-# Type 75000 satoshis (initial swap amount — leaves enough onchain to swap
-# 50000 back the other direction in the second leg). Tap Done on the
-# keyboard's accessory toolbar (added in SwapViewController.viewDidLoad);
-# Maestro's hideKeyboard doesn't work against iOS numeric keyboards reliably.
-- tapOn:
-    id: "swap.amountTextField"
-- inputText: "75000"
-- tapOn:
-    text: "Done"
-- takeScreenshot: shared/docs/screenshots/swap/04_swap_amount_entered
-- tapOn:
-    id: "swap.nextButton"
+# If it's the gate, dismiss it and reprovision a fresh wallet with notifications
+# allowed (a clearState reinstall resets the OS notification permission — it
+# can't be re-enabled via Settings once denied), then re-run the leg. The gated
+# Next never created a swap.
+- runFlow:
+    when:
+      visible:
+        text: ".*To process swaps.*"
+    commands:
+      - tapOn:
+          text: "Okay"
+      - runFlow: ../helpers/reprovision_for_swap.yaml
+      - runFlow: ../helpers/swap_leg1.yaml
+      - extendedWaitUntil:
+          visible:
+            id: "alert.button.0"
+          timeout: 30000
 
-# Fees alert: [Cancel, Proceed]. Proceed is index 1.
+# Fail loudly if still blocked (e.g. clearState didn't reset the notification
+# permission) rather than silently skipping the swap below.
+- assertNotVisible:
+    text: ".*To process swaps.*"
+
+# Now it's the fees alert: [Cancel, Proceed]. Proceed is index 1.
 - assertVisible:
     id: "alert.button.1"
 - takeScreenshot: shared/docs/screenshots/swap/05_fees_alert

--- a/shared/flows/features/swap.yaml
+++ b/shared/flows/features/swap.yaml
@@ -193,6 +193,21 @@ appId: com.bittr.bittr-regtest
 - evalScript: ${output.blocksToMine = 1}
 - runScript: ../scripts/mine_blocks.js
 
+# Recovery: if the funding tx stays unconfirmed and the status stalls on
+# "Waiting to be mined" instead of progressing to "Swap complete" on its own,
+# mine 6 more blocks and tap the status refresh button to pull a fresh status
+# from Boltz. Skipped when the swap has already moved on (the status label
+# shows one status at a time, so "Waiting to be mined" is no longer visible).
+- runFlow:
+    when:
+      visible:
+        text: "Waiting to be mined"
+    commands:
+      - evalScript: ${output.blocksToMine = 6}
+      - runScript: ../scripts/mine_blocks.js
+      - tapOn:
+          id: "swapStatus.refreshButton"
+
 - extendedWaitUntil:
     visible:
       text: "Swap complete"

--- a/shared/flows/helpers/reprovision_for_swap.yaml
+++ b/shared/flows/helpers/reprovision_for_swap.yaml
@@ -1,0 +1,53 @@
+# Helper: reprovision a fresh wallet with notifications ALLOWED, then open the
+# lightning channel. swap.yaml runs this only when the first swap attempt hit
+# the "notifications required" gate (no APNs device token because a prior run —
+# e.g. buy_signup_no_notifications.yaml — denied notifications).
+#
+# Why a full reinstall: once notifications are denied on the simulator they
+# can't be re-enabled via Settings, and `permissions: allow` can't re-grant a
+# decided permission. A clearState launch REINSTALLS the app, which resets the
+# notification permission to "not determined"; permissions: allow + the
+# onboarding flow then grant it so signup registers a device token, and
+# buy_incoming reopens the channel the swap pulls from.
+#
+# Heavy by design (full onboarding + channel open). Prereqs are the same as
+# buy_incoming.yaml: the push helper (node shared/flows/scripts/push_server.js)
+# and the hosted regtest e2e endpoints must be available.
+#
+# NOTE: this hinges on Maestro's iOS clearState actually reinstalling the app
+# (and thus resetting notifications) — verified working on iPhone 16e / iOS 18.5.
+# If it ever doesn't, the swap stays blocked and swap.yaml's assertNotVisible
+# guard fails loudly rather than silently passing.
+
+appId: com.bittr.bittr-regtest
+---
+- launchApp:
+    clearState: true
+    clearKeychain: true
+    permissions:
+      notifications: allow
+
+# Fresh onboarding: create the wallet and complete the bittr signup. The signup
+# step allows notifications (happy_path_signup taps Allow on the prompt), which
+# registers the device token the swap needs.
+- runFlow:
+    when:
+      visible:
+        id: "signup.create.start.createWalletButton"
+    file: ../onboarding/happy_path_wallet.yaml
+- runFlow:
+    when:
+      visible:
+        id: "signup.create.ready.topLabelOne"
+    file: ../onboarding/happy_path_signup.yaml
+
+# Open + confirm the lightning channel (buy_incoming self-launches, preserving
+# the freshly-onboarded state).
+- runFlow: ../features/buy_incoming.yaml
+
+# buy_incoming ends on the Profit screen — close it back to Home so the swap
+# retry (helpers/swap_leg1.yaml) starts from the balance card.
+- tapOn:
+    id: "header.downButton"
+- assertVisible:
+    id: "home.headerLabel"

--- a/shared/flows/helpers/swap_leg1.yaml
+++ b/shared/flows/helpers/swap_leg1.yaml
@@ -1,0 +1,47 @@
+# Helper: from Home, set up the lightning → onchain swap leg (75000 sats) and
+# tap Next. swap.yaml calls this once normally, and again after a reprovision if
+# the first attempt hit the notifications gate.
+#
+# It STOPS right after tapping Next — it does not assert the fees alert. Tapping
+# Next is where the app checks for an APNs device token: with one it shows the
+# fees alert, without one (notifications denied) it shows the "notifications
+# required" gate instead. The caller waits for whichever appears and branches.
+
+appId: com.bittr.bittr-regtest
+---
+# Settle any wallet sync first (also covers the re-sync after a reprovision).
+- extendedWaitUntil:
+    notVisible:
+      id: "home.headerSpinner"
+    timeout: 60000
+
+# Tap the big balance card → MoveVC. profitButton overlays the lower half, so
+# the 50%,20% offset lands in the upper half (the big balance numbers).
+- tapOn:
+    id: "home.balanceCardButton"
+    point: "50%,20%"
+- assertVisible:
+    id: "move.subtitleLabel"
+- takeScreenshot: shared/docs/screenshots/swap/02_move
+
+# Tap the exchange icon between regular and instant balances → SwapVC.
+- tapOn:
+    id: "move.swapButton"
+- assertVisible:
+    id: "swap.amountTextField"
+- takeScreenshot: shared/docs/screenshots/swap/03_swap_initial
+
+# Type 75000 satoshis. Tap Done on the keyboard accessory toolbar (Maestro's
+# hideKeyboard is unreliable against iOS numeric keyboards).
+- tapOn:
+    id: "swap.amountTextField"
+- inputText: "75000"
+- tapOn:
+    text: "Done"
+- takeScreenshot: shared/docs/screenshots/swap/04_swap_amount_entered
+
+# Tap Next. The app now checks for an APNs token: it shows EITHER the fees alert
+# (token present) OR the "notifications required" gate (token absent). The
+# caller decides what to do next.
+- tapOn:
+    id: "swap.nextButton"

--- a/shared/test-ids/test-ids.json
+++ b/shared/test-ids/test-ids.json
@@ -104,8 +104,6 @@
       "devicetoken": null,
       "publickey": null,
       "bittrpeer": null,
-      "purchases": null,
-      "notification": null,
       "pendingpayouts": null,
       "lightningchannels": null,
       "restore": null

--- a/shared/test-ids/test-ids.json
+++ b/shared/test-ids/test-ids.json
@@ -126,7 +126,8 @@
   },
   "swapStatus": {
     "confirmCard": null,
-    "confirmStatusLabel": null
+    "confirmStatusLabel": null,
+    "refreshButton": null
   },
   "unlock": {
     "topLabel": null


### PR DESCRIPTION
**Updates**:
- Removed "**Bittr purchases**" and "**Bittr notification**" from Device Details and settings.yaml test.
- Removed "**bitcoin:**" from SendVC onchain address copying without amount.
- In **Transfer2VC**, when user denies push notifications, send **payment_mode** to API and allow signup to continue.
- In **BuyVC**, block payment mode **switching to lightning** if push notifications have been denied.
- Include this in buy_signup_no_notifications.yaml test.
- Include **wrong 2FA code** entry in buy_signup_no_notifications.yaml test.
- Refactor for **fiat amount String formatting**.
- Include swap status refreshing in **swap.yaml** test.
- Show **remaining pin attempts** when entering wrong pin in PinVC.