### PR TITLE
Fix BDK sync scan latch and false-success in light sync

### DIFF
--- a/ios/bittr/AlertManager.swift
+++ b/ios/bittr/AlertManager.swift
@@ -44,17 +44,22 @@ protocol OnchainSyncFailureReporting: UIViewController {
 
 extension OnchainSyncFailureReporting {
     /// Stops the on-chain sync spinner and tells the user the on-chain sync
-    /// failed and to retry later. Safe to call from any thread — BDK completions
-    /// fire off the main thread.
+    /// failed. Safe to call from any thread — BDK completions fire off the main
+    /// thread.
+    ///
+    /// A scan that timed out gets different copy: the scan is still running and
+    /// can't be stopped, so "try again later" would send the user back to a
+    /// screen that stays blocked no matter how long they wait.
     func presentOnchainSyncFailedAlert() {
         DispatchQueue.main.async {
             self.bdkSpinner.stopAnimating()
+            let timedOut = BitcoinManager.shared.bdkFullScanTimedOut
             // Replace the "syncing" alert (if still visible) with the failure alert.
             self.hideAlert()
             self.showAlert(
                 presentingController: self,
                 title: Language.getWord(withID: "onchainsyncfailedtitle"),
-                message: Language.getWord(withID: "onchainsyncfailed"),
+                message: Language.getWord(withID: timedOut ? "onchainsynctimedout" : "onchainsyncfailed"),
                 buttons: [Language.getWord(withID: "okay")],
                 actions: nil
             )

--- a/ios/bittr/BDKManager.swift
+++ b/ios/bittr/BDKManager.swift
@@ -86,7 +86,14 @@ extension BitcoinManager {
     func didSyncBdkWallet(completion originalCompletion: @escaping (Bool) -> Void) {
         Log.info("Will sync BDK wallet.")
         self.bdkWalletIsScanning = true
-        
+        self.bdkFullScanTimedOut = false
+
+        // The watchdog below hands the caller a failure, but it cannot stop the
+        // scan — so `bdkWalletIsScanning` stays set and every scan-gated screen
+        // stays blocked until the app is restarted. Callers surface that via
+        // `bdkFullScanTimedOut` rather than the generic "try again later" copy,
+        // which would be a lie: nothing the user does in this session will help.
+        //
         // NOTE: `timeout` must stay comfortably above a legitimately slow scan
         // (the fullScan below is documented as "seconds to minutes"), or slow
         // syncs get reported as failures. Tune before shipping.
@@ -101,6 +108,7 @@ extension BitcoinManager {
         }
         DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + timeout) {
             Log.info("BDK full scan timed out after \(Int(timeout))s; failing so callers don't hang.")
+            self.bdkFullScanTimedOut = true
             completion(false)
         }
 
@@ -201,6 +209,17 @@ extension BitcoinManager {
     }
     
     func lightSyncBdkWallet() -> Bool {
+        // Stand down while a full scan is running. Both work through the same
+        // wallet, electrum client and SQLite connection, which serialize
+        // internally — so overlapping them doesn't corrupt anything, it starves
+        // the scan behind a light sync that re-fires every 30s until the scan's
+        // watchdog gives up. BackgroundSync has no idea a scan is in flight, so
+        // the check has to live here.
+        guard !self.bdkWalletIsScanning else {
+            Log.info("Skipping light sync — a BDK full scan is in progress.")
+            return false
+        }
+
         guard let bdkWallet = self.bdkWallet,
               let electrumClient = self.electrumClient,
               let connection = self.connection else {

--- a/ios/bittr/BDKManager.swift
+++ b/ios/bittr/BDKManager.swift
@@ -86,15 +86,7 @@ extension BitcoinManager {
     func didSyncBdkWallet(completion originalCompletion: @escaping (Bool) -> Void) {
         Log.info("Will sync BDK wallet.")
         self.bdkWalletIsScanning = true
-
-        // Fire the caller's completion exactly once and clear the scanning flag.
-        // A hung electrum makes the blocking fullScan below wait forever (BDK's
-        // client has no timeout), which would otherwise leave every caller on a
-        // spinner indefinitely. The watchdog fails after `timeout` so callers
-        // recover. It races the scan, and the scan can't be cancelled once
-        // started, so guard against a late second callback; the guard runs on
-        // main, so it's race-free.
-        //
+        
         // NOTE: `timeout` must stay comfortably above a legitimately slow scan
         // (the fullScan below is documented as "seconds to minutes"), or slow
         // syncs get reported as failures. Tune before shipping.
@@ -104,7 +96,6 @@ extension BitcoinManager {
             DispatchQueue.main.async {
                 guard !didComplete else { return }
                 didComplete = true
-                self.bdkWalletIsScanning = false
                 originalCompletion(success)
             }
         }
@@ -248,6 +239,7 @@ extension BitcoinManager {
             try bdkWallet.applyUpdate(update: update)
         } catch {
             self.handleError(error: error, row: 594)
+            return false
         }
         
         // Persist update to wallet.

--- a/ios/bittr/BitcoinManager.swift
+++ b/ios/bittr/BitcoinManager.swift
@@ -28,6 +28,9 @@ class BitcoinManager {
     var connection: BitcoinDevKit.Connection?
     var bdkWalletIsScanning = false
     var bdkWalletHasBeenScanned = false
+    // Set when the full scan's watchdog fires. The scan can't be cancelled, so
+    // this session stays scan-blocked and only a restart clears it.
+    var bdkFullScanTimedOut = false
     
     // General
     private let storageManager = LightningStorage()

--- a/ios/bittr/Core/StartLightning.swift
+++ b/ios/bittr/Core/StartLightning.swift
@@ -192,6 +192,12 @@ extension CoreViewController {
         BitcoinManager.shared.didSyncBdkWallet { hasBeenSynced in
             guard hasBeenSynced else {
                 Log.info("Could not scan BDK wallet.")
+                // A timed-out scan blocks Send and Swap for the rest of the
+                // session. On this path nobody else is listening — the user is
+                // on the home screen — so say so rather than failing silently.
+                if BitcoinManager.shared.bdkFullScanTimedOut {
+                    self.showAlert(presentingController: self, title: Language.getWord(withID: "onchainsyncfailedtitle"), message: Language.getWord(withID: "onchainsynctimedout"), buttons: [Language.getWord(withID: "okay")], actions: nil)
+                }
                 return
             }
             Log.info("Did scan BDK wallet.")

--- a/ios/bittr/Language.swift
+++ b/ios/bittr/Language.swift
@@ -503,6 +503,7 @@ class Language: NSObject {
             "awaitingbdksync": "To send a regular transaction, please wait a moment while we sync your wallet.",
             "onchainsyncfailedtitle": "Syncing issue",
             "onchainsyncfailed": "We ran into an issue syncing the on-chain part of your wallet. Please try again later.",
+            "onchainsynctimedout": "Syncing the on-chain part of your wallet is taking longer than expected. Your wallet and funds are safe.\n\nPlease reopen the app to try again. Do not delete the app from your phone.",
             "transferfee": "Transfer fee",
             "bittrfee": "Bittr fee",
             "surcharge": "Surcharge",


### PR DESCRIPTION
didSyncBdkWallet: the 180s watchdog cleared bdkWalletIsScanning while the un-cancellable fullScan kept running, so a second scan could start against the same non-thread-safe wallet/SQLite and corrupt it. Clear the latch only when the real scan closure finishes; the watchdog now only unblocks the caller's completion.

lightSyncBdkWallet: a failed applyUpdate fell through to `return true`, reporting a failed sync as success and feeding stale coins into swap fee/coin selection. Return false in the catch, as didSyncBdkWallet does.