### PR TITLE
Guard ConfirmSendVC confirm button against double-tapping

### DIFF
--- a/ios/bittr/Move, Send, Receive/SendVC/Confirm/ConfirmSendViewController.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/Confirm/ConfirmSendViewController.swift
@@ -282,6 +282,7 @@ class ConfirmSendViewController: UIViewController {
     }
     
     @IBAction func confirmButtonTapped(_ sender: UIButton) {
+        if self.confirmSpinner.isAnimating { return }
         guard self.checkInternetConnection() else { return }
         
         if self.sendVC!.onchainOrLightning == .onchain {

--- a/ios/bittr/Move, Send, Receive/SendVC/SendOnchain.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/SendOnchain.swift
@@ -178,6 +178,14 @@ extension ConfirmSendViewController {
     }
     
     @objc func performOnchainTransaction() {
+        // An on-chain send reaches the broadcast from the confirmation alert's
+        // Confirm button, not from confirmButtonTapped — which shows that alert
+        // and returns without ever starting the spinner. So the guard on the
+        // button can't catch this; it has to sit here, where the spinner goes up.
+        // sendOnchainPayment below blocks main, so a second tap queues behind it
+        // and gets delivered once the broadcast is already under way.
+        if self.confirmSpinner.isAnimating { return }
+
         self.hideAlert()
         
         // Start spinner.

--- a/ios/bittr/Notifications/HandlePaymentNotification.swift
+++ b/ios/bittr/Notifications/HandlePaymentNotification.swift
@@ -395,9 +395,17 @@ extension CoreViewController {
                     let receiveVC = (self.homeVC!.presentedViewController as? ReceiveViewController ?? self.homeVC!.moveVC?.presentedViewController as? ReceiveViewController)
                     let swapVC = self.swapVC
                     
-                    // Update views.
+                    // Update views. The confirm spinner has to be stopped here
+                    // too, the way addNewPaymentToTable does on success: a
+                    // payment LDK accepts and then fails asynchronously
+                    // (routeNotFound, retriesExhausted, recipientRejected)
+                    // leaves the user on the confirm screen, and the spinner
+                    // now gates the Confirm button — so leaving it running
+                    // would strand them with no way to retry.
                     sendVC?.nextLabel.alpha = 1
                     sendVC?.nextSpinner.stopAnimating()
+                    sendVC?.confirmSendVC?.confirmLabel.alpha = 1
+                    sendVC?.confirmSendVC?.confirmSpinner.stopAnimating()
                     sendVC?.resetFields()
                     
                     // Parse failure reason.


### PR DESCRIPTION
In the **ConfirmSendVC**, confirmButtonTapped started the send spinner without blocking further taps, so a rapid double-tap fired two sendPayment/broadcast calls. 

LDK dedups BOLT11 by payment hash, but BOLT12/zero-amount and on-chain sends are timing-dependent. 

Return early while confirmSpinner is animating, mirroring SwapViewController.nextTapped; the spinner is cleared on every success/failure/retry path, so it doubles as the in-flight latch.