### PR TITLE
Allow clearing a transaction note to delete it

### DIFF
--- a/ios/bittr/CacheManager.swift
+++ b/ios/bittr/CacheManager.swift
@@ -808,6 +808,21 @@ class CacheManager: NSObject {
         }
     }
     
+    static func deleteTransactionNote(txid:String) {
+
+        let envKey = EnvironmentConfig.cacheKey(for: "transactionnotes")
+
+        let defaults = UserDefaults.standard
+        let cachedTransactionNotes = defaults.value(forKey: envKey) as? NSDictionary
+        if let actualCachedNotes = cachedTransactionNotes {
+            // Notes have been cached.
+            if let actualMutableNotes = actualCachedNotes.mutableCopy() as? NSMutableDictionary {
+                actualMutableNotes.removeObject(forKey: txid)
+                defaults.set(actualMutableNotes, forKey: envKey)
+            }
+        }
+    }
+
     static func getTransactionNote(txid:String) -> String {
         
         let envKey = EnvironmentConfig.cacheKey(for: "transactionnotes")

--- a/ios/bittr/Transaction/TransactionViewController.swift
+++ b/ios/bittr/Transaction/TransactionViewController.swift
@@ -640,8 +640,13 @@ class TransactionViewController: UIViewController {
         NSLayoutConstraint.deactivate([self.noteStackHeight])
         self.noteStackHeight = NSLayoutConstraint(item: self.noteStack, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 0)
         NSLayoutConstraint.activate([self.noteStackHeight])
-        self.addANoteStack.alpha = 1
-        self.addANoteStackHeight.constant = 45
+        // Keep "Add a note" hidden on the Bittr payout summary, which suppresses
+        // it deliberately — reverting to it there would put the button on a
+        // screen that never offers one.
+        if !self.showConfetti {
+            self.addANoteStack.alpha = 1
+            self.addANoteStackHeight.constant = 45
+        }
         self.view.layoutIfNeeded()
     }
     
@@ -656,9 +661,12 @@ class TransactionViewController: UIViewController {
             saveTitle: Language.getWord(withID: "save")
         ) { [weak self] noteText in
             guard let self = self else { return }
-            if noteText.trimmingCharacters(in: .whitespacesAndNewlines) != "" {
-                CacheManager.storeTransactionNote(txid: self.tappedTransaction.id, note: noteText)
-                self.labelNote.text = noteText
+            let trimmedNote = noteText.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedNote != "" {
+                // Store what the emptiness check was made against, so a note
+                // isn't persisted (and redisplayed) with stray padding.
+                CacheManager.storeTransactionNote(txid: self.tappedTransaction.id, note: trimmedNote)
+                self.labelNote.text = trimmedNote
                 self.showNoteStack()
             } else {
                 // The user cleared the note: delete it and revert to the "Add a note" button.

--- a/ios/bittr/Transaction/TransactionViewController.swift
+++ b/ios/bittr/Transaction/TransactionViewController.swift
@@ -635,6 +635,16 @@ class TransactionViewController: UIViewController {
         self.view.layoutIfNeeded()
     }
     
+    func hideNoteStack() {
+        self.noteStack.alpha = 0
+        NSLayoutConstraint.deactivate([self.noteStackHeight])
+        self.noteStackHeight = NSLayoutConstraint(item: self.noteStack, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 0)
+        NSLayoutConstraint.activate([self.noteStackHeight])
+        self.addANoteStack.alpha = 1
+        self.addANoteStackHeight.constant = 45
+        self.view.layoutIfNeeded()
+    }
+    
     @IBAction func noteButtonTapped(_ sender: UIButton) {
 
         self.showTextFieldAlert(
@@ -650,6 +660,11 @@ class TransactionViewController: UIViewController {
                 CacheManager.storeTransactionNote(txid: self.tappedTransaction.id, note: noteText)
                 self.labelNote.text = noteText
                 self.showNoteStack()
+            } else {
+                // The user cleared the note: delete it and revert to the "Add a note" button.
+                CacheManager.deleteTransactionNote(txid: self.tappedTransaction.id)
+                self.labelNote.text = ""
+                self.hideNoteStack()
             }
         }
     }


### PR DESCRIPTION
In **TransactionVC**, emptying the **note text field** and tapping Save now **deletes the stored note** and reverts the card to the "Add a note" button, instead of silently keeping the old note.