### PR TITLE
Store PIN and Mnemonic in Keychain instead of UserDefaults

### DIFF
--- a/ios/bittr.xcodeproj/project.pbxproj
+++ b/ios/bittr.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		05C5A0ED2A33252C004CC671 /* Transfer1ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05C5A0EC2A33252C004CC671 /* Transfer1ViewController.swift */; };
 		05C5A0EF2A334E30004CC671 /* Transfer3ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05C5A0EE2A334E30004CC671 /* Transfer3ViewController.swift */; };
 		05CF0FE62D32557300DF2D9F /* GraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CF0FE52D32557300DF2D9F /* GraphView.swift */; };
+		05CF63B93004ECB800E55351 /* SecureStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CF63B83004ECB800E55351 /* SecureStore.swift */; };
 		05CF933A2A1E711B0084A221 /* Signup3ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CF93392A1E711B0084A221 /* Signup3ViewController.swift */; };
 		05D5D0E72A66825000A1E771 /* BitcoinManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D5D0E62A66825000A1E771 /* BitcoinManager.swift */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		05D5D0EA2A66836300A1E771 /* LightningStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D5D0E92A66836300A1E771 /* LightningStorage.swift */; };
@@ -347,6 +348,7 @@
 		05C5A0EC2A33252C004CC671 /* Transfer1ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transfer1ViewController.swift; sourceTree = "<group>"; };
 		05C5A0EE2A334E30004CC671 /* Transfer3ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transfer3ViewController.swift; sourceTree = "<group>"; };
 		05CF0FE52D32557300DF2D9F /* GraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphView.swift; sourceTree = "<group>"; };
+		05CF63B83004ECB800E55351 /* SecureStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureStore.swift; sourceTree = "<group>"; };
 		05CF93392A1E711B0084A221 /* Signup3ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Signup3ViewController.swift; sourceTree = "<group>"; };
 		05D5D0E62A66825000A1E771 /* BitcoinManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitcoinManager.swift; sourceTree = "<group>"; };
 		05D5D0E92A66836300A1E771 /* LightningStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightningStorage.swift; sourceTree = "<group>"; };
@@ -876,6 +878,7 @@
 				051BE0872B641D41009CED5B /* Reachability.swift */,
 				059704A62E43514F00B56690 /* BitcoinValue.swift */,
 				05117B9D2EDEC6AA00A5E4E6 /* Log.swift */,
+				05CF63B83004ECB800E55351 /* SecureStore.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1290,6 +1293,7 @@
 				05C3C0B629CCBFED00C1E695 /* CoreViewController.swift in Sources */,
 				05A8BD7E2B7509BD002F0282 /* StartLightning.swift in Sources */,
 				05D5D0EA2A66836300A1E771 /* LightningStorage.swift in Sources */,
+				05CF63B93004ECB800E55351 /* SecureStore.swift in Sources */,
 				05622A692DB61E3B00D91066 /* AlertManager.swift in Sources */,
 				0509EFBA2FC7FC1F003488D4 /* UIButton.swift in Sources */,
 				058B2FD42EE9B5A70010693D /* URIs.swift in Sources */,

--- a/ios/bittr/AppDelegate.swift
+++ b/ios/bittr/AppDelegate.swift
@@ -139,6 +139,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             }
         }
 
+        // Migrate any legacy UserDefaults-stored secrets (mnemonic, PIN) into the
+        // Keychain. Safe to call on every launch; a no-op once migrated. The
+        // getters also self-heal on first read, so this is just eager cleanup.
+        CacheManager.migrateSecretsToKeychainIfNeeded()
+
         UNUserNotificationCenter.current().delegate = self
         
         return true

