### PR TITLE
Inspect the QuestionVC lightning channel stats in send_lightning.yaml

### DIFF
--- a/ios/bittr/Helpers/TestIDs.swift
+++ b/ios/bittr/Helpers/TestIDs.swift
@@ -119,6 +119,8 @@ enum TestID {
         static let addressTitle = "receive.addressTitle"
         static let amountTextField = "receive.amountTextField"
         static let copyButton = "receive.copyButton"
+        static let currencyButton = "receive.currencyButton"
+        static let currencyLabel = "receive.currencyLabel"
         static let editButton = "receive.editButton"
         static let invoiceLabel = "receive.invoiceLabel"
         static let moreButton = "receive.moreButton"

--- a/ios/bittr/Helpers/TestIDs.swift
+++ b/ios/bittr/Helpers/TestIDs.swift
@@ -77,6 +77,7 @@ enum TestID {
         static let userLocationButton = "map.userLocationButton"
     }
     enum Move {
+        static let channelButton = "move.channelButton"
         static let satsInstant = "move.satsInstant"
         static let satsRegular = "move.satsRegular"
         static let satsTotal = "move.satsTotal"
@@ -112,6 +113,7 @@ enum TestID {
     }
     enum Question {
         static let answerLabel = "question.answerLabel"
+        static let channelView = "question.channelView"
         static let yellowCard = "question.yellowCard"
     }
     enum Receive {

--- a/ios/bittr/Move, Send, Receive/MoveVC/MoveViewController.swift
+++ b/ios/bittr/Move, Send, Receive/MoveVC/MoveViewController.swift
@@ -58,6 +58,7 @@ class MoveViewController: UIViewController {
         self.satsTotal.accessibilityIdentifier = TestID.Move.satsTotal
         self.satsRegular.accessibilityIdentifier = TestID.Move.satsRegular
         self.satsInstant.accessibilityIdentifier = TestID.Move.satsInstant
+        self.channelButton.accessibilityIdentifier = TestID.Move.channelButton
         self.swapButton.accessibilityIdentifier = TestID.Move.swapButton
         self.swapButton.accessibilityLabel = "Swap"
 

--- a/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveViewController.swift
+++ b/ios/bittr/Move, Send, Receive/ReceiveVC/ReceiveViewController.swift
@@ -136,6 +136,8 @@ class ReceiveViewController: UIViewController, UITextFieldDelegate, UIContextMen
         self.qrSpinner.accessibilityIdentifier = TestID.Receive.qrSpinner
         self.questionButton.accessibilityIdentifier = TestID.Receive.questionButton
         self.bothAmountTextField.accessibilityIdentifier = TestID.Receive.amountTextField
+        self.btcButton.accessibilityIdentifier = TestID.Receive.currencyButton
+        self.btcLabel.accessibilityIdentifier = TestID.Receive.currencyLabel
         self.copyButton.accessibilityIdentifier = TestID.Receive.copyButton
         self.refreshButton.accessibilityIdentifier = TestID.Receive.refreshButton
         self.editButton.accessibilityIdentifier = TestID.Receive.editButton

--- a/ios/bittr/Question/QuestionViewController.swift
+++ b/ios/bittr/Question/QuestionViewController.swift
@@ -39,6 +39,7 @@ class QuestionViewController: UIViewController {
 
         self.yellowCard.accessibilityIdentifier = TestID.Question.yellowCard
         self.answerLabel.accessibilityIdentifier = TestID.Question.answerLabel
+        self.channelView.accessibilityIdentifier = TestID.Question.channelView
 
         // Corner radii and button titles
         self.yellowCard.layer.cornerRadius = 13

--- a/shared/flows/features/receive_onchain.yaml
+++ b/shared/flows/features/receive_onchain.yaml
@@ -9,7 +9,12 @@
 #      with the address filled in and no amount.
 #   4. Back in Receive, attach a 5000 sat amount, copy, paste into Send and
 #      verify the address + amount carry across.
-#   5. Renew the onchain address repeatedly until the pool is exhausted and the
+#   5. Optional (only when a lightning channel is present, i.e. the More button
+#      is shown): switch to the unified Bitcoin QR, read its info alert, attach a
+#      5 EUR amount, copy it, paste into Send and verify it carries both the
+#      lightning invoice + amount and — after tapping Regular — the onchain
+#      address + amount.
+#   6. Renew the onchain address repeatedly until the pool is exhausted and the
 #      "no new address available" alert appears.
 #
 # Assumes a wallet exists. If launched on a clean install it auto-runs the
@@ -192,6 +197,142 @@ appId: com.bittr.bittr-regtest
 # exhausted.
 - tapOn:
     id: "home.receiveButton"
+
+# Optional Bitcoin QR detour. The default Receive type depends on lightning
+# availability — a unified Bitcoin QR is only offered when a channel exists,
+# which is exactly when the More button is present. If there's no channel this
+# whole block is skipped and we fall straight through to the onchain renew path
+# below. We wait out the QR spinner first so the More button has rendered before
+# the gate is evaluated.
+- extendedWaitUntil:
+    notVisible:
+      id: "receive.qrSpinner"
+    timeout: 30000
+- runFlow:
+    when:
+      visible:
+        id: "receive.moreButton"
+    commands:
+      # Open the Transaction Type picker and switch to Bitcoin QR. Picker
+      # buttons: [Cancel, Address, Bitcoin QR, Create invoice, Show LNURL] —
+      # Bitcoin QR is index 2.
+      - tapOn:
+          id: "receive.moreButton"
+      - tapOn:
+          id: "alert.button.2"
+      - extendedWaitUntil:
+          notVisible:
+            id: "receive.qrSpinner"
+          timeout: 30000
+
+      # Read the Bitcoin QR info alert (question mark) and close it.
+      - tapOn:
+          id: "receive.questionButton"
+      - assertVisible:
+          id: "alert.button.0"
+      - takeScreenshot: shared/docs/screenshots/receive_onchain/07a_bitcoinqr_info
+      - tapOn:
+          id: "alert.button.0"
+
+      # Add an amount in euros: reveal the amount field, switch the currency
+      # from Sats to € via the currency action sheet, confirm it reads EUR,
+      # then enter 5 and tap Done.
+      - tapOn:
+          id: "receive.editButton"
+      - tapOn:
+          id: "receive.amountTextField"
+      - tapOn:
+          id: "receive.currencyButton"
+      - tapOn:
+          text: "€"
+      - assertVisible:
+          id: "receive.currencyLabel"
+          text: "EUR"
+      - tapOn:
+          id: "receive.amountTextField"
+      - inputText: "5"
+      - tapOn:
+          text: "Done"
+
+      # The Bitcoin QR regenerates with the amount appended. Wait for the
+      # spinner to settle, then confirm the label reloaded with "?amount=".
+      - extendedWaitUntil:
+          notVisible:
+            id: "receive.qrSpinner"
+          timeout: 30000
+      - assertVisible:
+          id: "receive.invoiceLabel"
+          text: ".*amount=.*"
+      - takeScreenshot: shared/docs/screenshots/receive_onchain/07b_bitcoinqr_amount
+
+      # Copy the unified Bitcoin QR (bitcoin:<addr>?amount=…&lightning=<invoice>),
+      # close the "Copied" alert.
+      - tapOn:
+          id: "receive.copyButton"
+      - assertVisible:
+          id: "alert.button.0"
+      - tapOn:
+          id: "alert.button.0"
+
+      # Close Receive → Home.
+      - tapOn:
+          id: "header.downButton"
+      - assertVisible:
+          id: "home.headerLabel"
+
+      # Open Send and paste the unified QR. It carries a lightning invoice, so
+      # Send defaults to lightning: the invoice lands in the "to" field and the
+      # invoice amount in the amount field.
+      - tapOn:
+          id: "home.sendButton"
+      - tapOn:
+          id: "send.pasteButton"
+      - tapOn:
+          id: "alert.button.0"
+          optional: true
+      - assertVisible:
+          id: "send.toLabel"
+          text: "Invoice and amount"
+      - assertVisible:
+          id: "send.toTextField"
+          text: ".*lnbcrt.*"
+      - assertVisible:
+          id: "send.amountTextField"
+          text: ".*[0-9].*"
+      - takeScreenshot: shared/docs/screenshots/receive_onchain/07c_send_invoice_amount
+
+      # Switch to Regular (onchain): the stored onchain address from the unified
+      # QR replaces the invoice, keeping the amount. A BDK rescan may surface a
+      # "syncing wallet" alert — dismiss it and wait out the spinner.
+      - tapOn:
+          id: "send.regularButton"
+      - tapOn:
+          id: "alert.button.0"
+          optional: true
+      - extendedWaitUntil:
+          notVisible:
+            id: "send.bdkSpinner"
+          timeout: 60000
+      - assertVisible:
+          id: "send.toLabel"
+          text: "Address and amount"
+      - assertVisible:
+          id: "send.toTextField"
+          text: ".*bcrt1.*"
+      - assertVisible:
+          id: "send.amountTextField"
+          text: ".*[0-9].*"
+      - takeScreenshot: shared/docs/screenshots/receive_onchain/07d_send_address_amount
+
+      # Close Send → Home, then reopen Receive so the existing onchain renew
+      # path below picks up from a freshly-opened Receive screen.
+      - tapOn:
+          id: "header.downButton"
+      - assertVisible:
+          id: "home.headerLabel"
+      - tapOn:
+          id: "home.receiveButton"
+
 - runFlow:
     file: ../helpers/show_onchain_address.yaml
 - takeScreenshot: shared/docs/screenshots/receive_onchain/08_before_renew

--- a/shared/flows/features/send_lightning.yaml
+++ b/shared/flows/features/send_lightning.yaml
@@ -1,9 +1,12 @@
 # Feature test: lightning send end-to-end (three invoice types).
 #
 # Starts like features/send_onchain.yaml (launch, auto-recover/unlock, wait for
-# the Home sync spinner) and then sends three lightning payments back to back,
-# exercising the normal-invoice, zero-amount-invoice and Lightning-Address
-# (LNURL) paths:
+# the Home sync spinner). First it inspects the lightning channel — taps the
+# balance card → MoveViewController → the question mark next to the lightning
+# balance → QuestionViewController, which (with an open channel) shows the
+# channel-statistics chart — then closes back to Home. It then sends three
+# lightning payments back to back, exercising the normal-invoice,
+# zero-amount-invoice and Lightning-Address (LNURL) paths:
 #   1. Normal invoice (amount baked in): Send → Paste → the amount field
 #      auto-populates → Next → Confirm screen (invoice + amount) → Send →
 #      TransactionViewController with the confirmed payment → close it.
@@ -70,6 +73,42 @@ appId: com.bittr.bittr-regtest
       id: "home.headerSpinner"
     timeout: 60000
 - takeScreenshot: shared/docs/screenshots/send_lightning/01_home
+
+# ---------------------------------------------------------------------------
+# 0. Inspect the lightning channel via the balance screen.
+# ---------------------------------------------------------------------------
+
+# Tap the balance card → MoveViewController. profitButton overlays the lower
+# half of the card, so tap the upper half (50%,20%) to hit the balance numbers
+# rather than routing to Profit (same trick as swap.yaml).
+- tapOn:
+    id: "home.balanceCardButton"
+    point: "50%,20%"
+- assertVisible:
+    id: "move.subtitleLabel"
+- takeScreenshot: shared/docs/screenshots/send_lightning/01a_move
+
+# Tap the question mark next to the lightning (instant) balance → the
+# QuestionViewController. This test always runs with an open channel, so the
+# channel-statistics chart is shown.
+- tapOn:
+    id: "move.channelButton"
+- assertVisible:
+    id: "question.yellowCard"
+- assertVisible:
+    id: "question.channelView"
+- takeScreenshot: shared/docs/screenshots/send_lightning/01b_channel_stats
+
+# Close the QuestionViewController (header down button) → back on Move.
+- tapOn:
+    id: "header.downButton"
+- assertVisible:
+    id: "move.subtitleLabel"
+# Close the MoveViewController → back on Home.
+- tapOn:
+    id: "header.downButton"
+- assertVisible:
+    id: "home.headerLabel"
 
 # ---------------------------------------------------------------------------
 # 1. Normal invoice (amount baked in).

--- a/shared/test-ids/test-ids.json
+++ b/shared/test-ids/test-ids.json
@@ -176,6 +176,8 @@
     "qrSpinner": null,
     "questionButton": null,
     "amountTextField": null,
+    "currencyButton": null,
+    "currencyLabel": null,
     "copyButton": null,
     "refreshButton": null,
     "editButton": null,

--- a/shared/test-ids/test-ids.json
+++ b/shared/test-ids/test-ids.json
@@ -79,6 +79,7 @@
     "satsTotal": null,
     "satsRegular": null,
     "satsInstant": null,
+    "channelButton": null,
     "swapButton": null
   },
   "nav": {
@@ -152,7 +153,8 @@
   },
   "question": {
     "yellowCard": null,
-    "answerLabel": null
+    "answerLabel": null,
+    "channelView": null
   },
   "transaction": {
     "yellowCard": null,


### PR DESCRIPTION
Adds a channel-inspection step to the start of `features/send_lightning.yaml`, right after the Home sync spinner settles and before the first Send.

1. Tap the balance card → MoveViewController (tapping the upper half at `50%,20%` so the profitButton overlay doesn't route to Profit, same trick as `swap.yaml`).
2. Tap the question mark next to the lightning balance → QuestionViewController.
3. Assert `question.yellowCard` **and** `question.channelView` — the channel-statistics chart, which is shown because this flow always runs with an open channel.
4. Close the QuestionViewController → Move → Home, then the existing test proceeds.