### PR TITLE
Various additional guards during wallet loading and resetting

### DIFF
--- a/ios/bittr/BDKManager.swift
+++ b/ios/bittr/BDKManager.swift
@@ -210,11 +210,16 @@ extension BitcoinManager {
     }
     
     func lightSyncBdkWallet() -> Bool {
+        guard let bdkWallet = self.bdkWallet,
+              let electrumClient = self.electrumClient,
+              let connection = self.connection else {
+            return false
+        }
         
         // Create sync request.
         let syncRequest:SyncRequest
         do {
-            syncRequest = try self.bdkWallet!.startSyncWithRevealedSpks().build()
+            syncRequest = try bdkWallet.startSyncWithRevealedSpks().build()
         } catch {
             self.handleError(error: error, row: 570)
             return false
@@ -223,7 +228,7 @@ extension BitcoinManager {
         // Create update.
         let update:Update
         do {
-            update = try self.electrumClient!.sync(
+            update = try electrumClient.sync(
                 request: syncRequest,
                 batchSize: UInt64(25),
                 fetchPrevTxouts: true
@@ -233,16 +238,21 @@ extension BitcoinManager {
             return false
         }
         
+        // Ensure bdkWallet hasn't been cleared in the meantime.
+        guard self.bdkWallet === bdkWallet else {
+            return false
+        }
+        
         // Apply update to wallet.
         do {
-            try self.bdkWallet!.applyUpdate(update: update)
+            try bdkWallet.applyUpdate(update: update)
         } catch {
             self.handleError(error: error, row: 594)
         }
         
         // Persist update to wallet.
         do {
-            _ = try self.bdkWallet!.persist(connection: self.connection!)
+            _ = try bdkWallet.persist(connection: connection)
         } catch {
             self.handleError(error: error, row: 603)
         }

--- a/ios/bittr/BitcoinManager.swift
+++ b/ios/bittr/BitcoinManager.swift
@@ -482,7 +482,7 @@ class BitcoinManager {
         }
     }
     
-    func getFeeEstimates() async -> NSDictionary? {
+    func getFeeEstimates() async -> FeeEstimates? {
 
         let feeDictionary: NSDictionary
         do {
@@ -516,7 +516,17 @@ class BitcoinManager {
             return nil
         }
 
-        return feeDictionary
+        // A response missing any of the three rates is unusable — treat it as a
+        // failed fetch rather than handing back a half-filled struct that every
+        // call site would have to re-check.
+        guard let fastest = feeDictionary["fastestFee"] as? Double,
+              let hour = feeDictionary["hourFee"] as? Double,
+              let economy = feeDictionary["economyFee"] as? Double else {
+            Log.info("Fee estimate response was missing one or more expected rates.")
+            return nil
+        }
+
+        return FeeEstimates(fastest: fastest, hour: hour, economy: economy)
     }
     
     func syncWallets() throws {
@@ -724,6 +734,14 @@ class BitcoinManager {
         return "m/84'/\(coinType)'/\(account)'/\(change)/\(addressIndex)"
     }
     
+}
+
+/// Recommended on-chain fee rates in sat/vByte, already normalized by
+/// `getFeeEstimates()`: each rate is at least 1 and rounded, as LDKNode requires.
+struct FeeEstimates {
+    let fastest: Double
+    let hour: Double
+    let economy: Double
 }
 
 enum WalletError: Error {

--- a/ios/bittr/BitcoinManager.swift
+++ b/ios/bittr/BitcoinManager.swift
@@ -425,26 +425,24 @@ class BitcoinManager {
     }
     
     func getFeeEstimates() async -> NSDictionary? {
-        
-        var receivedDictionary:NSDictionary
+
+        let feeDictionary: NSDictionary
         do {
-            receivedDictionary = try await withCheckedThrowingContinuation { continuation in
+            feeDictionary = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<NSDictionary, Error>) in
                 Task {
                     await CallsManager.makeApiCall(url: "https://mempool.space/api/v1/fees/precise", parameters: nil, getOrPost: .get) { result in
                         switch result {
                         case .success(let receivedDictionary):
-                            let mutableDictionary = receivedDictionary.mutableCopy() as! NSMutableDictionary
-                            for (key, value) in mutableDictionary {
-                                if (value as? Double) == nil || (key as? String) == nil { continuation.resume(returning: receivedDictionary) }
-                                if (value as! Double) < 1 {
-                                    // Minimum fee is 1 sat/vByte.
-                                    mutableDictionary.setValue(Double(1), forKey: (key as! String))
-                                } else {
-                                    // LDKNode requires a rounded number for sat/vByte.
-                                    mutableDictionary.setValue((value as! Double).rounded(), forKey: (key as! String))
-                                }
+                            // Build a fresh dictionary of validated Double fee rates: skip any
+                            // non-numeric entries instead of force-casting them, and never mutate
+                            // the dictionary being enumerated.
+                            let normalized = NSMutableDictionary()
+                            for (key, value) in receivedDictionary {
+                                guard let feeKey = key as? String, let feeRate = value as? Double else { continue }
+                                // Minimum fee is 1 sat/vByte; LDKNode requires a rounded number.
+                                normalized[feeKey] = feeRate < 1 ? Double(1) : feeRate.rounded()
                             }
-                            continuation.resume(returning: mutableDictionary)
+                            continuation.resume(returning: normalized)
                         case .failure(let error):
                             continuation.resume(throwing: error)
                         }
@@ -459,8 +457,8 @@ class BitcoinManager {
             }
             return nil
         }
-        
-        return receivedDictionary
+
+        return feeDictionary
     }
     
     func syncWallets() throws {

--- a/ios/bittr/BitcoinManager.swift
+++ b/ios/bittr/BitcoinManager.swift
@@ -17,6 +17,10 @@ class BitcoinManager {
     public var ldkNode: LDKNode.Node?
     private var network: LDKNode.Network
     
+    // LDK Node single-flight startup guard.
+    private let nodeStartLock = NSLock()
+    private var isStartingNode = false
+    
     // BDK
     var bdkWallet: BitcoinDevKit.Wallet?
     var electrumClient: BitcoinDevKit.ElectrumClient?
@@ -49,6 +53,33 @@ class BitcoinManager {
     
     deinit {
         self.cancelEventListener()
+    }
+    
+    // MARK: Manage LDKNode starting.
+    enum NodeStartDecision {
+        case proceed         // LDKNode hasn't been started yet.
+        case startInFlight   // LDKNode is already being started.
+        case alreadyRunning  // LDKNode is already running.
+    }
+    
+    func claimNodeStart() -> NodeStartDecision {
+        nodeStartLock.lock()
+        defer { nodeStartLock.unlock() }
+        
+        if isStartingNode {
+            return .startInFlight
+        }
+        if ldkNode != nil, status()?.isRunning == true {
+            return .alreadyRunning
+        }
+        isStartingNode = true
+        return .proceed
+    }
+    
+    func endNodeStart() {
+        nodeStartLock.lock()
+        isStartingNode = false
+        nodeStartLock.unlock()
     }
     
     func didStartLDK() -> Bool {

--- a/ios/bittr/BitcoinManager.swift
+++ b/ios/bittr/BitcoinManager.swift
@@ -20,6 +20,7 @@ class BitcoinManager {
     // LDK Node single-flight startup guard.
     private let nodeStartLock = NSLock()
     private var isStartingNode = false
+    private var nodeStartCompletions = [(Bool) -> Void]()
     
     // BDK
     var bdkWallet: BitcoinDevKit.Wallet?
@@ -62,11 +63,21 @@ class BitcoinManager {
         case alreadyRunning  // LDKNode is already running.
     }
     
-    func claimNodeStart() -> NodeStartDecision {
+    /// Claims the right to start the node.
+    ///
+    /// - Parameter onInFlightStart: called on the main thread with the outcome of
+    ///   the start that is *already* running, but only when `.startInFlight` is
+    ///   returned. Callers that can't just walk away from a start they didn't win
+    ///   (they've raised a spinner, or they're a retry after a hang) must pass this
+    ///   — otherwise their branch is a silent dead end for as long as that start runs.
+    func claimNodeStart(onInFlightStart: ((Bool) -> Void)? = nil) -> NodeStartDecision {
         nodeStartLock.lock()
         defer { nodeStartLock.unlock() }
-        
+
         if isStartingNode {
+            if let onInFlightStart {
+                nodeStartCompletions.append(onInFlightStart)
+            }
             return .startInFlight
         }
         if ldkNode != nil, status()?.isRunning == true {
@@ -75,11 +86,29 @@ class BitcoinManager {
         isStartingNode = true
         return .proceed
     }
-    
-    func endNodeStart() {
+
+    /// Runs the node start that `claimNodeStart()` just granted, releasing the
+    /// single-flight flag however `start` exits. Owning both sides of the guard here
+    /// is what makes it unleakable: a caller can't return early past the release, and
+    /// nothing outside this method is in a position to bypass it.
+    func runClaimedNodeStart(_ start: () -> Bool) -> Bool {
+        var didStart = false
+        defer { endNodeStart(didStart: didStart) }
+        didStart = start()
+        return didStart
+    }
+
+    private func endNodeStart(didStart: Bool) {
         nodeStartLock.lock()
         isStartingNode = false
+        let completions = nodeStartCompletions
+        nodeStartCompletions.removeAll()
         nodeStartLock.unlock()
+
+        guard !completions.isEmpty else { return }
+        DispatchQueue.main.async {
+            completions.forEach { $0(didStart) }
+        }
     }
     
     func didStartLDK() -> Bool {

--- a/ios/bittr/BitcoinManager.swift
+++ b/ios/bittr/BitcoinManager.swift
@@ -340,19 +340,13 @@ class BitcoinManager {
     }
     
     func listPayments() -> [PaymentDetails] {
-        guard self.ldkNode != nil else {
-            return []
-        }
-        let payments = self.ldkNode!.listPayments()
-        return payments
+        guard let node = self.ldkNode else { return [] }
+        return node.listPayments()
     }
-    
+
     func listChannels() -> [LDKNode.ChannelDetails] {
-        guard self.ldkNode != nil else {
-            return []
-        }
-        let channels = self.ldkNode!.listChannels()
-        return channels
+        guard let node = self.ldkNode else { return [] }
+        return node.listChannels()
     }
 
     /// Whether it is safe to wipe the wallet from the device.
@@ -400,12 +394,16 @@ class BitcoinManager {
         
         DispatchQueue.global(qos: .background).async {
             Log.info("Will light sync wallet.")
+            guard let node = self.ldkNode else {
+                DispatchQueue.main.async { completion(false) }
+                return
+            }
             
             // Light sync BDK.
             _ = self.lightSyncBdkWallet()
             
             // Check if any changes have been found.
-            if self.bittrWallet.satoshisOnchain != Int(self.ldkNode!.listBalances().totalOnchainBalanceSats) || self.bittrWallet.allTransactions.count != self.listPayments().count {
+            if self.bittrWallet.satoshisOnchain != Int(node.listBalances().totalOnchainBalanceSats) || self.bittrWallet.allTransactions.count != self.listPayments().count {
                 Log.info("Did find updates in light sync.")
                 
                 Task {
@@ -462,7 +460,8 @@ class BitcoinManager {
     }
     
     func syncWallets() throws {
-        try self.ldkNode!.syncWallets()
+        guard let node = self.ldkNode else { throw WalletError.walletNotInitiated }
+        try node.syncWallets()
     }
     
     func getInvoice(amountMsat: UInt64, description:String, expirySecs:UInt32) async -> Bolt11Invoice? {
@@ -497,13 +496,13 @@ class BitcoinManager {
     }
     
     func sendPayment(invoice: Bolt11Invoice) throws -> PaymentHash {
-        let paymentHash = try self.ldkNode!.bolt11Payment().send(invoice: invoice, routeParameters: nil)
-        return paymentHash
+        guard let node = self.ldkNode else { throw WalletError.walletNotInitiated }
+        return try node.bolt11Payment().send(invoice: invoice, routeParameters: nil)
     }
-    
+
     func sendZeroAmountPayment(invoice: Bolt11Invoice, amount:Int) throws -> PaymentHash {
-        let paymentHash = try self.ldkNode!.bolt11Payment().sendUsingAmount(invoice: invoice, amountMsat: UInt64(amount*1000), routeParameters: nil)
-        return paymentHash
+        guard let node = self.ldkNode else { throw WalletError.walletNotInitiated }
+        return try node.bolt11Payment().sendUsingAmount(invoice: invoice, amountMsat: UInt64(amount*1000), routeParameters: nil)
     }
     
     func sendBolt12Payment(offer:LDKNode.Offer, amount:Int) throws -> PaymentId? {
@@ -513,21 +512,18 @@ class BitcoinManager {
             maxTotalCltvExpiryDelta: 1008,
             maxPathCount: 10,
             maxChannelSaturationPowerOfHalf: 2)
-        let paymentId = try self.ldkNode!.bolt12Payment().sendUsingAmount(offer: offer, amountMsat: UInt64(amount*1000), quantity: nil, payerNote: nil, routeParameters: routeConfig)
+        guard let node = self.ldkNode else { throw WalletError.walletNotInitiated }
+        let paymentId = try node.bolt12Payment().sendUsingAmount(offer: offer, amountMsat: UInt64(amount*1000), quantity: nil, payerNote: nil, routeParameters: routeConfig)
         return paymentId
     }
     
     func getNewOnchainAddress() -> String? {
-        
-        if self.ldkNode == nil {
+        guard let node = self.ldkNode else { return nil }
+        do {
+            let newAddress = try node.onchainPayment().newAddress()
+            return newAddress.description
+        } catch {
             return nil
-        } else {
-            do {
-                let newAddress = try self.ldkNode!.onchainPayment().newAddress()
-                return newAddress.description
-            } catch {
-                return nil
-            }
         }
     }
     
@@ -537,18 +533,16 @@ class BitcoinManager {
         let feeRate = LDKNode.FeeRate.fromSatPerVbUnchecked(satVb: feeRateSatVb)
         
         // Broadcast transaction.
-        let onchainID = try self.ldkNode!.onchainPayment().sendToAddress(address: address, amountSats: amountSats, feeRate: feeRate)
+        guard let node = self.ldkNode else { throw WalletError.walletNotInitiated }
+        let onchainID = try node.onchainPayment().sendToAddress(address: address, amountSats: amountSats, feeRate: feeRate)
         
         // Return transaction ID.
         return onchainID.description
     }
     
     func getPaymentDetails(paymentHash: PaymentHash) -> PaymentDetails? {
-        if let invoiceDetails = self.ldkNode!.payment(paymentId: paymentHash) {
-            return invoiceDetails
-        } else {
-            return nil
-        }
+        guard let node = self.ldkNode else { return nil }
+        return node.payment(paymentId: paymentHash)
     }
     
     func getEsploraClient() -> EsploraClient? {

--- a/ios/bittr/Core/CoreViewController.swift
+++ b/ios/bittr/Core/CoreViewController.swift
@@ -22,6 +22,11 @@ class CoreViewController: UIViewController {
     var resettingPin = false
     var removingWalletForIncorrectPin = false
     var isRemovalInFlight = false
+
+    // True while continueStartWallet's post-start work is running. Several
+    // startWallet callers can be attached to a single node start, and they all
+    // get told when it finishes — but that work is global, not per-caller.
+    var isContinuingStartWallet = false
     
     // Client details (bittrWallet now lives on BitcoinManager.shared)
     var walletSync:BackgroundSync?

--- a/ios/bittr/Core/CoreViewController.swift
+++ b/ios/bittr/Core/CoreViewController.swift
@@ -21,6 +21,7 @@ class CoreViewController: UIViewController {
     // Pin reset
     var resettingPin = false
     var removingWalletForIncorrectPin = false
+    var isRemovalInFlight = false
     
     // Client details (bittrWallet now lives on BitcoinManager.shared)
     var walletSync:BackgroundSync?

--- a/ios/bittr/Core/ResetApp.swift
+++ b/ios/bittr/Core/ResetApp.swift
@@ -228,6 +228,14 @@ extension CoreViewController {
             DispatchQueue.main.async {
                 self.didCloseChannel()
                 self.genericSpinner.stopAnimating()
+
+                // Release the single-flight guard: the close is broadcast and a
+                // terminal alert is about to go up, so the only way forward is a
+                // fresh user-initiated attempt. Holding the guard past this point
+                // makes that attempt a silent no-op — and nothing else would ever
+                // clear it for the rest of the session.
+                self.isRemovalInFlight = false
+
                 if self.removingWalletForIncorrectPin {
                     // User is locked out. Show "Try again" button as only available user action.
                     self.showAlert(presentingController: self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "stillclosing"), buttons: [Language.getWord(withID: "tryagain")], actions: [#selector(self.startWalletInBackground)])

--- a/ios/bittr/Core/ResetApp.swift
+++ b/ios/bittr/Core/ResetApp.swift
@@ -76,6 +76,11 @@ extension CoreViewController {
                 if BitcoinManager.shared.listChannels().getActiveChannel() != nil {
                     Log.info("Channel still open — initiating cooperative close before any reset.")
                     if self.removingWalletForIncorrectPin {
+                        guard !self.isRemovalInFlight else {
+                            Log.info("Channel close already in flight — skipping duplicate.")
+                            return
+                        }
+                        self.isRemovalInFlight = true
                         self.closeChannelConfirmed()
                     } else {
                         self.showAlert(presentingController: self, title: Language.getWord(withID: "removewallet"), message: Language.getWord(withID: "restorewallet4"), buttons: [Language.getWord(withID: "cancel"), Language.getWord(withID: "closechannel")], actions: [nil, #selector(self.closeChannelAlert)])
@@ -85,6 +90,9 @@ extension CoreViewController {
                     // on-chain yet (still being swept). Don't wipe — tell the
                     // user to come back once it has settled.
                     Log.info("Channel closed but funds still settling — deferring wallet reset.")
+                    
+                    // Release the single-flight guard so the wipe can proceed once swept.
+                    self.isRemovalInFlight = false
                     
                     if self.removingWalletForIncorrectPin {
                         // User is locked out. Show "Try again" button, as only available user action.
@@ -98,6 +106,8 @@ extension CoreViewController {
                     }
                 }
             } else {
+                // Fully closed and swept — the close is done.
+                self.isRemovalInFlight = false
                 if self.resettingPin || self.removingWalletForIncorrectPin {
                     Log.info("No channels and nothing left to sweep — removing wallet.")
                     self.performWalletReset()
@@ -166,13 +176,8 @@ extension CoreViewController {
                     if didConnectToPeer {
                         self.closeChannelConfirmed()
                     } else if self.removingWalletForIncorrectPin {
-                        // Automated wipe path: we only ever cooperatively close,
-                        // which needs the peer online. Don't force close (it locks
-                        // funds behind a CSV delay and risks loss on the wipe) and
-                        // don't wipe. Offer a single "Try again" action
-                        // (startWalletInBackground re-syncs + re-checks), matching
-                        // the "still closing" path — otherwise tapping Okay would
-                        // strand the locked-out user on a static full-screen cover.
+                        // Close attempt failed — release the single-flight guard.
+                        self.isRemovalInFlight = false
                         self.genericSpinner.stopAnimating()
                         self.showAlert(presentingController: self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "closeretrylater"), buttons: [Language.getWord(withID: "tryagain")], actions: [#selector(self.startWalletInBackground)])
                     } else {
@@ -204,11 +209,8 @@ extension CoreViewController {
                         scope.setExtra(value: "ResetApp row 170", key: "context")
                     }
                     if self.removingWalletForIncorrectPin {
-                        // Coop close failed during the automated wipe. Do not force
-                        // close or wipe. Offer a single "Try again" action
-                        // (startWalletInBackground re-syncs + re-checks), matching
-                        // the "still closing" path, so the locked-out user isn't
-                        // stranded behind the cover with only a dismiss button.
+                        // Close attempt failed — release the single-flight guard.
+                        self.isRemovalInFlight = false
                         self.genericSpinner.stopAnimating()
                         self.showAlert(presentingController: self, title: Language.getWord(withID: "restorewallet"), message: Language.getWord(withID: "closeretrylater"), buttons: [Language.getWord(withID: "tryagain")], actions: [#selector(self.startWalletInBackground)])
                     } else {

--- a/ios/bittr/Core/ResetApp.swift
+++ b/ios/bittr/Core/ResetApp.swift
@@ -301,17 +301,12 @@ extension CoreViewController {
         self.resettingPin = false
         self.removingWalletForIncorrectPin = false
         
-        // Removal finished — clear the resume-on-launch flag.
-        CacheManager.setWalletRemovalInProgress(false)
-        
-        // Clear mnemonic from cache
-        CacheManager.deleteClientInfo()
-        
         // Clear the in-memory account entity.
         BitcoinManager.shared.bittrWallet = BittrWallet()
-        
+
         // Remove wallet from device and remove corresponding cached data.
         DispatchQueue.global(qos: .userInitiated).async {
+            var cleanupSucceeded = false
             do {
                 Log.info("Starting wallet reset cleanup")
                 
@@ -332,6 +327,7 @@ extension CoreViewController {
                 BitcoinManager.shared.resetNodeState()
                 Log.info("Node state reset completed")
                 
+                cleanupSucceeded = true
             } catch {
                 Log.info("Error during cleanup: \(error.localizedDescription)")
                 DispatchQueue.main.async {
@@ -340,11 +336,13 @@ extension CoreViewController {
                     }
                 }
                 
-                // Even if everything fails, try to clean up documents
+                // Even if everything fails, try to clean up documents (and state).
                 do {
                     Log.info("Attempting final fallback document cleanup")
                     try BitcoinManager.shared.deleteDocuments()
+                    BitcoinManager.shared.resetNodeState()
                     Log.info("Final fallback document cleanup successful")
+                    cleanupSucceeded = true
                 } catch {
                     Log.info("Final fallback document cleanup failed: \(error.localizedDescription)")
                     DispatchQueue.main.async {
@@ -355,7 +353,23 @@ extension CoreViewController {
                 }
             }
             
-            // Cleanup done — relaunch the create-wallet flow on main.
+            guard cleanupSucceeded else {
+                // Teardown failed.
+                Log.info("Wallet reset cleanup did not complete — seed left intact to resume on next launch.")
+                DispatchQueue.main.async {
+                    self.genericSpinner.stopAnimating()
+                    self.fullViewCover.alpha = 0
+                    self.showAlert(presentingController: self, title: Language.getWord(withID: "removewallet"), message: Language.getWord(withID: "removalfailed"), buttons: [Language.getWord(withID: "okay")], actions: nil)
+                }
+                return
+            }
+            
+            // Node stopped and files removed — now it's safe to delete the seed
+            // (last), and the removal is fully complete.
+            CacheManager.deleteClientInfo()
+            CacheManager.setWalletRemovalInProgress(false)
+            
+            // Relaunch the create-wallet flow on main.
             DispatchQueue.main.async {
                 // Hide signup view and launch create wallet flow
                 // Since we've cleared the PIN, we need to manually show the create wallet flow

--- a/ios/bittr/Core/ResetApp.swift
+++ b/ios/bittr/Core/ResetApp.swift
@@ -307,16 +307,20 @@ extension CoreViewController {
         self.hideAlert()
         self.hideSettings()
         
-        // Stop background sync timer.
+        // Stop background sync timer. This has to happen before the teardown
+        // below — a sync running against a half-deleted wallet is worse than
+        // losing the timer if the cleanup then fails, and the failure alert
+        // tells the user to reopen the app, which starts it again.
         self.walletSync?.stop()
         self.walletSync = nil
-        
-        // Reset PIN reset state
+
+        // Reset PIN reset state, remembering it so the failure path can put it
+        // back: if nothing was actually removed the user is still mid-PIN-reset
+        // or still locked out, and clearing these strands them outside both flows.
+        let wasResettingPin = self.resettingPin
+        let wasRemovingWalletForIncorrectPin = self.removingWalletForIncorrectPin
         self.resettingPin = false
         self.removingWalletForIncorrectPin = false
-        
-        // Clear the in-memory account entity.
-        BitcoinManager.shared.bittrWallet = BittrWallet()
 
         // Remove wallet from device and remove corresponding cached data.
         DispatchQueue.global(qos: .userInitiated).async {
@@ -371,6 +375,10 @@ extension CoreViewController {
                 // Teardown failed.
                 Log.info("Wallet reset cleanup did not complete — seed left intact to resume on next launch.")
                 DispatchQueue.main.async {
+                    // Nothing was removed, so put the removal state back rather
+                    // than leaving the app half-reset for the rest of the session.
+                    self.resettingPin = wasResettingPin
+                    self.removingWalletForIncorrectPin = wasRemovingWalletForIncorrectPin
                     self.genericSpinner.stopAnimating()
                     self.fullViewCover.alpha = 0
                     self.showAlert(presentingController: self, title: Language.getWord(withID: "removewallet"), message: Language.getWord(withID: "removalfailed"), buttons: [Language.getWord(withID: "okay")], actions: nil)
@@ -385,6 +393,12 @@ extension CoreViewController {
             
             // Relaunch the create-wallet flow on main.
             DispatchQueue.main.async {
+                // Clear the in-memory account entity now that the on-device
+                // wallet is actually gone. Doing this up front would leave a
+                // zeroed-out wallet behind on the failure path above, where
+                // everything it described still exists.
+                BitcoinManager.shared.bittrWallet = BittrWallet()
+
                 // Hide signup view and launch create wallet flow
                 // Since we've cleared the PIN, we need to manually show the create wallet flow
                 self.hideSignup()

--- a/ios/bittr/Core/ResetApp.swift
+++ b/ios/bittr/Core/ResetApp.swift
@@ -297,6 +297,10 @@ extension CoreViewController {
         self.hideAlert()
         self.hideSettings()
         
+        // Stop background sync timer.
+        self.walletSync?.stop()
+        self.walletSync = nil
+        
         // Reset PIN reset state
         self.resettingPin = false
         self.removingWalletForIncorrectPin = false

--- a/ios/bittr/Core/StartLightning.swift
+++ b/ios/bittr/Core/StartLightning.swift
@@ -13,7 +13,17 @@ extension CoreViewController {
     
     func startWallet() {
         
-        if BitcoinManager.shared.ldkNode == nil || BitcoinManager.shared.status()?.isRunning == false {
+        switch BitcoinManager.shared.claimNodeStart() {
+        case .alreadyRunning:
+            // Node is already running.
+            self.continueStartWallet()
+            
+        case .startInFlight:
+            // Node is already being started.
+            Log.info("Node start already in flight — skipping duplicate startWallet.")
+            
+        case .proceed:
+            // Node has not yet been started.
             self.startSync(.ldk)
 
             // Watchdog: building/starting the node can hang on network and
@@ -32,6 +42,7 @@ extension CoreViewController {
 
             DispatchQueue.global(qos: .userInitiated).async {
                 let didStartLDKNode = self.startLightning()
+                BitcoinManager.shared.endNodeStart()
                 DispatchQueue.main.async {
                     ldkStartCompleted = true
                     // The watchdog already surfaced the retry alert; Try again
@@ -45,8 +56,6 @@ extension CoreViewController {
                     self.continueStartWallet()
                 }
             }
-        } else {
-            self.continueStartWallet()
         }
     }
     

--- a/ios/bittr/Core/StartLightning.swift
+++ b/ios/bittr/Core/StartLightning.swift
@@ -12,54 +12,90 @@ import Sentry
 extension CoreViewController {
     
     func startWallet() {
-        
-        switch BitcoinManager.shared.claimNodeStart() {
-        case .alreadyRunning:
-            // Node is already running.
-            self.continueStartWallet()
-            
-        case .startInFlight:
-            // Node is already being started.
-            Log.info("Node start already in flight — skipping duplicate startWallet.")
-            
-        case .proceed:
-            // Node has not yet been started.
-            self.startSync(.ldk)
 
-            // Watchdog: building/starting the node can hang on network and
-            // didStartLDK has no timeout of its own, so without a deadline a
-            // hang means spinner-forever. Surface the retry alert after 15s
-            // (the same deadline the previous async implementation raced
-            // against). Both flags are only touched on main, so no races.
-            var ldkStartCompleted = false
-            var ldkWatchdogFired = false
+        // Both flags are only touched on main, so no races.
+        var ldkStartCompleted = false
+        var ldkWatchdogFired = false
+
+        let showRetryAlert = { [weak self] in
+            guard let self else { return }
+            self.showAlert(presentingController: self, title: Language.getWord(withID: "oops"), message: Language.getWord(withID: "walletconnectfail"), buttons: [Language.getWord(withID: "tryagain")], actions: [#selector(self.restartLightning)])
+        }
+
+        // Watchdog: building/starting the node can hang on network and
+        // didStartLDK has no timeout of its own, so without a deadline a hang
+        // means spinner-forever. Surface the retry alert after 15s (the same
+        // deadline the previous async implementation raced against).
+        let armWatchdog = {
             DispatchQueue.main.asyncAfter(deadline: .now() + 15) {
                 guard !ldkStartCompleted else { return }
                 ldkWatchdogFired = true
                 Log.info("Starting LDK Node takes too long.")
-                self.showAlert(presentingController: self, title: Language.getWord(withID: "oops"), message: Language.getWord(withID: "walletconnectfail"), buttons: [Language.getWord(withID: "tryagain")], actions: [#selector(self.restartLightning)])
+                showRetryAlert()
             }
+        }
+
+        // Called on main with the outcome of the start this call is riding on —
+        // whether we own it or attached to one already in flight.
+        let finish: (Bool) -> Void = { [weak self] didStartLDKNode in
+            ldkStartCompleted = true
+            // The watchdog already surfaced the retry alert; Try again re-enters
+            // startWallet, which either sees the now-running node or attaches to
+            // the start still in flight.
+            guard !ldkWatchdogFired else { return }
+            guard didStartLDKNode else {
+                showRetryAlert()
+                return
+            }
+            self?.continueStartWallet()
+        }
+
+        switch BitcoinManager.shared.claimNodeStart(onInFlightStart: finish) {
+        case .alreadyRunning:
+            // Node is already running.
+            self.continueStartWallet()
+
+        case .startInFlight:
+            // A start is already running and `finish` is now attached to it, so
+            // this call still gets an outcome instead of returning into nothing.
+            // Arm a watchdog here too: this branch is exactly where the retry
+            // alert's Try again lands when a start hangs, and without a fresh
+            // deadline that tap would dismiss the alert with nothing left to
+            // re-show it — leaving the user behind a full-screen cover with no
+            // action available, on the lockout path especially.
+            Log.info("Node start already in flight — attaching to it.")
+            self.startSync(.ldk)
+            armWatchdog()
+
+        case .proceed:
+            // Node has not yet been started.
+            self.startSync(.ldk)
+            armWatchdog()
 
             DispatchQueue.global(qos: .userInitiated).async {
-                let didStartLDKNode = self.startLightning()
-                BitcoinManager.shared.endNodeStart()
+                let didStartLDKNode = BitcoinManager.shared.runClaimedNodeStart {
+                    self.startLightning()
+                }
                 DispatchQueue.main.async {
-                    ldkStartCompleted = true
-                    // The watchdog already surfaced the retry alert; Try again
-                    // re-enters startWallet, which sees the now-running node
-                    // and continues immediately.
-                    guard !ldkWatchdogFired else { return }
-                    guard didStartLDKNode else {
-                        self.showAlert(presentingController: self, title: Language.getWord(withID: "oops"), message: Language.getWord(withID: "walletconnectfail"), buttons: [Language.getWord(withID: "tryagain")], actions: [#selector(self.restartLightning)])
-                        return
-                    }
-                    self.continueStartWallet()
+                    finish(didStartLDKNode)
                 }
             }
         }
     }
     
     func continueStartWallet() {
+
+        // One node start can have several startWallet callers riding on it, and
+        // each of them is told when it finishes. The work below (syncWallets,
+        // loadWalletData, startBDK) is global rather than per-caller, so let the
+        // first one through and drop the rest until it has finished. Only ever
+        // touched on main.
+        guard !self.isContinuingStartWallet else {
+            Log.info("continueStartWallet already running — skipping duplicate.")
+            return
+        }
+        self.isContinuingStartWallet = true
+
         self.completeSync(.ldk)
         
         // Start final calculations.
@@ -74,8 +110,12 @@ extension CoreViewController {
         }
         
         DispatchQueue.global(qos: .userInitiated).async {
+            // Release the guard however this block exits, so a later restart
+            // (after a reset, or a genuinely new start) isn't locked out by it.
+            defer { DispatchQueue.main.async { self.isContinuingStartWallet = false } }
+
             guard BitcoinManager.shared.ldkNode != nil else { return }
-            
+
             // Sync wallet.
             do {
                 try BitcoinManager.shared.syncWallets()

--- a/ios/bittr/Helpers/BittrService.swift
+++ b/ios/bittr/Helpers/BittrService.swift
@@ -25,7 +25,7 @@ class BittrService {
         ]
         
         guard let url = urlComponents.url else {
-            throw BittrServiceError.other("Invalid URL" as! Error)
+            throw BittrServiceError.invalidURL
         }
 
         var request = URLRequest(url: url)
@@ -74,7 +74,7 @@ class BittrService {
             lightningPubKey = pubkeyString
         } else {
             Log.info("Wallet has not yet synced. Cannot fetch pubkey.")
-            throw BittrServiceError.other("Unsynced wallet" as! Error)
+            throw BittrServiceError.unsyncedWallet
         }
         
         do {
@@ -92,7 +92,7 @@ class BittrService {
             ]
             
             guard let url = urlComponents.url else {
-                throw BittrServiceError.other("Invalid URL" as! Error)
+                throw BittrServiceError.invalidURL
             }
             
             var request = URLRequest(url: url)
@@ -136,7 +136,7 @@ class BittrService {
         ]
         
         guard let url = urlComponents.url else {
-            throw BittrServiceError.other("Invalid URL" as! Error)
+            throw BittrServiceError.invalidURL
         }
 
         var request = URLRequest(url: url)
@@ -250,6 +250,8 @@ struct BittrTransaction: Codable {
 }
 
 enum BittrServiceError: Error {
+    case invalidURL
+    case unsyncedWallet
     case serverError(String)
     case networkError(Error)
     case decodingError(Error)
@@ -261,6 +263,10 @@ enum BittrServiceError: Error {
 extension BittrServiceError: LocalizedError {
     var errorDescription: String? {
         switch self {
+        case .invalidURL:
+            return "Couldn't build a valid request URL."
+        case .unsyncedWallet:
+            return "Your wallet hasn't finished syncing. Please try again in a moment."
         case .serverError(let message):
             return message
         case .networkError(let error):

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -14,34 +14,49 @@ extension HomeViewController {
     func loadWalletData() {
         
         // Get channels, balance, and funding transaction ID.
-        BitcoinManager.shared.bittrWallet.satoshisLightning = 0
-        BitcoinManager.shared.bittrWallet.lightningChannels = BitcoinManager.shared.listChannels()
-        if let activeChannel = BitcoinManager.shared.bittrWallet.lightningChannels.getActiveChannel() {
+        var satoshisLightning = 0
+        let lightningChannels = BitcoinManager.shared.listChannels()
+        if let activeChannel = lightningChannels.getActiveChannel() {
             if let channelTxoID = activeChannel.fundingTxo?.txid as? String {
                 CacheManager.storeTxoID(txoID: channelTxoID)
             }
             if Int(activeChannel.outboundCapacityMsat/1000) != 0 {
                 // Channel balance is more than punishment reserve.
-                BitcoinManager.shared.bittrWallet.satoshisLightning += Int((activeChannel.outboundCapacityMsat / 1000) + (activeChannel.unspendablePunishmentReserve ?? 0))
+                satoshisLightning += Int((activeChannel.outboundCapacityMsat / 1000) + (activeChannel.unspendablePunishmentReserve ?? 0))
             } else {
                 // Channel balance is less than punishment reserve.
-                BitcoinManager.shared.bittrWallet.satoshisLightning += Int(activeChannel.channelValueSats - activeChannel.inboundCapacityMsat/1000 - activeChannel.counterpartyUnspendablePunishmentReserve)
+                satoshisLightning += Int(activeChannel.channelValueSats - activeChannel.inboundCapacityMsat/1000 - activeChannel.counterpartyUnspendablePunishmentReserve)
             }
         }
         
         // Get transactions.
-        BitcoinManager.shared.bittrWallet.allTransactions = BitcoinManager.shared.listPayments()
+        let allTransactions = BitcoinManager.shared.listPayments()
         
         // Get onchain balance.
-        BitcoinManager.shared.bittrWallet.satoshisOnchain = Int(BitcoinManager.shared.ldkNode!.listBalances().totalOnchainBalanceSats)
+        guard let node = BitcoinManager.shared.ldkNode else { return }
+        let satoshisOnchain = Int(node.listBalances().totalOnchainBalanceSats)
         
-        Task {
-            // Check whether transactions were Bittr purchases.
-            _ = await self.getBittrTransactionDetails()
+        // Apply the snapshot to the shared wallet on the main thread.
+        let apply = {
+            BitcoinManager.shared.bittrWallet.satoshisLightning = satoshisLightning
+            BitcoinManager.shared.bittrWallet.lightningChannels = lightningChannels
+            BitcoinManager.shared.bittrWallet.allTransactions = allTransactions
+            BitcoinManager.shared.bittrWallet.satoshisOnchain = satoshisOnchain
 
-            DispatchQueue.main.async {
-                self.updateTransactionHistory()
+            Task {
+                // Check whether transactions were Bittr purchases.
+                _ = await self.getBittrTransactionDetails()
+
+                DispatchQueue.main.async {
+                    self.updateTransactionHistory()
+                }
             }
+        }
+        
+        if Thread.isMainThread {
+            apply()
+        } else {
+            DispatchQueue.main.async(execute: apply)
         }
     }
     

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -12,7 +12,12 @@ import Sentry
 extension HomeViewController {
 
     func loadWalletData() {
-        
+
+        // Take the node handle up front — everything below reads through it, and
+        // bailing halfway (after caching a txo ID, before any of the balances)
+        // leaves the cache describing a snapshot we never applied.
+        guard let node = BitcoinManager.shared.ldkNode else { return }
+
         // Get channels, balance, and funding transaction ID.
         var satoshisLightning = 0
         let lightningChannels = BitcoinManager.shared.listChannels()
@@ -33,7 +38,6 @@ extension HomeViewController {
         let allTransactions = BitcoinManager.shared.listPayments()
         
         // Get onchain balance.
-        guard let node = BitcoinManager.shared.ldkNode else { return }
         let satoshisOnchain = Int(node.listBalances().totalOnchainBalanceSats)
         
         // Apply the snapshot to the shared wallet on the main thread.

--- a/ios/bittr/Language.swift
+++ b/ios/bittr/Language.swift
@@ -248,6 +248,7 @@ class Language: NSObject {
             "pinwarning2": "You've entered the wrong PIN several times. After 10 failed attempts this wallet will be erased from the device, and any Bitcoin or Lightning funds it holds may be permanently lost.\n\nIf you still have your 12-word recovery phrase, tap \"Forgot PIN\" to reset your PIN instead — this keeps your wallet and your funds.\n\nNever delete the app from your phone, as this can also lead to loss of funds.",
             "stillclosing": "Your Lightning connection is still being closed. For your safety, the wallet can only be reset once the connection is fully closed and the funds have returned on-chain — this can take a while.\n\nPlease reopen the app later to finish the reset. Do not delete the app from your phone, as this will lead to loss of funds.",
             "closeretrylater": "Your Lightning connection could not be closed right now — the bittr node may be temporarily offline. Your wallet has not been reset.\n\nPlease reopen the app to try again later. Do not delete the app from your phone, as this will lead to loss of funds.",
+            "removalfailed": "Something went wrong removing your wallet, so it hasn't been removed — your wallet and funds are safe.\n\nPlease reopen the app to try again. Do not delete the app from your phone.",
             "pinlength": "PIN Length",
             "pincanbeupto8": "PIN can be up to 8 digits",
             "pinrequired": "PIN Required",

--- a/ios/bittr/Move, Send, Receive/SendVC/SendOnchain.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/SendOnchain.swift
@@ -86,11 +86,7 @@ extension SendViewController {
         
         // Create transaction.
         Task {
-            let feeEstimates = await BitcoinManager.shared.getFeeEstimates()
-            guard let feeEstimates = feeEstimates,
-                  let economyFee = feeEstimates["economyFee"] as? Double,
-                  let hourFee = feeEstimates["hourFee"] as? Double,
-                  let fastestFee = feeEstimates["fastestFee"] as? Double else {
+            guard let feeEstimates = await BitcoinManager.shared.getFeeEstimates() else {
                 DispatchQueue.main.async {
                     self.nextLabel.alpha = 1
                     self.arrowIcon.alpha = 1
@@ -99,9 +95,9 @@ extension SendViewController {
                 }
                 return
             }
-            self.feePerVbLow = Float(economyFee)
-            self.feePerVbMedium = Float(hourFee)
-            self.feePerVbHigh = Float(fastestFee)
+            self.feePerVbLow = Float(feeEstimates.economy)
+            self.feePerVbMedium = Float(feeEstimates.hour)
+            self.feePerVbHigh = Float(feeEstimates.fastest)
             
             // Get transaction size.
             let size:UInt64

--- a/ios/bittr/Move, Send, Receive/SendVC/SendOnchain.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/SendOnchain.swift
@@ -87,7 +87,10 @@ extension SendViewController {
         // Create transaction.
         Task {
             let feeEstimates = await BitcoinManager.shared.getFeeEstimates()
-            guard feeEstimates != nil else {
+            guard let feeEstimates = feeEstimates,
+                  let economyFee = feeEstimates["economyFee"] as? Double,
+                  let hourFee = feeEstimates["hourFee"] as? Double,
+                  let fastestFee = feeEstimates["fastestFee"] as? Double else {
                 DispatchQueue.main.async {
                     self.nextLabel.alpha = 1
                     self.arrowIcon.alpha = 1
@@ -96,9 +99,9 @@ extension SendViewController {
                 }
                 return
             }
-            self.feePerVbLow = Float(feeEstimates!["economyFee"] as! Double)
-            self.feePerVbMedium = Float(feeEstimates!["hourFee"] as! Double)
-            self.feePerVbHigh = Float(feeEstimates!["fastestFee"] as! Double)
+            self.feePerVbLow = Float(economyFee)
+            self.feePerVbMedium = Float(hourFee)
+            self.feePerVbHigh = Float(fastestFee)
             
             // Get transaction size.
             let size:UInt64

--- a/ios/bittr/Swaps/Swap Manager/BoltzRefund.swift
+++ b/ios/bittr/Swaps/Swap Manager/BoltzRefund.swift
@@ -29,7 +29,9 @@ class BoltzRefund {
     /// Both claim and refund transactions are always 99 vbytes in size
     static func calculateClaimOrRefundTransactionFee() async throws -> Int {
         let feeEstimates = await BitcoinManager.shared.getFeeEstimates()
-        let highPriorityFeeRate = feeEstimates!["fastestFee"] as! Double
+        guard let highPriorityFeeRate = feeEstimates?["fastestFee"] as? Double else {
+            throw BoltzAPIError.requestFailed("Could not fetch fee estimates for the claim/refund transaction.")
+        }
         let transactionSizeVBytes = 99 // Fixed size for claim/refund transactions
         
         let calculatedFee = Int(highPriorityFeeRate * Double(transactionSizeVBytes))

--- a/ios/bittr/Swaps/Swap Manager/BoltzRefund.swift
+++ b/ios/bittr/Swaps/Swap Manager/BoltzRefund.swift
@@ -28,13 +28,12 @@ class BoltzRefund {
     /// Calculates transaction fee using the highest priority fee rate
     /// Both claim and refund transactions are always 99 vbytes in size
     static func calculateClaimOrRefundTransactionFee() async throws -> Int {
-        let feeEstimates = await BitcoinManager.shared.getFeeEstimates()
-        guard let highPriorityFeeRate = feeEstimates?["fastestFee"] as? Double else {
+        guard let feeEstimates = await BitcoinManager.shared.getFeeEstimates() else {
             throw BoltzAPIError.requestFailed("Could not fetch fee estimates for the claim/refund transaction.")
         }
         let transactionSizeVBytes = 99 // Fixed size for claim/refund transactions
-        
-        let calculatedFee = Int(highPriorityFeeRate * Double(transactionSizeVBytes))
+
+        let calculatedFee = Int(feeEstimates.fastest * Double(transactionSizeVBytes))
         
         return calculatedFee
     }

--- a/ios/bittr/Swaps/Swap Manager/SwapManager.swift
+++ b/ios/bittr/Swaps/Swap Manager/SwapManager.swift
@@ -219,7 +219,7 @@ class SwapManager: NSObject {
         Task {
             if swapVC.highestFeePerVbyte == nil {
                 let feeEstimates = await BitcoinManager.shared.getFeeEstimates()
-                if feeEstimates == nil {
+                guard let fastestFee = feeEstimates?["fastestFee"] as? Double else {
                     Log.info("Could not fetch fee estimates.")
                     DispatchQueue.main.async {
                         swapVC.nextLabel.alpha = 1
@@ -229,9 +229,9 @@ class SwapManager: NSObject {
                     }
                     return
                 }
-                
+
                 // Select highest fee.
-                swapVC.highestFeePerVbyte = Float(feeEstimates!["fastestFee"] as! Double)
+                swapVC.highestFeePerVbyte = Float(fastestFee)
             }
             
             var size:UInt64

--- a/ios/bittr/Swaps/Swap Manager/SwapManager.swift
+++ b/ios/bittr/Swaps/Swap Manager/SwapManager.swift
@@ -218,8 +218,7 @@ class SwapManager: NSObject {
         // Check what the onchain fees will be for sending this onchain payment.
         Task {
             if swapVC.highestFeePerVbyte == nil {
-                let feeEstimates = await BitcoinManager.shared.getFeeEstimates()
-                guard let fastestFee = feeEstimates?["fastestFee"] as? Double else {
+                guard let feeEstimates = await BitcoinManager.shared.getFeeEstimates() else {
                     Log.info("Could not fetch fee estimates.")
                     DispatchQueue.main.async {
                         swapVC.nextLabel.alpha = 1
@@ -231,7 +230,7 @@ class SwapManager: NSObject {
                 }
 
                 // Select highest fee.
-                swapVC.highestFeePerVbyte = Float(fastestFee)
+                swapVC.highestFeePerVbyte = Float(feeEstimates.fastest)
             }
             
             var size:UInt64

--- a/ios/bittr/Swaps/SwapVC/SendableAmount.swift
+++ b/ios/bittr/Swaps/SwapVC/SendableAmount.swift
@@ -95,7 +95,7 @@ extension SwapViewController {
 
                 Task {
                     let feeEstimates = await BitcoinManager.shared.getFeeEstimates()
-                    if feeEstimates == nil {
+                    guard let fastestFee = feeEstimates?["fastestFee"] as? Double else {
                         Log.info("Could not fetch fee estimates.")
                         DispatchQueue.main.async {
                             guard self.swapDirection == requestedDirection else { return }
@@ -104,9 +104,9 @@ extension SwapViewController {
                         }
                         return
                     }
-                    
+
                     // Select highest fee.
-                    self.highestFeePerVbyte = Float(feeEstimates!["fastestFee"] as! Double)
+                    self.highestFeePerVbyte = Float(fastestFee)
                     
                     // Get own onchain address.
                     let actualAddress:String = BitcoinManager.shared.getAddress(atIndex: 0)

--- a/ios/bittr/Swaps/SwapVC/SendableAmount.swift
+++ b/ios/bittr/Swaps/SwapVC/SendableAmount.swift
@@ -94,8 +94,7 @@ extension SwapViewController {
                 let requestedDirection = self.swapDirection
 
                 Task {
-                    let feeEstimates = await BitcoinManager.shared.getFeeEstimates()
-                    guard let fastestFee = feeEstimates?["fastestFee"] as? Double else {
+                    guard let feeEstimates = await BitcoinManager.shared.getFeeEstimates() else {
                         Log.info("Could not fetch fee estimates.")
                         DispatchQueue.main.async {
                             guard self.swapDirection == requestedDirection else { return }
@@ -106,7 +105,7 @@ extension SwapViewController {
                     }
 
                     // Select highest fee.
-                    self.highestFeePerVbyte = Float(fastestFee)
+                    self.highestFeePerVbyte = Float(feeEstimates.fastest)
                     
                     // Get own onchain address.
                     let actualAddress:String = BitcoinManager.shared.getAddress(atIndex: 0)


### PR DESCRIPTION
- During wallet removal, only remove **seed and pin details** as the last step.
- Updates to **BittrServiceError** distinctions.
- Improve **getFeeEstimates** to not crash when receiving unexpected data.
- Additional guards against **ldkNode==nil**.
- Guard against **double LDKNode starts**.
- **Thread improvement** for loadWalletData.
- Guard against **double wallet removal**.