--- a/ios/bittr/BitcoinManager.swift
+++ b/ios/bittr/BitcoinManager.swift
@@ -648,7 +648,10 @@ class BitcoinManager {
         let network: KeyDerivationNetwork = EnvironmentConfig.isDevelopment ? .testnet : .mainnet
         
         // Create SimpleKeyDerivation instance with the stored mnemonic
-        let keyDerivation = try SimpleKeyDerivation(mnemonic: CacheManager.getMnemonic()!, network: network)
+        guard let mnemonic = CacheManager.getMnemonic() else {
+            throw WalletError.walletNotInitiated
+        }
+        let keyDerivation = try SimpleKeyDerivation(mnemonic: mnemonic, network: network)
             
         // Derive keys for the given path
         let (privateKeyHex, publicKeyHex) = try keyDerivation.getPrivatePublicKeyForPath(path)

--- a/ios/bittr/BitcoinManager.swift
+++ b/ios/bittr/BitcoinManager.swift
@@ -158,11 +158,11 @@ class BitcoinManager {
         return true
     }
     
-    func getNewMnemonic() -> String {
+    func getNewMnemonic() throws -> String {
         // New mnemonic.
         Log.info("Creating a new mnemonic.")
         let newMnemonic:String = LDKNode.generateEntropyMnemonic(wordCount: .words12).description
-        CacheManager.storeMnemonic(newMnemonic)
+        try CacheManager.storeMnemonic(newMnemonic)
         return newMnemonic
     }
     

--- a/ios/bittr/CacheManager.swift
+++ b/ios/bittr/CacheManager.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import Sentry
+import CryptoKit
 
 class CacheManager: NSObject {
     
@@ -893,19 +894,56 @@ class CacheManager: NSObject {
     }
     
     // MARK: - Pin
-    
-    // The PIN is stored in the Keychain as its raw value so getPin()'s existing
-    // call sites (PinViewController) keep working unchanged. It is protected at
-    // rest by the Keychain (device-locked, never backed up or synced). Follow-up
-    // hardening: store a salted hash behind a verifyPin() API, and move the
-    // failed-attempt counter into the Keychain too (it is currently a plain,
-    // resettable Int in UserDefaults).
+
+    // The PIN is stored as a salted SHA-256 record ("v1$<salt>$<digest>",
+    // base64) so its raw value never sits anywhere at rest — people reuse
+    // bank-card PINs, so disclosure matters beyond this app. Honest scope:
+    // hashing cannot make a 4-8 digit PIN resistant to offline brute force
+    // (the keyspace is tiny); the wipe-after-10 attempt counter is the real
+    // guard, and the mnemonic — not the PIN — is the actual key material.
+    // Legacy raw values (UserDefaults, or early Keychain builds) are
+    // re-hashed by the launch migration; verifyPin also upgrades any
+    // straggler on its next successful entry.
     static func storePin(pin:String) {
-        writeSecret(pin, account: EnvironmentConfig.cacheKey(for: "pin"), label: "pin", accessibility: .whenUnlockedThisDeviceOnly)
+        writeSecret(hashedPinRecord(for: pin), account: EnvironmentConfig.cacheKey(for: "pin"), label: "pin", accessibility: .whenUnlockedThisDeviceOnly)
     }
-    
-    static func getPin() -> String? {
-        readSecret(account: EnvironmentConfig.cacheKey(for: "pin"))
+
+    /// Whether a PIN is stored (hashed or legacy raw).
+    static func hasPin() -> Bool {
+        readSecret(account: EnvironmentConfig.cacheKey(for: "pin")) != nil
+    }
+
+    /// Check an entered PIN against the stored record.
+    static func verifyPin(_ entered: String) -> Bool {
+        guard let stored = readSecret(account: EnvironmentConfig.cacheKey(for: "pin")) else { return false }
+        if let record = parseHashedPinRecord(stored) {
+            return pinDigest(entered, salt: record.salt) == record.digest
+        }
+        // Legacy raw value — compare directly, and upgrade to the hashed form
+        // now that the correct PIN is known.
+        guard stored == entered else { return false }
+        storePin(pin: entered)
+        return true
+    }
+
+    private static func hashedPinRecord(for pin: String) -> String {
+        var salt = Data(count: 32)
+        _ = salt.withUnsafeMutableBytes { SecRandomCopyBytes(kSecRandomDefault, 32, $0.baseAddress!) }
+        return "v1$\(salt.base64EncodedString())$\(pinDigest(pin, salt: salt).base64EncodedString())"
+    }
+
+    private static func parseHashedPinRecord(_ record: String) -> (salt: Data, digest: Data)? {
+        let parts = record.split(separator: "$")
+        guard parts.count == 3, parts[0] == "v1",
+              let salt = Data(base64Encoded: String(parts[1])),
+              let digest = Data(base64Encoded: String(parts[2])) else { return nil }
+        return (salt, digest)
+    }
+
+    private static func pinDigest(_ pin: String, salt: Data) -> Data {
+        var input = salt
+        input.append(Data(pin.utf8))
+        return Data(SHA256.hash(data: input))
     }
     
     // MARK: - Secure storage (Keychain)
@@ -949,6 +987,11 @@ class CacheManager: NSObject {
         // Rewriting in place re-applies the intended class; idempotent.
         refreshAccessibility(account: EnvironmentConfig.cacheKey(for: "mnemonic"), accessibility: .afterFirstUnlockThisDeviceOnly)
         refreshAccessibility(account: EnvironmentConfig.cacheKey(for: "pin"), accessibility: .whenUnlockedThisDeviceOnly)
+        // Re-hash a legacy raw PIN (from UserDefaults, or an early Keychain
+        // build that stored the raw value).
+        if let storedPin = (try? SecureStore.getString(account: EnvironmentConfig.cacheKey(for: "pin"))) ?? nil, parseHashedPinRecord(storedPin) == nil {
+            storePin(pin: storedPin)
+        }
     }
 
     /// Re-apply the intended accessibility class to an already-stored secret
@@ -1154,39 +1197,45 @@ class CacheManager: NSObject {
     
     // MARK: - Failed pin attempts
     
+    // The wipe-after-10 counter lives in the Keychain, not UserDefaults:
+    // backups restore UserDefaults but a live device's Keychain kept the PIN,
+    // so a backup-restore cycle used to reset the counter while the PIN
+    // survived — unlimited attempts for anyone with backup access. Honest
+    // scope: a full same-device erase-and-restore replays ThisDeviceOnly
+    // items too and buys another 9 attempts per multi-minute cycle; the
+    // Keychain counter turns a seconds-long plist edit into that, it does
+    // not eliminate it. Reads fail open (0): wiping wallets on a transient
+    // Keychain error would be worse than granting extra attempts.
+    private static var failedAttemptsAccount: String {
+        EnvironmentConfig.cacheKey(for: "failedattempts")
+    }
+
     static func getFailedPinAttempts() -> Int {
-        
-        let envKey = EnvironmentConfig.cacheKey(for: "failedattempts")
-        
-        let defaults = UserDefaults.standard
-        let cachedFailedAttempts = defaults.value(forKey: envKey) as? Int
-        if let actualCachedAttempts = cachedFailedAttempts {
-            return actualCachedAttempts
-        } else {
-            return 0
-        }
+        migrateLegacyFailedAttemptsIfNeeded()
+        guard let stored = (try? SecureStore.getString(account: failedAttemptsAccount)) ?? nil else { return 0 }
+        return Int(stored) ?? 0
     }
-    
+
     static func increaseFailedPinAttempts() {
-        
-        let envKey = EnvironmentConfig.cacheKey(for: "failedattempts")
-        
-        let defaults = UserDefaults.standard
-        let cachedFailedAttempts = defaults.value(forKey: envKey) as? Int
-        if var actualCachedAttempts = cachedFailedAttempts {
-            actualCachedAttempts += 1
-            defaults.set(actualCachedAttempts, forKey: envKey)
-        } else {
-            defaults.set(1, forKey: envKey)
-        }
+        let next = getFailedPinAttempts() + 1
+        try? SecureStore.setString("\(next)", account: failedAttemptsAccount, accessibility: .whenUnlockedThisDeviceOnly)
     }
-    
+
     static func resetFailedPinAttempts() {
-        
-        let envKey = EnvironmentConfig.cacheKey(for: "failedattempts")
-        
-        let defaults = UserDefaults.standard
-        defaults.set(0, forKey: envKey)
+        SecureStore.remove(account: failedAttemptsAccount)
+        UserDefaults.standard.removeObject(forKey: failedAttemptsAccount)
+    }
+
+    /// Move a legacy UserDefaults counter into the Keychain. Keeps the higher
+    /// of the two values so a restored (older) count can never lower a live
+    /// one. Idempotent; the UserDefaults copy is removed once read.
+    private static func migrateLegacyFailedAttemptsIfNeeded() {
+        guard let legacy = UserDefaults.standard.value(forKey: failedAttemptsAccount) as? Int else { return }
+        let current = Int(((try? SecureStore.getString(account: failedAttemptsAccount)) ?? nil) ?? "0") ?? 0
+        if legacy > current {
+            try? SecureStore.setString("\(legacy)", account: failedAttemptsAccount, accessibility: .whenUnlockedThisDeviceOnly)
+        }
+        UserDefaults.standard.removeObject(forKey: failedAttemptsAccount)
     }
 
     // MARK: - Wallet removal in progress

--- a/ios/bittr/CacheManager.swift
+++ b/ios/bittr/CacheManager.swift
@@ -942,6 +942,24 @@ class CacheManager: NSObject {
         migrateLegacyValue(account: EnvironmentConfig.cacheKey(for: "mnemonic"))
         migrateLegacyValue(account: EnvironmentConfig.cacheKey(for: "pin"))
         migrateLegacyOngoingSwapKey()
+        applyProtectionToExistingSwapFiles()
+    }
+
+    /// Stamp existing swap JSON files with the at-rest protection class that
+    /// new writes get explicitly (saveSwapDetailsToFile). Files are only ever
+    /// rewritten while a swap is in flight, so completed swaps' files would
+    /// otherwise keep whatever class they were created with. Idempotent and
+    /// content-preserving: this sets a file attribute — the file's deliberate
+    /// plain-text content (the Boltz rescue artifact) is untouched.
+    private static func applyProtectionToExistingSwapFiles() {
+        let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        guard let files = try? FileManager.default.contentsOfDirectory(at: documentsPath, includingPropertiesForKeys: nil) else { return }
+        for file in files where file.pathExtension == "json" {
+            try? FileManager.default.setAttributes(
+                [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+                ofItemAtPath: file.path
+            )
+        }
     }
 
     /// Move a legacy ongoingswap dictionary's inline Boltz refund key into the

--- a/ios/bittr/CacheManager.swift
+++ b/ios/bittr/CacheManager.swift
@@ -878,8 +878,8 @@ class CacheManager: NSObject {
     
     // MARK: - Mnemonic
     
-    static func storeMnemonic(_ mnemonic:String) {
-        writeSecret(mnemonic, account: EnvironmentConfig.cacheKey(for: "mnemonic"), label: "mnemonic")
+    static func storeMnemonic(_ mnemonic:String) throws {
+        try persistSecret(mnemonic, account: EnvironmentConfig.cacheKey(for: "mnemonic"), label: "mnemonic")
     }
     
     static func getMnemonic() -> String? {
@@ -936,23 +936,29 @@ class CacheManager: NSObject {
         migrateLegacyValue(account: EnvironmentConfig.cacheKey(for: "pin"))
     }
 
-    /// Write a secret to the Keychain, verifying the write by reading it back.
-    /// storeMnemonic/storePin stay non-throwing to preserve their call sites; a
-    /// failure is reported to Sentry rather than silently losing the value.
-    /// (Recommended follow-up: make the mnemonic write throwing so the wallet-
-    /// creation flow can abort/retry if the seed cannot be persisted.)
-    private static func writeSecret(_ value: String, account: String, label: String) {
+    /// Write a secret to the Keychain and confirm it by reading it back. Throws
+    /// if the write fails or the read-back doesn't match, so callers that must
+    /// not proceed without the secret persisted (wallet creation/restore) can
+    /// fail loudly instead of stranding a wallet whose seed was never saved.
+    private static func persistSecret(_ value: String, account: String, label: String) throws {
         do {
             try SecureStore.setString(value, account: account)
             let readBack = (try? SecureStore.getString(account: account)) ?? nil
-            if readBack != value {
-                SentrySDK.capture(message: "Keychain \(label) write could not be verified.")
+            guard readBack == value else {
+                throw SecureStore.SecureStoreError.writeVerificationFailed
             }
         } catch {
             SentrySDK.capture(error: error) { scope in
                 scope.setExtra(value: "storing \(label) in keychain", key: "context")
             }
+            throw error
         }
+    }
+
+    /// Non-throwing convenience for secrets where a failed write is recoverable
+    /// (e.g. the PIN, which can be reset via the mnemonic). Failures are logged.
+    private static func writeSecret(_ value: String, account: String, label: String) {
+        try? persistSecret(value, account: account, label: label)
     }
 
     /// Non-throwing read used by getMnemonic()/getPin(). A Keychain read failure

--- a/ios/bittr/CacheManager.swift
+++ b/ios/bittr/CacheManager.swift
@@ -22,6 +22,12 @@ class CacheManager: NSObject {
         defaults.removeObject(forKey: EnvironmentConfig.cacheKey(for: "lightning"))
         defaults.removeObject(forKey: EnvironmentConfig.cacheKey(for: "bittraddress"))
         defaults.removeObject(forKey: EnvironmentConfig.cacheKey(for: "onchainaddresses"))
+
+        // Remove the secrets from the Keychain too — they no longer live in
+        // UserDefaults, so the UserDefaults removals above wouldn't clear them.
+        SecureStore.remove(account: EnvironmentConfig.cacheKey(for: "mnemonic"))
+        SecureStore.remove(account: EnvironmentConfig.cacheKey(for: "pin"))
+
         self.resetFailedPinAttempts()
     }
     
@@ -873,49 +879,93 @@ class CacheManager: NSObject {
     // MARK: - Mnemonic
     
     static func storeMnemonic(_ mnemonic:String) {
-        
-        let envKey = EnvironmentConfig.cacheKey(for: "mnemonic")
-        
-        let defaults = UserDefaults.standard
-        defaults.set(mnemonic, forKey: envKey)
+        writeSecret(mnemonic, account: EnvironmentConfig.cacheKey(for: "mnemonic"), label: "mnemonic")
     }
     
     static func getMnemonic() -> String? {
-        
-        let envKey = EnvironmentConfig.cacheKey(for: "mnemonic")
-        
-        let defaults = UserDefaults.standard
-        let cachedMnemonic = defaults.value(forKey: envKey) as? String
-        
-        if let actualCachedMnemonic = cachedMnemonic {
-            return actualCachedMnemonic
-        } else {
-            return nil
-        }
+        readSecret(account: EnvironmentConfig.cacheKey(for: "mnemonic"))
     }
     
     // MARK: - Pin
     
+    // The PIN is stored in the Keychain as its raw value so getPin()'s existing
+    // call sites (PinViewController) keep working unchanged. It is protected at
+    // rest by the Keychain (device-locked, never backed up or synced). Follow-up
+    // hardening: store a salted hash behind a verifyPin() API, and move the
+    // failed-attempt counter into the Keychain too (it is currently a plain,
+    // resettable Int in UserDefaults).
     static func storePin(pin:String) {
-        
-        let envKey = EnvironmentConfig.cacheKey(for: "pin")
-        
-        let defaults = UserDefaults.standard
-        defaults.set(pin, forKey: envKey)
+        writeSecret(pin, account: EnvironmentConfig.cacheKey(for: "pin"), label: "pin")
     }
     
     static func getPin() -> String? {
+        readSecret(account: EnvironmentConfig.cacheKey(for: "pin"))
+    }
+    
+    // MARK: - Secure storage (Keychain)
+    
+    /// Eagerly migrate any legacy UserDefaults-stored secrets (mnemonic, PIN)
+    /// into the Keychain. Safe to call on every launch; a no-op once migrated.
+    static func migrateSecretsToKeychainIfNeeded() {
+        migrateLegacySecretIfNeeded(account: EnvironmentConfig.cacheKey(for: "mnemonic"))
+        migrateLegacySecretIfNeeded(account: EnvironmentConfig.cacheKey(for: "pin"))
+    }
+    
+    /// Write a secret to the Keychain, verifying the write by reading it back.
+    /// storeMnemonic/storePin stay non-throwing to preserve their call sites; a
+    /// failure is reported to Sentry rather than silently losing the value.
+    /// (Recommended follow-up: make the mnemonic write throwing so the wallet-
+    /// creation flow can abort/retry if the seed cannot be persisted.)
+    private static func writeSecret(_ value: String, account: String, label: String) {
+        do {
+            try SecureStore.setString(value, account: account)
+            if SecureStore.getString(account: account) != value {
+                SentrySDK.capture(message: "Keychain \(label) write could not be verified.")
+            }
+        } catch {
+            SentrySDK.capture(error: error) { scope in
+                scope.setExtra(value: "storing \(label) in keychain", key: "context")
+            }
+        }
+    }
+
+    /// Read a secret from the Keychain, transparently migrating a legacy
+    /// UserDefaults value on first read (older installs stored these in
+    /// UserDefaults).
+    private static func readSecret(account: String) -> String? {
+        if let value = SecureStore.getString(account: account) {
+            return value
+        }
+        return migrateLegacySecretIfNeeded(account: account)
+    }
+
+    /// Move a legacy UserDefaults value into the Keychain. The UserDefaults copy
+    /// is removed only once the Keychain copy reads back correctly, so a user is
+    /// never left without their seed. Idempotent.
+    @discardableResult
+    private static func migrateLegacySecretIfNeeded(account: String) -> String? {
+        // Already in the Keychain? Clean up any leftover UserDefaults copy.
+        if let value = SecureStore.getString(account: account) {
+            UserDefaults.standard.removeObject(forKey: account)
+            return value
+        }
         
-        let envKey = EnvironmentConfig.cacheKey(for: "pin")
-        
-        let defaults = UserDefaults.standard
-        let cachedPin = defaults.value(forKey: envKey) as? String
-        
-        if let actualCachedPin = cachedPin {
-            return actualCachedPin
-        } else {
+        guard let legacy = UserDefaults.standard.value(forKey: account) as? String else {
             return nil
         }
+        
+        do {
+            try SecureStore.setString(legacy, account: account)
+            if SecureStore.getString(account: account) == legacy {
+                UserDefaults.standard.removeObject(forKey: account)   // safe: verified in Keychain
+            }
+        } catch {
+            // Keychain write failed — keep the UserDefaults copy so access isn't lost.
+            SentrySDK.capture(error: error) { scope in
+                scope.setExtra(value: "migrating secret to keychain", key: "context")
+            }
+        }
+        return legacy
     }
     
     // MARK: - Txo ID

--- a/ios/bittr/CacheManager.swift
+++ b/ios/bittr/CacheManager.swift
@@ -904,13 +904,38 @@ class CacheManager: NSObject {
     
     // MARK: - Secure storage (Keychain)
     
+    // Check whether PIN and mnemonic are available.
+    enum WalletSecretsPresence {
+        case present
+        case absent
+        case unavailable
+    }
+    
+    static func walletSecretsPresence() -> WalletSecretsPresence {
+        // While the device is locked the WhenUnlockedThisDeviceOnly items are
+        // unreadable, so we can't decide anything.
+        guard UIApplication.shared.isProtectedDataAvailable else { return .unavailable }
+        do {
+            let mnemonic = try readSecretOrThrow(account: EnvironmentConfig.cacheKey(for: "mnemonic"))
+            let pin = try readSecretOrThrow(account: EnvironmentConfig.cacheKey(for: "pin"))
+            return (mnemonic != nil && pin != nil) ? .present : .absent
+        } catch {
+            // A Keychain read failed (not a genuine absence). Report it and treat
+            // as unavailable so nothing destructive happens.
+            SentrySDK.capture(error: error) { scope in
+                scope.setExtra(value: "reading wallet secrets for presence check", key: "context")
+            }
+            return .unavailable
+        }
+    }
+
     /// Eagerly migrate any legacy UserDefaults-stored secrets (mnemonic, PIN)
     /// into the Keychain. Safe to call on every launch; a no-op once migrated.
     static func migrateSecretsToKeychainIfNeeded() {
-        migrateLegacySecretIfNeeded(account: EnvironmentConfig.cacheKey(for: "mnemonic"))
-        migrateLegacySecretIfNeeded(account: EnvironmentConfig.cacheKey(for: "pin"))
+        migrateLegacyValue(account: EnvironmentConfig.cacheKey(for: "mnemonic"))
+        migrateLegacyValue(account: EnvironmentConfig.cacheKey(for: "pin"))
     }
-    
+
     /// Write a secret to the Keychain, verifying the write by reading it back.
     /// storeMnemonic/storePin stay non-throwing to preserve their call sites; a
     /// failure is reported to Sentry rather than silently losing the value.
@@ -919,7 +944,8 @@ class CacheManager: NSObject {
     private static func writeSecret(_ value: String, account: String, label: String) {
         do {
             try SecureStore.setString(value, account: account)
-            if SecureStore.getString(account: account) != value {
+            let readBack = (try? SecureStore.getString(account: account)) ?? nil
+            if readBack != value {
                 SentrySDK.capture(message: "Keychain \(label) write could not be verified.")
             }
         } catch {
@@ -929,34 +955,43 @@ class CacheManager: NSObject {
         }
     }
 
-    /// Read a secret from the Keychain, transparently migrating a legacy
-    /// UserDefaults value on first read (older installs stored these in
-    /// UserDefaults).
+    /// Non-throwing read used by getMnemonic()/getPin(). A Keychain read failure
+    /// yields nil here (existing callers guard on nil and handle it gracefully);
+    /// it never drives a destructive decision — the launch presence check uses
+    /// walletSecretsPresence() instead, which separates failure from absence.
     private static func readSecret(account: String) -> String? {
-        if let value = SecureStore.getString(account: account) {
-            return value
+        do {
+            return try readSecretOrThrow(account: account)
+        } catch {
+            // Keychain read failed — still honour a legacy UserDefaults copy if one exists.
+            return migrateLegacyValue(account: account)
         }
-        return migrateLegacySecretIfNeeded(account: account)
     }
 
-    /// Move a legacy UserDefaults value into the Keychain. The UserDefaults copy
-    /// is removed only once the Keychain copy reads back correctly, so a user is
-    /// never left without their seed. Idempotent.
-    @discardableResult
-    private static func migrateLegacySecretIfNeeded(account: String) -> String? {
-        // Already in the Keychain? Clean up any leftover UserDefaults copy.
-        if let value = SecureStore.getString(account: account) {
-            UserDefaults.standard.removeObject(forKey: account)
+    /// Read a secret, throwing on a Keychain read failure and returning nil only
+    /// when the value is genuinely absent (checked in the Keychain and in a
+    /// legacy UserDefaults copy). Migrates a legacy value on the way.
+    private static func readSecretOrThrow(account: String) throws -> String? {
+        if let value = try SecureStore.getString(account: account) {
+            UserDefaults.standard.removeObject(forKey: account)   // clean up any legacy leftover
             return value
         }
-        
+        return migrateLegacyValue(account: account)
+    }
+
+    /// Move a legacy UserDefaults value into the Keychain (if one exists). Returns
+    /// the value so a read still works even if the Keychain write can't complete
+    /// right now; the UserDefaults copy is removed only once the Keychain copy is
+    /// confirmed readable, so access is never lost. Idempotent.
+    @discardableResult
+    private static func migrateLegacyValue(account: String) -> String? {
         guard let legacy = UserDefaults.standard.value(forKey: account) as? String else {
             return nil
         }
-        
         do {
             try SecureStore.setString(legacy, account: account)
-            if SecureStore.getString(account: account) == legacy {
+            let confirmed = (try? SecureStore.getString(account: account)) ?? nil
+            if confirmed == legacy {
                 UserDefaults.standard.removeObject(forKey: account)   // safe: verified in Keychain
             }
         } catch {

--- a/ios/bittr/CacheManager.swift
+++ b/ios/bittr/CacheManager.swift
@@ -1044,7 +1044,7 @@ class CacheManager: NSObject {
             UserDefaults.standard.removeObject(forKey: account)   // clean up any legacy leftover
             return value
         }
-        return migrateLegacyValue(account: account)
+        return migrateLegacyValue(account: account, accessibility: accessibilityForAccount(account))
     }
 
     /// Move a legacy UserDefaults value into the Keychain (if one exists). Returns

--- a/ios/bittr/CacheManager.swift
+++ b/ios/bittr/CacheManager.swift
@@ -28,6 +28,12 @@ class CacheManager: NSObject {
         SecureStore.remove(account: EnvironmentConfig.cacheKey(for: "mnemonic"))
         SecureStore.remove(account: EnvironmentConfig.cacheKey(for: "pin"))
 
+        // A wiped wallet's pending swap is meaningless (its documents are
+        // deleted with the wallet): clear the ongoing-swap record and sweep
+        // the per-swap refund keys out of the Keychain.
+        defaults.removeObject(forKey: "ongoingswap")
+        SecureStore.removeAll(accountPrefix: "swapkey_")
+
         self.resetFailedPinAttempts()
     }
     
@@ -929,11 +935,29 @@ class CacheManager: NSObject {
         }
     }
 
-    /// Eagerly migrate any legacy UserDefaults-stored secrets (mnemonic, PIN)
-    /// into the Keychain. Safe to call on every launch; a no-op once migrated.
+    /// Eagerly migrate any legacy UserDefaults-stored secrets (mnemonic, PIN,
+    /// and an in-flight swap's refund key) into the Keychain. Safe to call on
+    /// every launch; a no-op once migrated.
     static func migrateSecretsToKeychainIfNeeded() {
         migrateLegacyValue(account: EnvironmentConfig.cacheKey(for: "mnemonic"))
         migrateLegacyValue(account: EnvironmentConfig.cacheKey(for: "pin"))
+        migrateLegacyOngoingSwapKey()
+    }
+
+    /// Move a legacy ongoingswap dictionary's inline Boltz refund key into the
+    /// Keychain. Same contract as migrateLegacyValue: the UserDefaults copy is
+    /// only stripped once the Keychain copy is confirmed readable, so access
+    /// is never lost. Idempotent.
+    private static func migrateLegacyOngoingSwapKey() {
+        guard let storedSwap = UserDefaults.standard.value(forKey: "ongoingswap") as? NSDictionary,
+              let privateKey = storedSwap["privateKey"] as? String,
+              let boltzID = storedSwap["boltzID"] as? String else {
+            return
+        }
+        if storeSwapPrivateKey(privateKey, boltzID: boltzID), let stripped = storedSwap.mutableCopy() as? NSMutableDictionary {
+            stripped.removeObject(forKey: "privateKey")
+            UserDefaults.standard.set(stripped, forKey: "ongoingswap")
+        }
     }
 
     /// Write a secret to the Keychain and confirm it by reading it back. Throws
@@ -1253,23 +1277,59 @@ class CacheManager: NSObject {
     // MARK: - Swaps
     
     static func saveLatestSwap(_ latestSwap:Swap?) {
-        
-        if latestSwap != nil {
-            let swapDictionary = latestSwap!.toDictionary()
+
+        if let swap = latestSwap, let swapDictionary = swap.toDictionary().mutableCopy() as? NSMutableDictionary {
+            // Keep the Boltz refund key out of UserDefaults: store it in the
+            // Keychain (keyed per swap) and strip it from the persisted
+            // dictionary — but only once the Keychain copy is confirmed
+            // readable. If the write fails, the key stays inline: for an
+            // in-flight swap, a plaintext key beats a lost refund key.
+            // (The per-swap JSON file DELIBERATELY keeps the key in plain
+            // text — it is the user-facing emergency artifact for Boltz's
+            // rescue flow and must not depend on a working app or Keychain.)
+            if let privateKey = swap.privateKey, let boltzID = swap.boltzID, storeSwapPrivateKey(privateKey, boltzID: boltzID) {
+                swapDictionary.removeObject(forKey: "privateKey")
+            }
             UserDefaults.standard.set(swapDictionary, forKey: "ongoingswap")
         } else {
-            if let storedSwap = UserDefaults.standard.value(forKey: "ongoingswap") as? NSDictionary {
-                UserDefaults.standard.removeObject(forKey: "ongoingswap")
+            if let storedSwap = UserDefaults.standard.value(forKey: "ongoingswap") as? NSDictionary, let boltzID = storedSwap["boltzID"] as? String {
+                SecureStore.remove(account: "swapkey_\(boltzID)")
             }
+            UserDefaults.standard.removeObject(forKey: "ongoingswap")
         }
     }
-    
+
     static func getLatestSwap() -> Swap? {
         if let storedSwap = UserDefaults.standard.value(forKey: "ongoingswap") as? NSDictionary {
             let thisSwap = storedSwap.toSwap()
+            // New saves strip the refund key from the dictionary — read it
+            // back from the Keychain. A legacy dictionary still carries it
+            // inline (toSwap picks that up), and
+            // migrateSecretsToKeychainIfNeeded moves it across on launch.
+            if thisSwap.privateKey == nil, let boltzID = thisSwap.boltzID {
+                thisSwap.privateKey = (try? SecureStore.getString(account: "swapkey_\(boltzID)")) ?? nil
+            }
             return thisSwap
         } else {
             return nil
+        }
+    }
+
+    /// Store an in-flight swap's Boltz refund key in the Keychain, verified by
+    /// read-back. Returns true only when the Keychain copy is confirmed, so
+    /// callers only strip the inline copy on certainty.
+    private static func storeSwapPrivateKey(_ privateKey: String, boltzID: String) -> Bool {
+        do {
+            try SecureStore.setString(privateKey, account: "swapkey_\(boltzID)")
+            guard ((try? SecureStore.getString(account: "swapkey_\(boltzID)")) ?? nil) == privateKey else {
+                throw SecureStore.SecureStoreError.writeVerificationFailed
+            }
+            return true
+        } catch {
+            SentrySDK.capture(error: error) { scope in
+                scope.setExtra(value: "storing swap private key in keychain", key: "context")
+            }
+            return false
         }
     }
     

--- a/ios/bittr/CacheManager.swift
+++ b/ios/bittr/CacheManager.swift
@@ -885,7 +885,7 @@ class CacheManager: NSObject {
     // MARK: - Mnemonic
     
     static func storeMnemonic(_ mnemonic:String) throws {
-        try persistSecret(mnemonic, account: EnvironmentConfig.cacheKey(for: "mnemonic"), label: "mnemonic")
+        try persistSecret(mnemonic, account: EnvironmentConfig.cacheKey(for: "mnemonic"), label: "mnemonic", accessibility: .afterFirstUnlockThisDeviceOnly)
     }
     
     static func getMnemonic() -> String? {
@@ -901,7 +901,7 @@ class CacheManager: NSObject {
     // failed-attempt counter into the Keychain too (it is currently a plain,
     // resettable Int in UserDefaults).
     static func storePin(pin:String) {
-        writeSecret(pin, account: EnvironmentConfig.cacheKey(for: "pin"), label: "pin")
+        writeSecret(pin, account: EnvironmentConfig.cacheKey(for: "pin"), label: "pin", accessibility: .whenUnlockedThisDeviceOnly)
     }
     
     static func getPin() -> String? {
@@ -939,10 +939,23 @@ class CacheManager: NSObject {
     /// and an in-flight swap's refund key) into the Keychain. Safe to call on
     /// every launch; a no-op once migrated.
     static func migrateSecretsToKeychainIfNeeded() {
-        migrateLegacyValue(account: EnvironmentConfig.cacheKey(for: "mnemonic"))
-        migrateLegacyValue(account: EnvironmentConfig.cacheKey(for: "pin"))
+        migrateLegacyValue(account: EnvironmentConfig.cacheKey(for: "mnemonic"), accessibility: .afterFirstUnlockThisDeviceOnly)
+        migrateLegacyValue(account: EnvironmentConfig.cacheKey(for: "pin"), accessibility: .whenUnlockedThisDeviceOnly)
         migrateLegacyOngoingSwapKey()
         applyProtectionToExistingSwapFiles()
+        // Items keep the accessibility class they were written with; the
+        // mnemonic's intended class changed (WhenUnlocked -> AfterFirstUnlock,
+        // so background node starts work) after the first Keychain builds.
+        // Rewriting in place re-applies the intended class; idempotent.
+        refreshAccessibility(account: EnvironmentConfig.cacheKey(for: "mnemonic"), accessibility: .afterFirstUnlockThisDeviceOnly)
+        refreshAccessibility(account: EnvironmentConfig.cacheKey(for: "pin"), accessibility: .whenUnlockedThisDeviceOnly)
+    }
+
+    /// Re-apply the intended accessibility class to an already-stored secret
+    /// by rewriting it in place. No-op when nothing is stored.
+    private static func refreshAccessibility(account: String, accessibility: SecureStore.Accessibility) {
+        guard let value = (try? SecureStore.getString(account: account)) ?? nil else { return }
+        try? SecureStore.setString(value, account: account, accessibility: accessibility)
     }
 
     /// Stamp existing swap JSON files with the at-rest protection class that
@@ -982,9 +995,9 @@ class CacheManager: NSObject {
     /// if the write fails or the read-back doesn't match, so callers that must
     /// not proceed without the secret persisted (wallet creation/restore) can
     /// fail loudly instead of stranding a wallet whose seed was never saved.
-    private static func persistSecret(_ value: String, account: String, label: String) throws {
+    private static func persistSecret(_ value: String, account: String, label: String, accessibility: SecureStore.Accessibility) throws {
         do {
-            try SecureStore.setString(value, account: account)
+            try SecureStore.setString(value, account: account, accessibility: accessibility)
             let readBack = (try? SecureStore.getString(account: account)) ?? nil
             guard readBack == value else {
                 throw SecureStore.SecureStoreError.writeVerificationFailed
@@ -999,20 +1012,27 @@ class CacheManager: NSObject {
 
     /// Non-throwing convenience for secrets where a failed write is recoverable
     /// (e.g. the PIN, which can be reset via the mnemonic). Failures are logged.
-    private static func writeSecret(_ value: String, account: String, label: String) {
-        try? persistSecret(value, account: account, label: label)
+    private static func writeSecret(_ value: String, account: String, label: String, accessibility: SecureStore.Accessibility) {
+        try? persistSecret(value, account: account, label: label, accessibility: accessibility)
     }
 
     /// Non-throwing read used by getMnemonic()/getPin(). A Keychain read failure
     /// yields nil here (existing callers guard on nil and handle it gracefully);
     /// it never drives a destructive decision — the launch presence check uses
     /// walletSecretsPresence() instead, which separates failure from absence.
+    /// The intended accessibility class for a secret, by account. The
+    /// mnemonic (and swap keys) must be readable in background wakes; the PIN
+    /// is foreground-only. See SecureStore's header.
+    private static func accessibilityForAccount(_ account: String) -> SecureStore.Accessibility {
+        return account == EnvironmentConfig.cacheKey(for: "pin") ? .whenUnlockedThisDeviceOnly : .afterFirstUnlockThisDeviceOnly
+    }
+
     private static func readSecret(account: String) -> String? {
         do {
             return try readSecretOrThrow(account: account)
         } catch {
             // Keychain read failed — still honour a legacy UserDefaults copy if one exists.
-            return migrateLegacyValue(account: account)
+            return migrateLegacyValue(account: account, accessibility: accessibilityForAccount(account))
         }
     }
 
@@ -1032,12 +1052,12 @@ class CacheManager: NSObject {
     /// right now; the UserDefaults copy is removed only once the Keychain copy is
     /// confirmed readable, so access is never lost. Idempotent.
     @discardableResult
-    private static func migrateLegacyValue(account: String) -> String? {
+    private static func migrateLegacyValue(account: String, accessibility: SecureStore.Accessibility) -> String? {
         guard let legacy = UserDefaults.standard.value(forKey: account) as? String else {
             return nil
         }
         do {
-            try SecureStore.setString(legacy, account: account)
+            try SecureStore.setString(legacy, account: account, accessibility: accessibility)
             let confirmed = (try? SecureStore.getString(account: account)) ?? nil
             if confirmed == legacy {
                 UserDefaults.standard.removeObject(forKey: account)   // safe: verified in Keychain
@@ -1338,7 +1358,7 @@ class CacheManager: NSObject {
     /// callers only strip the inline copy on certainty.
     private static func storeSwapPrivateKey(_ privateKey: String, boltzID: String) -> Bool {
         do {
-            try SecureStore.setString(privateKey, account: "swapkey_\(boltzID)")
+            try SecureStore.setString(privateKey, account: "swapkey_\(boltzID)", accessibility: .afterFirstUnlockThisDeviceOnly)
             guard ((try? SecureStore.getString(account: "swapkey_\(boltzID)")) ?? nil) == privateKey else {
                 throw SecureStore.SecureStoreError.writeVerificationFailed
             }

--- a/ios/bittr/Core/CoreViewController.swift
+++ b/ios/bittr/Core/CoreViewController.swift
@@ -14,6 +14,9 @@ class CoreViewController: UIViewController {
     // App start booleans
     var userHasSignedIn = false
     var walletHasSynced = false
+    // True while checkWalletAvailability is waiting for the Keychain to become
+    // readable (device locked / transient read error) before it decides.
+    private var isAwaitingProtectedData = false
     
     // Pin reset
     var resettingPin = false
@@ -150,25 +153,46 @@ class CoreViewController: UIViewController {
     
     func checkWalletAvailability() {
         
-        // Check wallet availability. The containers are revealed here, at
-        // viewDidLoad, and stay interactable during the launch animation:
-        // the animation cover passes taps through (its
-        // isUserInteractionEnabled is false), so the PIN/signup screen is
-        // usable while it becomes visible — and automation taps can't be
-        // swallowed by the cover.
-        if CacheManager.getMnemonic() != nil, CacheManager.getPin() != nil {
+        // Decide which screen to show based on whether a wallet exists. The
+        // containers are revealed here, at viewDidLoad, and stay interactable
+        // during the launch animation: the animation cover passes taps
+        // through (its isUserInteractionEnabled is false), so the PIN/signup
+        // screen is usable while it becomes visible — and automation taps
+        // can't be swallowed by the cover.
+        switch CacheManager.walletSecretsPresence() {
+        case .present:
             // Wallet has been created.
+            self.isAwaitingProtectedData = false
             self.signupContainerView.alpha = 0
             self.pinContainerView.alpha = 1
-        } else {
-            // User has not completed signup.
+            
+        case .absent:
+            // No wallet on this device.
+            self.isAwaitingProtectedData = false
             self.signupContainerView.alpha = 1
             self.pinContainerView.alpha = 0
-            // Remove cached mnemonic.
+            // Clear any stale cached client data and show the create-wallet flow.
             CacheManager.deleteClientInfo()
-            // Show SignupVC.
             self.launchSignup(onPage: 3)
+            
+        case .unavailable:
+            // The Keychain could not be read reliably.
+            Log.info("Wallet secrets unavailable — deferring wallet-availability check until the Keychain is readable.")
+            if !self.isAwaitingProtectedData {
+                self.isAwaitingProtectedData = true
+                NotificationCenter.default.addObserver(self, selector: #selector(self.recheckWalletAvailability), name: UIApplication.protectedDataDidBecomeAvailableNotification, object: nil)
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) { [weak self] in
+                guard let self = self, self.isAwaitingProtectedData else { return }
+                self.recheckWalletAvailability()
+            }
         }
+    }
+
+    @objc private func recheckWalletAvailability() {
+        NotificationCenter.default.removeObserver(self, name: UIApplication.protectedDataDidBecomeAvailableNotification, object: nil)
+        self.isAwaitingProtectedData = false
+        self.checkWalletAvailability()
     }
     
     func checkWalletRemoval() {

--- a/ios/bittr/Core/CoreViewController.swift
+++ b/ios/bittr/Core/CoreViewController.swift
@@ -161,14 +161,14 @@ class CoreViewController: UIViewController {
         // can't be swallowed by the cover.
         switch CacheManager.walletSecretsPresence() {
         case .present:
-            // Wallet has been created.
-            self.isAwaitingProtectedData = false
+            Log.info("Wallet is available.")
+            self.finishAwaitingProtectedDataIfNeeded()
             self.signupContainerView.alpha = 0
             self.pinContainerView.alpha = 1
             
         case .absent:
-            // No wallet on this device.
-            self.isAwaitingProtectedData = false
+            Log.info("No wallet on this device.")
+            self.finishAwaitingProtectedDataIfNeeded()
             self.signupContainerView.alpha = 1
             self.pinContainerView.alpha = 0
             // Clear any stale cached client data and show the create-wallet flow.
@@ -176,22 +176,40 @@ class CoreViewController: UIViewController {
             self.launchSignup(onPage: 3)
             
         case .unavailable:
-            // The Keychain could not be read reliably.
-            Log.info("Wallet secrets unavailable — deferring wallet-availability check until the Keychain is readable.")
-            if !self.isAwaitingProtectedData {
-                self.isAwaitingProtectedData = true
-                NotificationCenter.default.addObserver(self, selector: #selector(self.recheckWalletAvailability), name: UIApplication.protectedDataDidBecomeAvailableNotification, object: nil)
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) { [weak self] in
-                guard let self = self, self.isAwaitingProtectedData else { return }
-                self.recheckWalletAvailability()
-            }
+            Log.info("The Keychain could not be read.")
+            self.presentKeychainUnavailable()
         }
     }
+    
+    private func presentKeychainUnavailable() {
+        Log.info("Wallet secrets unavailable — showing the retry prompt.")
+        self.signupContainerView.alpha = 0
+        self.pinContainerView.alpha = 1
+        self.fullViewCover.alpha = 0.8
+        self.genericSpinner.startAnimating()
 
-    @objc private func recheckWalletAvailability() {
-        NotificationCenter.default.removeObserver(self, name: UIApplication.protectedDataDidBecomeAvailableNotification, object: nil)
+        if !self.isAwaitingProtectedData {
+            self.isAwaitingProtectedData = true
+            NotificationCenter.default.addObserver(self, selector: #selector(self.retryReadingKeychain), name: UIApplication.protectedDataDidBecomeAvailableNotification, object: nil)
+        }
+
+        self.showAlert(presentingController: self,
+                       title: Language.getWord(withID: "keychainunavailabletitle"),
+                       message: Language.getWord(withID: "keychainunavailable"),
+                       buttons: [Language.getWord(withID: "tryagain")],
+                       actions: [#selector(self.retryReadingKeychain)])
+    }
+    
+    private func finishAwaitingProtectedDataIfNeeded() {
+        guard self.isAwaitingProtectedData else { return }
         self.isAwaitingProtectedData = false
+        NotificationCenter.default.removeObserver(self, name: UIApplication.protectedDataDidBecomeAvailableNotification, object: nil)
+        self.fullViewCover.alpha = 0
+        self.genericSpinner.stopAnimating()
+    }
+    
+    @objc private func retryReadingKeychain() {
+        self.hideAlert()
         self.checkWalletAvailability()
     }
     

--- a/ios/bittr/Helpers/SecureStore.swift
+++ b/ios/bittr/Helpers/SecureStore.swift
@@ -39,6 +39,7 @@ enum SecureStore {
 
     enum SecureStoreError: Error {
         case unexpectedStatus(OSStatus)
+        case writeVerificationFailed
     }
 
     // MARK: - String convenience

--- a/ios/bittr/Helpers/SecureStore.swift
+++ b/ios/bittr/Helpers/SecureStore.swift
@@ -121,11 +121,33 @@ enum SecureStore {
     @discardableResult
     static func remove(account: String) -> Bool {
         let query: [String: Any] = [
-            kSecClass as String:       kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
+            kSecClass as String:                     kSecClassGenericPassword,
+            kSecAttrService as String:               service,
+            kSecAttrAccount as String:               account,
+            kSecUseDataProtectionKeychain as String: true,
         ]
         let status = SecItemDelete(query as CFDictionary)
         return status == errSecSuccess || status == errSecItemNotFound
+    }
+
+    /// Delete every item of ours whose account begins with `accountPrefix`
+    /// (e.g. the per-swap refund keys, "swapkey_", on wallet reset). Nothing
+    /// stored is not an error.
+    static func removeAll(accountPrefix: String) {
+        let query: [String: Any] = [
+            kSecClass as String:                     kSecClassGenericPassword,
+            kSecAttrService as String:               service,
+            kSecReturnAttributes as String:          true,
+            kSecMatchLimit as String:                kSecMatchLimitAll,
+            kSecUseDataProtectionKeychain as String: true,
+        ]
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let items = result as? [[String: Any]] else { return }
+        for item in items {
+            if let account = item[kSecAttrAccount as String] as? String, account.hasPrefix(accountPrefix) {
+                remove(account: account)
+            }
+        }
     }
 }

--- a/ios/bittr/Helpers/SecureStore.swift
+++ b/ios/bittr/Helpers/SecureStore.swift
@@ -55,25 +55,42 @@ enum SecureStore {
 
     // MARK: - Data
 
-    /// Insert or replace the item at `account`. Any existing item is removed
-    /// first so the accessibility attributes are always applied cleanly (a bare
-    /// `SecItemUpdate` would leave stale attributes in place).
+    /// Insert or replace the item at `account`. Adds the item, and if one already
+    /// exists, updates it in place. This is atomic: an existing value is only
+    /// ever replaced, never removed-then-re-added — so a failed write can't leave
+    /// nothing stored (which a delete-then-add could, if the add failed after the
+    /// delete succeeded). The accessibility attribute is (re)applied on both the
+    /// add and the update, so it never goes stale.
     static func setData(_ data: Data, account: String) throws {
-        remove(account: account)
-
-        let query: [String: Any] = [
+        // Identity of the item — also the search query when updating.
+        let identity: [String: Any] = [
             kSecClass as String:                     kSecClassGenericPassword,
             kSecAttrService as String:               service,
             kSecAttrAccount as String:               account,
-            kSecValueData as String:                 data,
-            kSecAttrAccessible as String:            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-            kSecAttrSynchronizable as String:        false,
             kSecUseDataProtectionKeychain as String: true,
         ]
 
-        let status = SecItemAdd(query as CFDictionary, nil)
-        guard status == errSecSuccess else {
-            throw SecureStoreError.unexpectedStatus(status)
+        var addQuery = identity
+        addQuery[kSecValueData as String] = data
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        addQuery[kSecAttrSynchronizable as String] = false
+
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        switch addStatus {
+        case errSecSuccess:
+            return
+        case errSecDuplicateItem:
+            // An item already exists — replace its value in place (atomic).
+            let attributes: [String: Any] = [
+                kSecValueData as String:      data,
+                kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            ]
+            let updateStatus = SecItemUpdate(identity as CFDictionary, attributes as CFDictionary)
+            guard updateStatus == errSecSuccess else {
+                throw SecureStoreError.unexpectedStatus(updateStatus)
+            }
+        default:
+            throw SecureStoreError.unexpectedStatus(addStatus)
         }
     }
 

--- a/ios/bittr/Helpers/SecureStore.swift
+++ b/ios/bittr/Helpers/SecureStore.swift
@@ -3,16 +3,15 @@
 //  bittr
 //
 //  Thin wrapper over the iOS Keychain for storing sensitive values (the wallet
-//  mnemonic and the app PIN). Every item is written with:
+//  mnemonic, the app PIN, and in-flight swap refund keys). Every item shares
+//  these invariants:
 //
-//    • kSecAttrAccessibleWhenUnlockedThisDeviceOnly
-//        Hardware-encrypted; readable only while the device is unlocked, and —
-//        crucially — NEVER included in device backups (iCloud/Finder) and NEVER
-//        synced through iCloud Keychain. This is the attribute that stops a
-//        stored value from ever appearing on another device or in Keychain
-//        Access on a Mac (the problem the old Keychain attempt hit). It also
-//        can't leave the device: `ThisDeviceOnly` and `Synchronizable` are
-//        mutually exclusive.
+//    • …ThisDeviceOnly accessibility
+//        Hardware-encrypted; NEVER included in device backups (iCloud/Finder)
+//        and NEVER synced through iCloud Keychain. This is what stops a stored
+//        value from ever appearing on another device or in Keychain Access on
+//        a Mac (the problem the old Keychain attempt hit). `ThisDeviceOnly`
+//        and `Synchronizable` are mutually exclusive.
 //
 //    • kSecAttrSynchronizable = false
 //        Belt-and-suspenders: explicitly never iCloud-synced.
@@ -22,10 +21,22 @@
 //        is ever built for Mac Catalyst — without it, items land in the
 //        user-visible login keychain).
 //
+//  The unlock requirement differs per secret, because the app declares the
+//  `fetch` and `remote-notification` background modes and genuinely runs while
+//  the device is locked:
+//
+//    • afterFirstUnlockThisDeviceOnly — the mnemonic and swap refund keys.
+//        Node start and swap processing happen in background wakes (silent
+//        pushes for held HTLCs and swap status); `WhenUnlocked` would silently
+//        break exactly those flows on a locked device. Readable any time after
+//        the device's first unlock since boot.
+//
+//    • whenUnlockedThisDeviceOnly — the PIN.
+//        Only ever read at the foreground unlock screen, so it keeps the
+//        strictest class for free.
+//
 //  No biometrics / SecAccessControl are used: values are protected by the
-//  device lock, which matches the app's current PIN-only UX. The seed is only
-//  ever read in the foreground with the device unlocked, so
-//  `WhenUnlockedThisDeviceOnly` never blocks a legitimate read.
+//  device lock, which matches the app's current PIN-only UX.
 //
 
 import Foundation
@@ -42,10 +53,25 @@ enum SecureStore {
         case writeVerificationFailed
     }
 
+    /// Unlock requirement for an item. Both variants are ThisDeviceOnly
+    /// (never backed up, never synced) — see the header for which secret
+    /// uses which and why.
+    enum Accessibility {
+        case whenUnlockedThisDeviceOnly
+        case afterFirstUnlockThisDeviceOnly
+
+        var attribute: CFString {
+            switch self {
+            case .whenUnlockedThisDeviceOnly: return kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+            case .afterFirstUnlockThisDeviceOnly: return kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            }
+        }
+    }
+
     // MARK: - String convenience
 
-    static func setString(_ value: String, account: String) throws {
-        try setData(Data(value.utf8), account: account)
+    static func setString(_ value: String, account: String, accessibility: Accessibility = .whenUnlockedThisDeviceOnly) throws {
+        try setData(Data(value.utf8), account: account, accessibility: accessibility)
     }
 
     static func getString(account: String) throws -> String? {
@@ -61,7 +87,7 @@ enum SecureStore {
     /// nothing stored (which a delete-then-add could, if the add failed after the
     /// delete succeeded). The accessibility attribute is (re)applied on both the
     /// add and the update, so it never goes stale.
-    static func setData(_ data: Data, account: String) throws {
+    static func setData(_ data: Data, account: String, accessibility: Accessibility = .whenUnlockedThisDeviceOnly) throws {
         // Identity of the item — also the search query when updating.
         let identity: [String: Any] = [
             kSecClass as String:                     kSecClassGenericPassword,
@@ -72,7 +98,7 @@ enum SecureStore {
 
         var addQuery = identity
         addQuery[kSecValueData as String] = data
-        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        addQuery[kSecAttrAccessible as String] = accessibility.attribute
         addQuery[kSecAttrSynchronizable as String] = false
 
         let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
@@ -81,9 +107,11 @@ enum SecureStore {
             return
         case errSecDuplicateItem:
             // An item already exists — replace its value in place (atomic).
+            // The accessibility attribute is re-applied here too, so a
+            // rewrite also migrates an item to its intended class.
             let attributes: [String: Any] = [
                 kSecValueData as String:      data,
-                kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+                kSecAttrAccessible as String: accessibility.attribute,
             ]
             let updateStatus = SecItemUpdate(identity as CFDictionary, attributes as CFDictionary)
             guard updateStatus == errSecSuccess else {

--- a/ios/bittr/Helpers/SecureStore.swift
+++ b/ios/bittr/Helpers/SecureStore.swift
@@ -1,0 +1,117 @@
+//
+//  SecureStore.swift
+//  bittr
+//
+//  Thin wrapper over the iOS Keychain for storing sensitive values (the wallet
+//  mnemonic and the app PIN). Every item is written with:
+//
+//    • kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+//        Hardware-encrypted; readable only while the device is unlocked, and —
+//        crucially — NEVER included in device backups (iCloud/Finder) and NEVER
+//        synced through iCloud Keychain. This is the attribute that stops a
+//        stored value from ever appearing on another device or in Keychain
+//        Access on a Mac (the problem the old Keychain attempt hit). It also
+//        can't leave the device: `ThisDeviceOnly` and `Synchronizable` are
+//        mutually exclusive.
+//
+//    • kSecAttrSynchronizable = false
+//        Belt-and-suspenders: explicitly never iCloud-synced.
+//
+//    • kSecUseDataProtectionKeychain = true
+//        Always use the iOS-style data-protection keychain (matters if the app
+//        is ever built for Mac Catalyst — without it, items land in the
+//        user-visible login keychain).
+//
+//  No biometrics / SecAccessControl are used: values are protected by the
+//  device lock, which matches the app's current PIN-only UX. The seed is only
+//  ever read in the foreground with the device unlocked, so
+//  `WhenUnlockedThisDeviceOnly` never blocks a legitimate read.
+//
+
+import Foundation
+import Security
+import Sentry
+
+enum SecureStore {
+
+    /// Scopes all items to this app. Using the (per-environment) bundle id also
+    /// keeps regtest / signet / mainnet builds isolated from one another.
+    private static let service = Bundle.main.bundleIdentifier ?? "com.bittr.bittr"
+
+    enum SecureStoreError: Error {
+        case unexpectedStatus(OSStatus)
+    }
+
+    // MARK: - String convenience
+
+    static func setString(_ value: String, account: String) throws {
+        try setData(Data(value.utf8), account: account)
+    }
+
+    static func getString(account: String) -> String? {
+        guard let data = getData(account: account) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    // MARK: - Data
+
+    /// Insert or replace the item at `account`. Any existing item is removed
+    /// first so the accessibility attributes are always applied cleanly (a bare
+    /// `SecItemUpdate` would leave stale attributes in place).
+    static func setData(_ data: Data, account: String) throws {
+        remove(account: account)
+
+        let query: [String: Any] = [
+            kSecClass as String:                     kSecClassGenericPassword,
+            kSecAttrService as String:               service,
+            kSecAttrAccount as String:               account,
+            kSecValueData as String:                 data,
+            kSecAttrAccessible as String:            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            kSecAttrSynchronizable as String:        false,
+            kSecUseDataProtectionKeychain as String: true,
+        ]
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw SecureStoreError.unexpectedStatus(status)
+        }
+    }
+
+    static func getData(account: String) -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String:                     kSecClassGenericPassword,
+            kSecAttrService as String:               service,
+            kSecAttrAccount as String:               account,
+            kSecReturnData as String:                true,
+            kSecMatchLimit as String:                kSecMatchLimitOne,
+            kSecUseDataProtectionKeychain as String: true,
+        ]
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        switch status {
+        case errSecSuccess:
+            return result as? Data
+        case errSecItemNotFound:
+            return nil
+        default:
+            // An unexpected read failure (e.g. errSecInteractionNotAllowed if
+            // somehow read while locked). Surface it, but never crash a read.
+            SentrySDK.capture(message: "Keychain read failed for account \(account): OSStatus \(status)")
+            return nil
+        }
+    }
+
+    /// Delete the item. A no-op (and success) when nothing is stored.
+    @discardableResult
+    static func remove(account: String) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String:       kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+}

--- a/ios/bittr/Helpers/SecureStore.swift
+++ b/ios/bittr/Helpers/SecureStore.swift
@@ -30,7 +30,6 @@
 
 import Foundation
 import Security
-import Sentry
 
 enum SecureStore {
 
@@ -48,8 +47,8 @@ enum SecureStore {
         try setData(Data(value.utf8), account: account)
     }
 
-    static func getString(account: String) -> String? {
-        guard let data = getData(account: account) else { return nil }
+    static func getString(account: String) throws -> String? {
+        guard let data = try getData(account: account) else { return nil }
         return String(data: data, encoding: .utf8)
     }
 
@@ -77,7 +76,7 @@ enum SecureStore {
         }
     }
 
-    static func getData(account: String) -> Data? {
+    static func getData(account: String) throws -> Data? {
         let query: [String: Any] = [
             kSecClass as String:                     kSecClassGenericPassword,
             kSecAttrService as String:               service,
@@ -96,10 +95,7 @@ enum SecureStore {
         case errSecItemNotFound:
             return nil
         default:
-            // An unexpected read failure (e.g. errSecInteractionNotAllowed if
-            // somehow read while locked). Surface it, but never crash a read.
-            SentrySDK.capture(message: "Keychain read failed for account \(account): OSStatus \(status)")
-            return nil
+            throw SecureStoreError.unexpectedStatus(status)
         }
     }
 

--- a/ios/bittr/Language.swift
+++ b/ios/bittr/Language.swift
@@ -223,6 +223,8 @@ class Language: NSObject {
             "closedlightningchannel3": " We've been notified that ",
             "bittrnotificationfail": "Something went wrong processing the notification we sent to you. Please contact support@getbittr.com if you have any questions.",
             "pinlock": "You've entered an incorrect PIN too many times. Please restore your wallet.",
+            "keychainunavailabletitle": "Couldn't access your wallet",
+            "keychainunavailable": "We couldn't securely read your wallet just now. This can happen right after unlocking your device or when the phone is busy — your wallet and funds are safe.\n\nPlease tap Try again. Do not delete the app from your phone.",
             "incorrectpin2": "Please enter your correct PIN. If you've forgotten it, please restore your wallet.",
             "pinattemptsleft": "You have <attempts> attempts left.",
             "pinattemptleft": "You have 1 attempt left.",

--- a/ios/bittr/Language.swift
+++ b/ios/bittr/Language.swift
@@ -225,6 +225,7 @@ class Language: NSObject {
             "pinlock": "You've entered an incorrect PIN too many times. Please restore your wallet.",
             "keychainunavailabletitle": "Couldn't access your wallet",
             "keychainunavailable": "We couldn't securely read your wallet just now. This can happen right after unlocking your device or when the phone is busy — your wallet and funds are safe.\n\nPlease tap Try again. Do not delete the app from your phone.",
+            "mnemonicsavefail": "Something went wrong securely saving your wallet. Please try again.",
             "incorrectpin2": "Please enter your correct PIN. If you've forgotten it, please restore your wallet.",
             "pinattemptsleft": "You have <attempts> attempts left.",
             "pinattemptleft": "You have 1 attempt left.",

--- a/ios/bittr/Pin/PinViewController.swift
+++ b/ios/bittr/Pin/PinViewController.swift
@@ -59,7 +59,6 @@ class PinViewController: UIViewController, UITextFieldDelegate, UICollectionView
     var allBackgrounds:[UIView]?
     
     // Variables
-    var correctPin:String?
     var coreVC:CoreViewController?
     
     // Changing elements
@@ -135,9 +134,6 @@ class PinViewController: UIViewController, UITextFieldDelegate, UICollectionView
         // Text field
         self.pinTextField.delegate = self
         
-        // Get correct pin
-        self.correctPin = CacheManager.getPin()
-        
         // Configure button backgrounds.
         self.allBackgrounds = [background0, background1, background2, background3, background4, background5, background6, background7, background8, background9, backgroundBackSpace]
         for eachBackground in self.allBackgrounds! {
@@ -194,7 +190,7 @@ class PinViewController: UIViewController, UITextFieldDelegate, UICollectionView
         switch self.embeddingView {
         case .core:
             guard (self.coreVC ?? self).checkInternetConnection() else { return }
-            guard self.correctPin != nil else {
+            guard CacheManager.hasPin() else {
                 Log.info("No pin found in storage.")
                 return
             }
@@ -206,7 +202,7 @@ class PinViewController: UIViewController, UITextFieldDelegate, UICollectionView
                 return
             }
             
-            if self.correctPin! == self.pinTextField.text {
+            if CacheManager.verifyPin(self.pinTextField.text ?? "") {
                 // Correct pin.
                 CacheManager.resetFailedPinAttempts()
                 self.pinSpinner.startAnimating()

--- a/ios/bittr/Signup/Create Wallet/Signup1ViewController.swift
+++ b/ios/bittr/Signup/Create Wallet/Signup1ViewController.swift
@@ -94,13 +94,21 @@ class Signup1ViewController: UIViewController {
         // Delay the call 1 second to keep the spinner visible for a moment.
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             
-            // Get mnemonic.
-            let _ = BitcoinManager.shared.getNewMnemonic()
-            
             // Stop spinner.
             self.createWalletLabel.alpha = 1
             self.createWalletArrow.alpha = 1
             self.createWalletSpinner.stopAnimating()
+
+            // Create and persist the wallet's mnemonic. If it can't be securely
+            // stored, abort loudly rather than continuing with an unsaved seed —
+            // a wallet the user then funds would otherwise be unrecoverable.
+            do {
+                _ = try BitcoinManager.shared.getNewMnemonic()
+            } catch {
+                self.showAlert(presentingController: self.signupVC?.coreVC ?? self.signupVC ?? self, title: Language.getWord(withID: "error"), message: Language.getWord(withID: "mnemonicsavefail"), buttons: [Language.getWord(withID: "okay")], actions: nil)
+                return
+            }
+
             self.signupVC?.moveToPage(4)
         }
     }

--- a/ios/bittr/Signup/MnemonicTextField.swift
+++ b/ios/bittr/Signup/MnemonicTextField.swift
@@ -243,8 +243,6 @@ class MnemonicTextField: UITextField {
             let maxDistance = min(2, text.count - 1) // Don't correct if distance is too high
             
             if distance <= maxDistance && distance > 0 {
-                print("Auto-correcting '\(text)' to '\(correctedWord)' (distance: \(distance))")
-                
                 // Show visual feedback for the correction
                 showCorrectionFeedback()
                 

--- a/ios/bittr/Signup/Restore Wallet/RestoreViewController.swift
+++ b/ios/bittr/Signup/Restore Wallet/RestoreViewController.swift
@@ -215,125 +215,95 @@ class RestoreViewController: UIViewController, UITextFieldDelegate {
     }
     
     @IBAction func restoreButtonTapped(_ sender: UIButton) {
-        
         self.view.endEditing(true)
+        guard self.coreVC != nil else {
+            Log.info("coreVC is nil - stopping spinner and showing error")
+            self.restoreButtonSpinner.stopAnimating()
+            self.restoreButtonText.alpha = 1
+            self.showAlert(presentingController: self.signupVC?.coreVC ?? self.signupVC ?? self, title: Language.getWord(withID: "error"), message: Language.getWord(withID: "restorewalleterror"), buttons: [Language.getWord(withID: "okay")], actions: nil
+            )
+            return
+        }
         
         self.restoreButtonText.alpha = 0
         self.restoreButtonSpinner.startAnimating()
         
         let enteredWords = [self.mnemonic1.text, self.mnemonic2.text, self.mnemonic3.text, self.mnemonic4.text, self.mnemonic5.text, self.mnemonic6.text, self.mnemonic7.text, self.mnemonic8.text, self.mnemonic9.text, self.mnemonic10.text, self.mnemonic11.text, self.mnemonic12.text]
-        
         var enteredMnemonic = ""
-        var handledWords = 0
         
         for eachWord in enteredWords {
-            if let actualWord = eachWord?.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: " ", with: "") as? String {
-                if actualWord == "" {
-                    // Found an empty field - show warning
-                    print("Found empty field - showing warning")
+            guard let actualWord = eachWord?.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: " ", with: "") as? String, actualWord != "" else {
+                self.restoreButtonSpinner.stopAnimating()
+                self.restoreButtonText.alpha = 1
+                self.showAlert(
+                    presentingController: self.signupVC?.coreVC ?? self.signupVC ?? self,
+                    title: Language.getWord(withID: "incompletephrase"),
+                    message: Language.getWord(withID: "incompletephrase2"),
+                    buttons: [Language.getWord(withID: "okay")],
+                    actions: nil
+                )
+                return
+            }
+            
+            if enteredMnemonic == "" {
+                enteredMnemonic = actualWord
+            } else {
+                enteredMnemonic += " \(actualWord)"
+            }
+        }
+        
+        if self.coreVC!.resettingPin {
+            Log.info("PIN reset mode detected.")
+            
+            // Get current mnemonic.
+            guard let currentMnemonic = CacheManager.getMnemonic() else {
+                // No existing mnenonic is available.
+                self.showAlert(presentingController: self.signupVC?.coreVC ?? self.signupVC ?? self, title: Language.getWord(withID: "forgotpin"), message: "\(Language.getWord(withID: "forgotpin3")) 2", buttons: [Language.getWord(withID: "okay")], actions: nil)
+                return
+            }
+            
+            // Check whether entered mnemonic is correct.
+            guard currentMnemonic == enteredMnemonic else {
+                // Entered mnemonic is incorrect.
+                self.showAlert(presentingController: self.signupVC?.coreVC ?? self.signupVC ?? self, title: Language.getWord(withID: "forgotpin"), message: Language.getWord(withID: "forgotpin3"), buttons: [Language.getWord(withID: "okay")], actions: nil)
+                return
+            }
+            Log.info("Correct mnemonic has been entered.")
+            
+        } else {
+            Log.info("Wallet restore mode detected.")
+            
+            // Validate mnemonic before storing.
+            guard BitcoinManager.shared.isValidMnemonic(enteredMnemonic) else {
+                Log.info("Mnemonic validation failed.")
+                DispatchQueue.main.async {
                     self.restoreButtonSpinner.stopAnimating()
                     self.restoreButtonText.alpha = 1
                     self.showAlert(
                         presentingController: self.signupVC?.coreVC ?? self.signupVC ?? self,
-                        title: Language.getWord(withID: "incompletephrase"),
-                        message: Language.getWord(withID: "incompletephrase2"),
+                        title: Language.getWord(withID: "invalidphrase"),
+                        message: Language.getWord(withID: "invalidphrase2"),
                         buttons: [Language.getWord(withID: "okay")],
                         actions: nil
                     )
-                    return
-                } else if enteredMnemonic == "" {
-                    enteredMnemonic = actualWord
-                    handledWords += 1
-                } else {
-                    enteredMnemonic = "\(enteredMnemonic) \(actualWord)"
-                    handledWords += 1
-                    if handledWords == 12 {
-                        Log.info("About to check coreVC...")
-                        
-                        if self.coreVC == nil {
-                            Log.info("coreVC is nil - stopping spinner and showing error")
-                            self.restoreButtonSpinner.stopAnimating()
-                            self.restoreButtonText.alpha = 1
-                            self.showAlert(
-                                presentingController: self.signupVC?.coreVC ?? self.signupVC ?? self,
-                                title: Language.getWord(withID: "error"),
-                                message: Language.getWord(withID: "restorewalleterror"),
-                                buttons: [Language.getWord(withID: "okay")],
-                                actions: nil
-                            )
-                            return
-                        } else if self.coreVC!.resettingPin {
-                            Log.info("PIN reset mode detected")
-                            // We're resetting the device PIN.
-                            
-                            self.restoreButtonSpinner.stopAnimating()
-                            self.restoreButtonText.alpha = 1
-                            
-                            if let currentMnemonic = CacheManager.getMnemonic() {
-                                if currentMnemonic == enteredMnemonic {
-                                    // Correct mnemonic has been entered.
-                                    
-                                    // Proceed to next page.
-                                    self.signupVC?.moveToPage(1)
-                                    
-                                    // Start wallet.
-                                    self.coreVC!.startWallet()
-                                } else {
-                                    // Entered mnemonic is incorrect.
-                                    self.showAlert(presentingController: self.signupVC?.coreVC ?? self.signupVC ?? self, title: Language.getWord(withID: "forgotpin"), message: Language.getWord(withID: "forgotpin3"), buttons: [Language.getWord(withID: "okay")], actions: nil)
-                                }
-                            } else {
-                                // No existing mnenonic is available.
-                                self.showAlert(presentingController: self.signupVC?.coreVC ?? self.signupVC ?? self, title: Language.getWord(withID: "forgotpin"), message: "\(Language.getWord(withID: "forgotpin3")) 2", buttons: [Language.getWord(withID: "okay")], actions: nil)
-                            }
-                        } else {
-                            Log.info("Wallet restore mode detected")
-                            // We're restoring an existing wallet.
-                            
-                            // Validate mnemonic before storing.
-                            if BitcoinManager.shared.isValidMnemonic(enteredMnemonic) {
-                                Log.info("Mnemonic validation successful")
-                                
-                                // Store restorable mnemonic in cache.
-                                CacheManager.storeMnemonic(enteredMnemonic)
-                                
-                                // Proceed to next page.
-                                self.signupVC?.moveToPage(1)
-                                Log.info("Moved to next page")
-                                
-                                self.restoreButtonSpinner.stopAnimating()
-                                self.restoreButtonText.alpha = 1
-                                Log.info("Restore process completed successfully")
-                                
-                                Log.info("About to start Lightning wallet...")
-                                // Start wallet.
-                                self.coreVC!.startWallet()
-                                Log.info("Lightning wallet started successfully")
-                                
-                            } else {
-                                Log.info("Mnemonic validation failed.")
-                                DispatchQueue.main.async {
-                                    self.restoreButtonSpinner.stopAnimating()
-                                    self.restoreButtonText.alpha = 1
-                                    self.showAlert(
-                                        presentingController: self.signupVC?.coreVC ?? self.signupVC ?? self,
-                                        title: Language.getWord(withID: "invalidphrase"),
-                                        message: Language.getWord(withID: "invalidphrase2"),
-                                        buttons: [Language.getWord(withID: "okay")],
-                                        actions: nil
-                                    )
-                                    return
-                                }
-                            }
-                        }
-                    }
                 }
-            } else {
-                self.restoreButtonSpinner.stopAnimating()
-                self.restoreButtonText.alpha = 1
                 return
             }
+            Log.info("Mnemonic validation successful")
+            
+            // Store restorable mnemonic in cache.
+            CacheManager.storeMnemonic(enteredMnemonic)
         }
+        
+        // Stop animation.
+        self.restoreButtonSpinner.stopAnimating()
+        self.restoreButtonText.alpha = 1
+        
+        // Proceed to next page.
+        self.signupVC?.moveToPage(1)
+        
+        // Start wallet.
+        self.coreVC!.startWallet()
     }
     
     @IBAction func backButtonTapped(_ sender: UIButton) {

--- a/ios/bittr/Signup/Restore Wallet/RestoreViewController.swift
+++ b/ios/bittr/Signup/Restore Wallet/RestoreViewController.swift
@@ -223,14 +223,11 @@ class RestoreViewController: UIViewController, UITextFieldDelegate {
         
         let enteredWords = [self.mnemonic1.text, self.mnemonic2.text, self.mnemonic3.text, self.mnemonic4.text, self.mnemonic5.text, self.mnemonic6.text, self.mnemonic7.text, self.mnemonic8.text, self.mnemonic9.text, self.mnemonic10.text, self.mnemonic11.text, self.mnemonic12.text]
         
-        print("Restore button tapped - checking words: \(enteredWords)")
-        
         var enteredMnemonic = ""
         var handledWords = 0
         
         for eachWord in enteredWords {
             if let actualWord = eachWord?.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: " ", with: "") as? String {
-                print("Processing word: '\(actualWord)'")
                 if actualWord == "" {
                     // Found an empty field - show warning
                     print("Found empty field - showing warning")
@@ -247,13 +244,10 @@ class RestoreViewController: UIViewController, UITextFieldDelegate {
                 } else if enteredMnemonic == "" {
                     enteredMnemonic = actualWord
                     handledWords += 1
-                    print("First word added: \(enteredMnemonic), handledWords: \(handledWords)")
                 } else {
                     enteredMnemonic = "\(enteredMnemonic) \(actualWord)"
                     handledWords += 1
-                    print("Word added: \(enteredMnemonic), handledWords: \(handledWords)")
                     if handledWords == 12 {
-                        print("All 12 words collected: \(enteredMnemonic)")
                         Log.info("About to check coreVC...")
                         
                         if self.coreVC == nil {
@@ -297,7 +291,6 @@ class RestoreViewController: UIViewController, UITextFieldDelegate {
                             // We're restoring an existing wallet.
                             
                             // Validate mnemonic before storing.
-                            print("Validating mnemonic: \(enteredMnemonic)")
                             if BitcoinManager.shared.isValidMnemonic(enteredMnemonic) {
                                 Log.info("Mnemonic validation successful")
                                 

--- a/ios/bittr/Signup/Restore Wallet/RestoreViewController.swift
+++ b/ios/bittr/Signup/Restore Wallet/RestoreViewController.swift
@@ -290,9 +290,17 @@ class RestoreViewController: UIViewController, UITextFieldDelegate {
                 return
             }
             Log.info("Mnemonic validation successful")
-            
-            // Store restorable mnemonic in cache.
-            CacheManager.storeMnemonic(enteredMnemonic)
+
+            // Store restorable mnemonic in cache. Abort loudly if it can't be
+            // securely persisted rather than proceeding with an unsaved seed.
+            do {
+                try CacheManager.storeMnemonic(enteredMnemonic)
+            } catch {
+                self.restoreButtonSpinner.stopAnimating()
+                self.restoreButtonText.alpha = 1
+                self.showAlert(presentingController: self.signupVC?.coreVC ?? self.signupVC ?? self, title: Language.getWord(withID: "error"), message: Language.getWord(withID: "mnemonicsavefail"), buttons: [Language.getWord(withID: "okay")], actions: nil)
+                return
+            }
         }
         
         // Stop animation.

--- a/ios/bittr/Swaps/Swap Manager/SwapManager.swift
+++ b/ios/bittr/Swaps/Swap Manager/SwapManager.swift
@@ -559,13 +559,20 @@ class SwapManager: NSObject {
         do {
             // Convert NSDictionary to JSON Data
             let jsonData = try JSONSerialization.data(withJSONObject: swapDictionary, options: .prettyPrinted)
-            
+
             // Get the documents directory
             let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
             let fileURL = documentsPath.appendingPathComponent("\(swapID).json")
-            
-            // Write the JSON data to file
-            try jsonData.write(to: fileURL)
+
+            // Write the JSON data to file. The swap file DELIBERATELY contains
+            // the Boltz refund key in plain text: it is the user-facing
+            // emergency artifact for Boltz's rescue flow (see the Download
+            // button in SwapStatusVC) and must stay usable without a working
+            // app or Keychain — do not strip or encrypt its contents. The
+            // file-protection option below encrypts it at rest with the
+            // device passcode (readable after first unlock, so background
+            // swap processing and the user's export both keep working).
+            try jsonData.write(to: fileURL, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
             
             print("Swap details saved to: \(fileURL.path)")
         } catch {

--- a/ios/bittr/Swaps/SwapStatusVC/SwapStatusViewController.swift
+++ b/ios/bittr/Swaps/SwapStatusVC/SwapStatusViewController.swift
@@ -383,7 +383,9 @@ class SwapStatusViewController: UIViewController {
             let fileName = "Swap \(ongoingSwap.boltzID!).json"
             let temporaryFileURL = temporaryFolder.appendingPathComponent(fileName)
             
-            try jsonData.write(to: temporaryFileURL)
+            // Same at-rest protection as the swap file itself; the exported
+            // copy the user shares stays plain-text JSON either way.
+            try jsonData.write(to: temporaryFileURL, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
             let vc = UIActivityViewController(activityItems: [temporaryFileURL], applicationActivities: [])
             self.present(vc, animated: true, completion: nil)
         } catch {


### PR DESCRIPTION
- Claude has run a large **security audit**, with the most critical suggestion being **use Keychain**.
- Remove **mnemonic print-statements** from various VCs as not to leak sensitive data.
- **Store PIN and Mnemonic in Keychain**, available on this device only, upon device unlock.
- **Migrate** existing users from UserDefaults to Keychain.
- In checkWalletAvailability(), handle cases in which **Keychain cannot be read**. Allow user to retry.
- Cleanup of **restoreButtonTapped()** function in RestoreVC.
- In **storeMnemonic()**, handle cases in which a new mnemonic cannot be stored. Allow user to retry.