### PR TITLE
Include Bitcoin QR testing in receive_onchain.yaml

### DIFF
--- a/ios/bittr/Helpers/TestIDs.swift
+++ b/ios/bittr/Helpers/TestIDs.swift
@@ -119,6 +119,8 @@ enum TestID {
         static let addressTitle = "receive.addressTitle"
         static let amountTextField = "receive.amountTextField"
         static let copyButton = "receive.copyButton"
+        static let currencyButton = "receive.currencyButton"
+        static let currencyLabel = "receive.currencyLabel"
         static let editButton = "receive.editButton"
         static let invoiceLabel = "receive.invoiceLabel"
         static let moreButton = "receive.moreButton"

--- a/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveViewController.swift
+++ b/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveViewController.swift
@@ -136,6 +136,8 @@ class ReceiveViewController: UIViewController, UITextFieldDelegate, UIContextMen
         self.qrSpinner.accessibilityIdentifier = TestID.Receive.qrSpinner
         self.questionButton.accessibilityIdentifier = TestID.Receive.questionButton
         self.bothAmountTextField.accessibilityIdentifier = TestID.Receive.amountTextField
+        self.btcButton.accessibilityIdentifier = TestID.Receive.currencyButton
+        self.btcLabel.accessibilityIdentifier = TestID.Receive.currencyLabel
         self.copyButton.accessibilityIdentifier = TestID.Receive.copyButton
         self.refreshButton.accessibilityIdentifier = TestID.Receive.refreshButton
         self.editButton.accessibilityIdentifier = TestID.Receive.editButton

--- a/shared/flows/features/receive_onchain.yaml
+++ b/shared/flows/features/receive_onchain.yaml
@@ -9,7 +9,12 @@
 #      with the address filled in and no amount.
 #   4. Back in Receive, attach a 5000 sat amount, copy, paste into Send and
 #      verify the address + amount carry across.
-#   5. Renew the onchain address repeatedly until the pool is exhausted and the
+#   5. Optional (only when a lightning channel is present, i.e. the More button
+#      is shown): switch to the unified Bitcoin QR, read its info alert, attach a
+#      5 EUR amount, copy it, paste into Send and verify it carries both the
+#      lightning invoice + amount and — after tapping Regular — the onchain
+#      address + amount.
+#   6. Renew the onchain address repeatedly until the pool is exhausted and the
 #      "no new address available" alert appears.
 #
 # Assumes a wallet exists. If launched on a clean install it auto-runs the
@@ -192,6 +197,142 @@ appId: com.bittr.bittr-regtest
 # exhausted.
 - tapOn:
     id: "home.receiveButton"
+
+# Optional Bitcoin QR detour. The default Receive type depends on lightning
+# availability — a unified Bitcoin QR is only offered when a channel exists,
+# which is exactly when the More button is present. If there's no channel this
+# whole block is skipped and we fall straight through to the onchain renew path
+# below. We wait out the QR spinner first so the More button has rendered before
+# the gate is evaluated.
+- extendedWaitUntil:
+    notVisible:
+      id: "receive.qrSpinner"
+    timeout: 30000
+- runFlow:
+    when:
+      visible:
+        id: "receive.moreButton"
+    commands:
+      # Open the Transaction Type picker and switch to Bitcoin QR. Picker
+      # buttons: [Cancel, Address, Bitcoin QR, Create invoice, Show LNURL] —
+      # Bitcoin QR is index 2.
+      - tapOn:
+          id: "receive.moreButton"
+      - tapOn:
+          id: "alert.button.2"
+      - extendedWaitUntil:
+          notVisible:
+            id: "receive.qrSpinner"
+          timeout: 30000
+
+      # Read the Bitcoin QR info alert (question mark) and close it.
+      - tapOn:
+          id: "receive.questionButton"
+      - assertVisible:
+          id: "alert.button.0"
+      - takeScreenshot: shared/docs/screenshots/receive_onchain/07a_bitcoinqr_info
+      - tapOn:
+          id: "alert.button.0"
+
+      # Add an amount in euros: reveal the amount field, switch the currency
+      # from Sats to € via the currency action sheet, confirm it reads EUR,
+      # then enter 5 and tap Done.
+      - tapOn:
+          id: "receive.editButton"
+      - tapOn:
+          id: "receive.amountTextField"
+      - tapOn:
+          id: "receive.currencyButton"
+      - tapOn:
+          text: "€"
+      - assertVisible:
+          id: "receive.currencyLabel"
+          text: "EUR"
+      - tapOn:
+          id: "receive.amountTextField"
+      - inputText: "5"
+      - tapOn:
+          text: "Done"
+
+      # The Bitcoin QR regenerates with the amount appended. Wait for the
+      # spinner to settle, then confirm the label reloaded with "?amount=".
+      - extendedWaitUntil:
+          notVisible:
+            id: "receive.qrSpinner"
+          timeout: 30000
+      - assertVisible:
+          id: "receive.invoiceLabel"
+          text: ".*amount=.*"
+      - takeScreenshot: shared/docs/screenshots/receive_onchain/07b_bitcoinqr_amount
+
+      # Copy the unified Bitcoin QR (bitcoin:<addr>?amount=…&lightning=<invoice>),
+      # close the "Copied" alert.
+      - tapOn:
+          id: "receive.copyButton"
+      - assertVisible:
+          id: "alert.button.0"
+      - tapOn:
+          id: "alert.button.0"
+
+      # Close Receive → Home.
+      - tapOn:
+          id: "header.downButton"
+      - assertVisible:
+          id: "home.headerLabel"
+
+      # Open Send and paste the unified QR. It carries a lightning invoice, so
+      # Send defaults to lightning: the invoice lands in the "to" field and the
+      # invoice amount in the amount field.
+      - tapOn:
+          id: "home.sendButton"
+      - tapOn:
+          id: "send.pasteButton"
+      - tapOn:
+          id: "alert.button.0"
+          optional: true
+      - assertVisible:
+          id: "send.toLabel"
+          text: "Invoice and amount"
+      - assertVisible:
+          id: "send.toTextField"
+          text: ".*lnbcrt.*"
+      - assertVisible:
+          id: "send.amountTextField"
+          text: ".*[0-9].*"
+      - takeScreenshot: shared/docs/screenshots/receive_onchain/07c_send_invoice_amount
+
+      # Switch to Regular (onchain): the stored onchain address from the unified
+      # QR replaces the invoice, keeping the amount. A BDK rescan may surface a
+      # "syncing wallet" alert — dismiss it and wait out the spinner.
+      - tapOn:
+          id: "send.regularButton"
+      - tapOn:
+          id: "alert.button.0"
+          optional: true
+      - extendedWaitUntil:
+          notVisible:
+            id: "send.bdkSpinner"
+          timeout: 60000
+      - assertVisible:
+          id: "send.toLabel"
+          text: "Address and amount"
+      - assertVisible:
+          id: "send.toTextField"
+          text: ".*bcrt1.*"
+      - assertVisible:
+          id: "send.amountTextField"
+          text: ".*[0-9].*"
+      - takeScreenshot: shared/docs/screenshots/receive_onchain/07d_send_address_amount
+
+      # Close Send → Home, then reopen Receive so the existing onchain renew
+      # path below picks up from a freshly-opened Receive screen.
+      - tapOn:
+          id: "header.downButton"
+      - assertVisible:
+          id: "home.headerLabel"
+      - tapOn:
+          id: "home.receiveButton"
+
 - runFlow:
     file: ../helpers/show_onchain_address.yaml
 - takeScreenshot: shared/docs/screenshots/receive_onchain/08_before_renew

--- a/shared/test-ids/test-ids.json
+++ b/shared/test-ids/test-ids.json
@@ -176,6 +176,8 @@
     "qrSpinner": null,
     "questionButton": null,
     "amountTextField": null,
+    "currencyButton": null,
+    "currencyLabel": null,
     "copyButton": null,
     "refreshButton": null,
     "editButton": null,


### PR DESCRIPTION
Adds an **optional** Bitcoin QR detour to `features/receive_onchain.yaml`, inserted before revealing ten onchain addresses back-to-back.

The block is gated on the `receive.moreButton` being visible — the unified Bitcoin QR is only offered when a lightning channel exists, which is exactly when the More button renders. If there's no channel the whole block is skipped and the flow falls through to the existing onchain renew path.