### PR TITLE
New test fresh_install_unhappy.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ maestro test shared/flows/onboarding/fresh_install.yaml
 # (taps "Skip" on Signup7 and lands on Home):
 maestro test shared/flows/onboarding/fresh_install_skip_signup.yaml
 
+# Option 1c: Full reset + wallet creation through every validation gate
+# (confirm-statements / screenshot-warning / invalid-word / wrong-phrase /
+# PIN-length alerts), then Skip to Home — the onboarding error-path counterpart.
+# To exercise the seed-phrase screenshot warning (optional): run
+# "node shared/flows/scripts/screenshot_server.js" (needs Accessibility
+# permission), AND on the simulated device turn OFF Settings > General > Screen
+# Capture > Full-Screen Previews (else the screenshot preview covers the app and
+# blocks the flow). Without this setup the screenshot step is skipped.
+maestro test shared/flows/onboarding/fresh_install_unhappy.yaml
+
 # Option 2: Full reset + restore existing wallet.
 # Followed by onboarding through the Buy page.
 maestro test shared/flows/onboarding/restore_wallet.yaml

--- a/ios/bittr/BitcoinManager.swift
+++ b/ios/bittr/BitcoinManager.swift
@@ -605,6 +605,7 @@ class BitcoinManager {
             guard let self else { return }
             
             while !Task.isCancelled {
+                guard self.ldkNode != nil else { return }
                 let event = await self.ldkNode!.nextEventAsync()
                 if Task.isCancelled { break }
                 await MainActor.run {

--- a/ios/bittr/Pin/PinViewController.swift
+++ b/ios/bittr/Pin/PinViewController.swift
@@ -157,6 +157,9 @@ class PinViewController: UIViewController, UITextFieldDelegate, UICollectionView
     }
     
     @IBAction func numberButtonTapped(_ sender: UIButton) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.allBackgrounds![sender.tag].alpha = 0
+        }
         
         // Check if PIN is already at max length (8 digits)
         if (pinTextField.text?.count ?? 0) >= 8 {
@@ -167,10 +170,6 @@ class PinViewController: UIViewController, UITextFieldDelegate, UICollectionView
         // Update text field.
         self.pinTextField.insertText(String(sender.tag))
         self.pinCollectionView.reloadData()
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            self.allBackgrounds![sender.tag].alpha = 0
-        }
     }
     
     @IBAction func backspaceButtonTapped(_ sender: UIButton) {

--- a/shared/docs/parity.md
+++ b/shared/docs/parity.md
@@ -13,6 +13,7 @@ Every flow under `shared/flows/` is listed below. iOS is the source of truth and
 | Bittr signup (onboarding subflow) | done | not started | `onboarding/happy_path_signup.yaml` | IBAN / email / OTP / info-cards from Signup7 through to Home. Reusable subflow. |
 | Fresh install (full onboarding) | done | not started | `onboarding/fresh_install.yaml` | Top-level orchestrator: clearState + clearKeychain, then runs `happy_path_wallet` + `happy_path_signup`. |
 | Fresh install, skip bittr signup | done | not started | `onboarding/fresh_install_skip_signup.yaml` | Creates a wallet from scratch then taps Skip on Signup7 → Home with no bittr account. |
+| Fresh install, unhappy path | done | not started | `onboarding/fresh_install_unhappy.yaml` | Wallet creation through every validation gate: Cancel back to Signup1, the confirm-statements alert, the seed-phrase screenshot warning (fires a real Simulator screenshot via `scripts/screenshot_server.js` since Maestro's own capture doesn't post the iOS notification; best-effort), an invalid non-BIP39 word (`invalidwords`) then a valid-but-wrong recovery phrase (`incorrectphrase`), and the PIN too-short / too-long / mismatch alerts, before creating the wallet and Skipping to Home. |
 | Restore wallet | done | not started | `onboarding/restore_wallet.yaml` | clearState + clearKeychain, restores from a fixed test mnemonic, sets PIN 1234 → Home. |
 
 ## Buy & bittr account

--- a/shared/docs/screens.md
+++ b/shared/docs/screens.md
@@ -61,40 +61,40 @@ For the full feature-/interaction-level gap list (LNURL-withdraw, deep links, pu
 
 - **VC**: `ios/bittr/Signup/Create Wallet/Signup2ViewController.swift`
 - **Purpose**: two acknowledgement switches before wallet generation.
-- **States**: initial (both off) / both on.
-- **Flow**: `shared/flows/onboarding/happy_path_wallet.yaml`
+- **States**: initial (both off) / both on / Cancel back to Signup1 + "confirm the statements" alert (unhappy).
+- **Flow**: `shared/flows/onboarding/happy_path_wallet.yaml`, `onboarding/fresh_install_unhappy.yaml`
 - **Screenshots**: `onboarding/02_confirm_initial.png`, `onboarding/03_confirm_both_on.png`
 
 ### Signup3 — Mnemonic
 
 - **VC**: `ios/bittr/Signup/Create Wallet/Signup3ViewController.swift`
 - **Purpose**: shows the 12-word mnemonic. User must scroll.
-- **States**: top / bottom (scrolled).
-- **Flow**: `shared/flows/onboarding/happy_path_wallet.yaml`
+- **States**: top / bottom (scrolled) / screenshot "be careful" warning (unhappy — fired by a real Simulator screenshot via `scripts/screenshot_server.js`, since Maestro's own capture doesn't post the iOS notification; best-effort).
+- **Flow**: `shared/flows/onboarding/happy_path_wallet.yaml`, `onboarding/fresh_install_unhappy.yaml`
 - **Screenshots**: `onboarding/04_mnemonic_top.png`, `onboarding/05_mnemonic_bottom.png`
 
 ### Signup4 — Verify
 
 - **VC**: `ios/bittr/Signup/Create Wallet/Signup4ViewController.swift`
 - **Purpose**: verify 3 random mnemonic words by index.
-- **States**: empty / filled.
-- **Flow**: `shared/flows/onboarding/happy_path_wallet.yaml`
+- **States**: empty / filled / invalid non-BIP39 word (`invalidwords`) + wrong-phrase (`incorrectphrase`) alerts → Back (unhappy).
+- **Flow**: `shared/flows/onboarding/happy_path_wallet.yaml`, `onboarding/fresh_install_unhappy.yaml`
 - **Screenshots**: `onboarding/06_verify_initial.png`, `onboarding/07_verify_filled.png`
 
 ### Signup5 — Set PIN
 
 - **VC**: `ios/bittr/Signup/Create Wallet/Signup5ViewController.swift` (embeds `PinViewController`)
 - **Purpose**: new PIN entry (min 4 digits).
-- **States**: empty / entered.
-- **Flow**: `shared/flows/onboarding/happy_path_wallet.yaml`
+- **States**: empty / entered / too-short (`pinshouldbe4to8`) + too-long (`pincanbeupto8`) alerts (unhappy).
+- **Flow**: `shared/flows/onboarding/happy_path_wallet.yaml`, `onboarding/fresh_install_unhappy.yaml`
 - **Screenshots**: `onboarding/08_pin_set_initial.png`, `onboarding/09_pin_set_entered.png`
 
 ### Signup6 — Confirm PIN
 
 - **VC**: `ios/bittr/Signup/Create Wallet/Signup6ViewController.swift` (embeds `PinViewController`)
 - **Purpose**: confirm PIN — must match Signup5.
-- **States**: empty / entered.
-- **Flow**: `shared/flows/onboarding/happy_path_wallet.yaml`
+- **States**: empty / entered / mismatch (`repeatnumber`) alert → Back to Signup5 (unhappy).
+- **Flow**: `shared/flows/onboarding/happy_path_wallet.yaml`, `onboarding/fresh_install_unhappy.yaml`
 - **Screenshots**: `onboarding/10_pin_confirm_initial.png`, `onboarding/11_pin_confirm_entered.png`
 
 ### Signup7 — Wallet ready

--- a/shared/flows/README.md
+++ b/shared/flows/README.md
@@ -13,6 +13,16 @@ shared/flows/
                           Wipes state, runs happy_path_wallet, then taps
                           "Skip" on Signup7 to land on Home without the
                           bittr signup. Top-level entry.
+    fresh_install_unhappy.yaml
+                          Wipes state and walks wallet creation through every
+                          validation gate — confirm-statements alert, the seed
+                          screenshot warning (real screenshot triggered via
+                          scripts/screenshot_server.js; best-effort), an invalid
+                          non-BIP39 word then a wrong recovery phrase, and the PIN
+                          too-short / too-long / mismatch alerts — before
+                          creating the wallet and Skipping to Home. The
+                          error-branch counterpart to happy_path_wallet.
+                          Top-level entry.
     happy_path_wallet.yaml  Reusable subflow: wallet creation, Signup1 →
                           the wallet-ready screen (Signup7).
     happy_path_signup.yaml  Reusable subflow: bittr signup, Signup7 → Home.
@@ -207,6 +217,16 @@ shared/flows/
     sleep.js                    Busy-waits output.sleepMs ms (Maestro has no
                                 native sleep) so a flow can let the app handle a
                                 push before the next step (notification_htlcincoming).
+    trigger_screenshot.js       Asks screenshot_server.js to fire a real
+                                Simulator screenshot (posts the screenshot
+                                notification, unlike Maestro's takeScreenshot);
+                                best-effort (fresh_install_unhappy).
+    screenshot_server.js        Local helper bridging Maestro → `osascript`
+                                clicking the Simulator's "Device > Trigger
+                                Screenshot". Needs Accessibility permission, and
+                                the device's Settings > General > Screen Capture >
+                                "Full-Screen Previews" turned OFF (else the
+                                preview covers the app and blocks the flow).
 ```
 
 ## Conventions

--- a/shared/flows/onboarding/fresh_install_unhappy.yaml
+++ b/shared/flows/onboarding/fresh_install_unhappy.yaml
@@ -1,0 +1,356 @@
+# Onboarding unhappy-path: wipes state and walks wallet creation through every
+# validation gate — the confirm-statements alert, the seed-phrase screenshot
+# warning, an invalid non-BIP39 word then a wrong recovery-phrase entry, and the
+# PIN length/mismatch alerts — before finally creating the wallet and landing on
+# Home.
+#
+# The happy-path counterpart is onboarding/happy_path_wallet.yaml; this exercises
+# the error branches that flow doesn't. Starts from a clean install (clearState +
+# clearKeychain), so no prior wallet is required.
+#
+# Note on the screenshot warning: the app shows a "Be careful!" alert when it
+# receives iOS's userDidTakeScreenshotNotification on the mnemonic screen.
+# Maestro's takeScreenshot only grabs the framebuffer and does NOT post that
+# notification, so this flow also triggers a real Simulator screenshot
+# (Device > Trigger Screenshot) via scripts/screenshot_server.js, which does.
+#
+# This part is OPTIONAL — without the setup below the alert step is skipped and
+# the flow still passes. To exercise and capture the alert, do ALL of:
+#   1. Run the helper:  node shared/flows/scripts/screenshot_server.js
+#   2. Grant your terminal Accessibility control (System Settings > Privacy &
+#      Security > Accessibility) so it can drive the Simulator menu.
+#   3. On the simulated device, turn OFF Settings > General > Screen Capture >
+#      "Full-Screen Previews". With it ON, the screenshot preview covers the app
+#      and never auto-dismisses, blocking the rest of the flow; with it OFF the
+#      preview is a corner thumbnail that clears on its own.
+#
+# Alert screenshots are taken after waitForAnimationToEnd so the alert is fully
+# slid up and cleanly visible.
+#
+# Run: maestro test shared/flows/onboarding/fresh_install_unhappy.yaml
+
+appId: com.bittr.bittr-regtest
+---
+# Clean slate — no wallet.
+- launchApp:
+    clearState: true
+    clearKeychain: true
+
+# Signup1 (start).
+- assertVisible:
+    id: "signup.create.start.createWalletButton"
+- takeScreenshot: shared/docs/screenshots/fresh_install_unhappy/01_signup1
+
+# Create wallet → confirm screen (Signup2), then Cancel straight back to Signup1.
+- tapOn:
+    id: "signup.create.start.createWalletButton"
+- assertVisible:
+    id: "signup.create.confirm.topLabel"
+- takeScreenshot: shared/docs/screenshots/fresh_install_unhappy/02_confirm
+- tapOn:
+    id: "signup.create.confirm.cancelButton"
+- assertVisible:
+    id: "signup.create.start.createWalletButton"
+- takeScreenshot: shared/docs/screenshots/fresh_install_unhappy/03_back_on_signup1
+
+# Create wallet again → tap "I understand" with neither toggle on → the
+# "please confirm the above statements" alert.
+- tapOn:
+    id: "signup.create.start.createWalletButton"
+- assertVisible:
+    id: "signup.create.confirm.topLabel"
+- tapOn:
+    id: "signup.create.confirm.nextButton"
+- assertVisible:
+    text: ".*confirm the above statements.*"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: shared/docs/screenshots/fresh_install_unhappy/04_confirm_statements_alert
+- tapOn:
+    id: "alert.button.0"
+
+# Turn both toggles on, then "I understand" → mnemonic screen (Signup3).
+- tapOn:
+    id: "signup.create.confirm.switchOne"
+- tapOn:
+    id: "signup.create.confirm.switchTwo"
+- tapOn:
+    id: "signup.create.confirm.nextButton"
+- assertVisible:
+    id: "signup.create.mnemonic.mnemonicStack"
+
+# The user takes a screenshot of the seed phrase. Maestro's takeScreenshot only
+# grabs the framebuffer (no userDidTakeScreenshotNotification), so also fire a
+# REAL Simulator screenshot via the helper (Device > Trigger Screenshot) — that
+# posts the notification and triggers the app's "Be careful!" warning. Best-
+# effort: with scripts/screenshot_server.js running (+ Accessibility permission)
+# the alert appears and is captured + dismissed; without it this is skipped and
+# the flow still passes.
+- takeScreenshot: shared/docs/screenshots/fresh_install_unhappy/05_mnemonic_screenshot
+- runScript: ../scripts/trigger_screenshot.js
+- runFlow:
+    when:
+      visible:
+        text: ".*recommend against screenshotting.*"
+    commands:
+      - waitForAnimationToEnd:
+          timeout: 3000
+      - takeScreenshot: shared/docs/screenshots/fresh_install_unhappy/06_screenshot_warning
+      - tapOn:
+          id: "alert.button.0"
+      # Triggering a real screenshot also raises iOS's screenshot preview, which
+      # isn't a targetable element. This step requires "Full-Screen Previews" to
+      # be OFF (Settings > General > Screen Capture) so the preview is the small
+      # corner thumbnail that auto-dismisses — wait out that ~5s before scrolling.
+      # (With Full-Screen Previews ON the preview covers the app and never
+      # dismisses, blocking the rest of the flow — see the header note.)
+      - evalScript: ${output.sleepMs = 6000}
+      - runScript: ../scripts/sleep.js
+
+# Scroll down and continue to the verify screen (Signup4).
+- scrollUntilVisible:
+    element:
+      id: "signup.create.mnemonic.nextButton"
+- tapOn:
+    id: "signup.create.mnemonic.nextButton"
+- assertVisible:
+    id: "signup.create.verify.topLabel"
+
+# First verify attempt: enter two valid words plus one non-BIP39 word
+# ("nonexistent") → Confirm → the "invalid words" alert (that word isn't in the
+# recovery-phrase word list). Close the keyboard first (tapping the
+# non-interactive topLabel falls through to endEditing) so Confirm is reachable.
+- tapOn:
+    id: "signup.create.verify.field1"
+- inputText: "wrong"
+- tapOn:
+    id: "signup.create.verify.field2"
+- inputText: "wrong"
+- tapOn:
+    id: "signup.create.verify.field3"
+- inputText: "nonexistent"
+- tapOn:
+    id: "signup.create.verify.topLabel"
+- tapOn:
+    id: "signup.create.verify.nextButton"
+- assertVisible:
+    text: ".*not valid recovery phrase words.*"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: shared/docs/screenshots/fresh_install_unhappy/07_invalid_word_alert
+- tapOn:
+    id: "alert.button.0"
+
+# Fix the third field to a valid (but still incorrect) word: now all three are
+# real BIP39 words yet none matches → Confirm → the "incorrect recovery phrase"
+# alert. Tap near the field's right edge so the caret lands at the end, erase
+# "nonexistent", then type "wrong".
+- tapOn:
+    id: "signup.create.verify.field3"
+    point: "95%,50%"
+- eraseText
+- inputText: "wrong"
+- tapOn:
+    id: "signup.create.verify.topLabel"
+- tapOn:
+    id: "signup.create.verify.nextButton"
+- assertVisible:
+    text: ".*entered are incorrect.*"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: shared/docs/screenshots/fresh_install_unhappy/08_wrong_phrase_alert
+- tapOn:
+    id: "alert.button.0"
+
+# Back to the mnemonic screen (Signup3), capture the 12 words this time, and
+# continue to the verify screen again.
+- tapOn:
+    id: "signup.create.verify.backButton"
+- assertVisible:
+    id: "signup.create.mnemonic.mnemonicStack"
+- evalScript: ${output.words = {}}
+- copyTextFrom:
+    id: "signup.create.mnemonic.word1"
+- evalScript: ${output.words[1] = maestro.copiedText}
+- copyTextFrom:
+    id: "signup.create.mnemonic.word2"
+- evalScript: ${output.words[2] = maestro.copiedText}
+- copyTextFrom:
+    id: "signup.create.mnemonic.word3"
+- evalScript: ${output.words[3] = maestro.copiedText}
+- copyTextFrom:
+    id: "signup.create.mnemonic.word4"
+- evalScript: ${output.words[4] = maestro.copiedText}
+- copyTextFrom:
+    id: "signup.create.mnemonic.word5"
+- evalScript: ${output.words[5] = maestro.copiedText}
+- copyTextFrom:
+    id: "signup.create.mnemonic.word6"
+- evalScript: ${output.words[6] = maestro.copiedText}
+- copyTextFrom:
+    id: "signup.create.mnemonic.word7"
+- evalScript: ${output.words[7] = maestro.copiedText}
+- copyTextFrom:
+    id: "signup.create.mnemonic.word8"
+- evalScript: ${output.words[8] = maestro.copiedText}
+- copyTextFrom:
+    id: "signup.create.mnemonic.word9"
+- evalScript: ${output.words[9] = maestro.copiedText}
+- copyTextFrom:
+    id: "signup.create.mnemonic.word10"
+- evalScript: ${output.words[10] = maestro.copiedText}
+- copyTextFrom:
+    id: "signup.create.mnemonic.word11"
+- evalScript: ${output.words[11] = maestro.copiedText}
+- copyTextFrom:
+    id: "signup.create.mnemonic.word12"
+- evalScript: ${output.words[12] = maestro.copiedText}
+- scrollUntilVisible:
+    element:
+      id: "signup.create.mnemonic.nextButton"
+- tapOn:
+    id: "signup.create.mnemonic.nextButton"
+
+# Second verify attempt: the screen asks for three 1-based indices; enter the
+# matching words. Closing the keyboard auto-advances once all three match
+# (same as happy_path_wallet.yaml) → PIN set screen (Signup5).
+- assertVisible:
+    id: "signup.create.verify.topLabel"
+- copyTextFrom:
+    id: "signup.create.verify.label1"
+- evalScript: ${output.idx1 = parseInt(maestro.copiedText)}
+- copyTextFrom:
+    id: "signup.create.verify.label2"
+- evalScript: ${output.idx2 = parseInt(maestro.copiedText)}
+- copyTextFrom:
+    id: "signup.create.verify.label3"
+- evalScript: ${output.idx3 = parseInt(maestro.copiedText)}
+- tapOn:
+    id: "signup.create.verify.field1"
+- inputText: ${output.words[output.idx1]}
+- tapOn:
+    id: "signup.create.verify.field2"
+- inputText: ${output.words[output.idx2]}
+- tapOn:
+    id: "signup.create.verify.field3"
+- inputText: ${output.words[output.idx3]}
+- tapOn:
+    id: "signup.create.verify.topLabel"
+
+# PIN set (Signup5). Enter 123 (too short) → Next → the "4 to 8 digits" alert.
+- assertVisible:
+    id: "signup.create.pinSet.topLabel"
+- takeScreenshot: shared/docs/screenshots/fresh_install_unhappy/09_pin_set
+- tapOn:
+    id: "pin.button1"
+- tapOn:
+    id: "pin.button2"
+- tapOn:
+    id: "pin.button3"
+- tapOn:
+    id: "pin.confirmButton"
+- assertVisible:
+    text: ".*between 4 and 8 digits.*"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: shared/docs/screenshots/fresh_install_unhappy/10_pin_too_short_alert
+- tapOn:
+    id: "alert.button.0"
+
+# Add 456789. The 9th digit is rejected with the "up to 8 digits" alert; the PIN
+# stays at 12345678.
+- tapOn:
+    id: "pin.button4"
+- tapOn:
+    id: "pin.button5"
+- tapOn:
+    id: "pin.button6"
+- tapOn:
+    id: "pin.button7"
+- tapOn:
+    id: "pin.button8"
+- tapOn:
+    id: "pin.button9"
+- assertVisible:
+    text: ".*up to 8 digits.*"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: shared/docs/screenshots/fresh_install_unhappy/11_pin_too_long_alert
+- tapOn:
+    id: "alert.button.0"
+
+# Backspace 4 times → 1234, then Next → PIN confirm screen (Signup6).
+- tapOn:
+    id: "pin.buttonBackspace"
+- tapOn:
+    id: "pin.buttonBackspace"
+- tapOn:
+    id: "pin.buttonBackspace"
+- tapOn:
+    id: "pin.buttonBackspace"
+- tapOn:
+    id: "pin.confirmButton"
+
+# Confirm PIN (Signup6): enter a mismatching 1111 → Confirm → the "repeat the
+# same number" alert.
+- assertVisible:
+    id: "signup.create.pinConfirm.topLabel"
+- tapOn:
+    id: "pin.button1"
+- tapOn:
+    id: "pin.button1"
+- tapOn:
+    id: "pin.button1"
+- tapOn:
+    id: "pin.button1"
+- tapOn:
+    id: "pin.confirmButton"
+- assertVisible:
+    text: ".*Repeat the same number.*"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: shared/docs/screenshots/fresh_install_unhappy/12_pin_mismatch_alert
+- tapOn:
+    id: "alert.button.0"
+
+# Back (the PIN pad's restore button is labelled "Back" here) → PIN set again.
+- tapOn:
+    id: "pin.restoreButton"
+- assertVisible:
+    id: "signup.create.pinSet.topLabel"
+
+# Enter 1234 → Next → PIN confirm.
+- tapOn:
+    id: "pin.button1"
+- tapOn:
+    id: "pin.button2"
+- tapOn:
+    id: "pin.button3"
+- tapOn:
+    id: "pin.button4"
+- tapOn:
+    id: "pin.confirmButton"
+
+# Confirm with the matching 1234 → wallet ready (Signup7).
+- assertVisible:
+    id: "signup.create.pinConfirm.topLabel"
+- tapOn:
+    id: "pin.button1"
+- tapOn:
+    id: "pin.button2"
+- tapOn:
+    id: "pin.button3"
+- tapOn:
+    id: "pin.button4"
+- tapOn:
+    id: "pin.confirmButton"
+
+# Wallet ready → Skip the bittr signup → Home.
+- assertVisible:
+    id: "signup.create.ready.topLabelOne"
+- takeScreenshot: shared/docs/screenshots/fresh_install_unhappy/13_wallet_ready
+- tapOn:
+    id: "signup.create.ready.skipButton"
+- assertVisible:
+    id: "home.headerLabel"
+- takeScreenshot: shared/docs/screenshots/fresh_install_unhappy/14_home

--- a/shared/flows/scripts/screenshot_server.js
+++ b/shared/flows/scripts/screenshot_server.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Local HTTP helper for Maestro flows — on POST /screenshot it invokes the iOS
+// Simulator's "Device > Trigger Screenshot" menu item via AppleScript.
+//
+// Why: `xcrun simctl io screenshot` and Maestro's own takeScreenshot only grab
+// the framebuffer, so they do NOT post UIApplication.userDidTakeScreenshotNotification.
+// The Simulator's "Trigger Screenshot" menu emulates the real screenshot gesture
+// and DOES post it, so an app that reacts to screenshots (e.g. the seed-phrase
+// "Be careful!" warning) fires. Maestro's GraalJS sandbox can't shell out, so —
+// like push_server.js / clipboard_server.js — this server does it.
+//
+// Prerequisites:
+//   - The Simulator is running.
+//   - This process is allowed to control the computer via Accessibility:
+//     System Settings > Privacy & Security > Accessibility → enable the terminal
+//     app you run this from (System Events automation otherwise fails).
+//   - The exact menu path can differ by Xcode version; adjust the AppleScript
+//     below if the item isn't found (it matches any Device-menu item containing
+//     "Screenshot").
+//   - On the simulated device, turn OFF Settings > General > Screen Capture >
+//     "Full-Screen Previews". Otherwise the screenshot preview covers the app
+//     and never auto-dismisses, blocking flows that continue after the shot.
+//
+// Run once before testing:
+//   node shared/flows/scripts/screenshot_server.js
+
+const http = require('http');
+const { spawnSync } = require('child_process');
+
+const PORT = 8890;
+
+// Activate the Simulator, then click the first "Device" menu item whose name
+// contains "Screenshot" (e.g. "Trigger Screenshot").
+const APPLESCRIPT = `
+tell application "Simulator" to activate
+delay 0.3
+tell application "System Events"
+  tell process "Simulator"
+    set deviceMenu to menu "Device" of menu bar 1
+    repeat with mi in menu items of deviceMenu
+      try
+        if name of mi contains "Screenshot" then
+          click mi
+          return "clicked: " & (name of mi)
+        end if
+      end try
+    end repeat
+    error "No Device-menu item containing 'Screenshot' was found"
+  end tell
+end tell
+`;
+
+http.createServer((req, res) => {
+    if (req.method !== 'POST' || req.url !== '/screenshot') {
+        res.writeHead(404);
+        res.end('only POST /screenshot is supported');
+        return;
+    }
+    const result = spawnSync('osascript', ['-e', APPLESCRIPT]);
+    const stdout = result.stdout?.toString().trim() ?? '';
+    const stderr = result.stderr?.toString().trim() ?? '';
+    if (result.status !== 0) {
+        console.error('osascript failed:', stderr);
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, stderr }));
+        return;
+    }
+    console.log(`triggered simulator screenshot (${stdout})`);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, stdout }));
+}).listen(PORT, '127.0.0.1', () => {
+    console.log(`maestro screenshot helper listening on http://127.0.0.1:${PORT}/screenshot`);
+    console.log('forwarding to: osascript → Simulator "Device > Trigger Screenshot"');
+});

--- a/shared/flows/scripts/trigger_screenshot.js
+++ b/shared/flows/scripts/trigger_screenshot.js
@@ -1,0 +1,23 @@
+// Asks the local screenshot_server.js helper to fire the Simulator's
+// "Device > Trigger Screenshot", which posts userDidTakeScreenshotNotification —
+// something Maestro's own takeScreenshot does not do. Use this when a flow needs
+// the app to react to a real screenshot (e.g. the seed-phrase warning).
+//
+// Prerequisite (best-effort): the helper must be running —
+//   node shared/flows/scripts/screenshot_server.js
+// If it isn't reachable this logs and returns without throwing, so the calling
+// flow can treat the resulting alert as optional and still pass.
+
+try {
+    var response = http.post(
+        'http://localhost:8890/screenshot',
+        { headers: { 'Content-Type': 'application/json' }, body: '{}' }
+    );
+    console.log('screenshot helper status: ' + response.status);
+    console.log('screenshot helper body: ' + response.body);
+    if (response.status < 200 || response.status >= 300) {
+        console.log('screenshot helper returned an error — the seed-phrase warning may not fire.');
+    }
+} catch (e) {
+    console.log('screenshot helper not reachable (skipping real screenshot trigger): ' + e);
+}


### PR DESCRIPTION
- New test **fresh_install_unhappy.yaml** to test all possible alerts during wallet creation.
- Requires to run **node shared/flows/scripts/screenshot_server.js** to take screenshots.
- Requires that **Terminal has Accessibility access** (Apple icon > System Settings > Privacy & Security > Accessibility > + > Applications > Utilities > Terminal.
- Requires **on the simulator**, go to Settings > General > Screen Capture > **Full-Screen Previews OFF**.
- Small guard for listenForEvents() crash.
- Small fix for PinVC numbers highlighting.