### PR TITLE
Refactor performSwapMatching into a dedicated, type-safe file

### DIFF
--- a/ios/bittr.xcodeproj/project.pbxproj
+++ b/ios/bittr.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		053C37542FD28E8E00A510DF /* BittrArticles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053C37532FD28E8800A510DF /* BittrArticles.swift */; };
 		054D42DF2F7B739E00599720 /* AnimationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054D42DE2F7B739800599720 /* AnimationViewController.swift */; };
 		05512F26300F80AF00E75272 /* WalletCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05512F25300F80AC00E75272 /* WalletCache.swift */; };
+		05512F28300F957C00E75272 /* SwapMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05512F27300F957900E75272 /* SwapMatching.swift */; };
 		0554035D2CB7EA04006F27CA /* LNURLDecoder in Frameworks */ = {isa = PBXBuildFile; productRef = 0554035C2CB7EA04006F27CA /* LNURLDecoder */; };
 		0554035F2CB82B2E006F27CA /* ReceiveVCLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0554035E2CB82B28006F27CA /* ReceiveVCLanguage.swift */; };
 		055403692CC14FC5006F27CA /* SendLNURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055403682CC14FC0006F27CA /* SendLNURL.swift */; };
@@ -281,6 +282,7 @@
 		053C37532FD28E8800A510DF /* BittrArticles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BittrArticles.swift; sourceTree = "<group>"; };
 		054D42DE2F7B739800599720 /* AnimationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationViewController.swift; sourceTree = "<group>"; };
 		05512F25300F80AC00E75272 /* WalletCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletCache.swift; sourceTree = "<group>"; };
+		05512F27300F957900E75272 /* SwapMatching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapMatching.swift; sourceTree = "<group>"; };
 		0554035E2CB82B28006F27CA /* ReceiveVCLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveVCLanguage.swift; sourceTree = "<group>"; };
 		055403682CC14FC0006F27CA /* SendLNURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendLNURL.swift; sourceTree = "<group>"; };
 		05546CF42F2A337600512129 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
@@ -682,6 +684,7 @@
 				05F8DC5629EEBFA1008052B5 /* HistoryTableViewCell.swift */,
 				05A8BD872B750F82002F0282 /* ShowCachedData.swift */,
 				05A8BD892B750FAF002F0282 /* LoadWalletData.swift */,
+				05512F27300F957900E75272 /* SwapMatching.swift */,
 				05A8BD8B2B7513B7002F0282 /* FetchAndPrint.swift */,
 				052171272CB416E7006C5663 /* HomeVCLanguage.swift */,
 				058B2FDF2EEA9ECC0010693D /* BottomCurveView.swift */,
@@ -1238,6 +1241,7 @@
 				051016602F9F4CF100D3F631 /* PlaceCategories.swift in Sources */,
 				05512F26300F80AF00E75272 /* WalletCache.swift in Sources */,
 				051015522F973F9E00D3F631 /* MapViewController.swift in Sources */,
+				05512F28300F957C00E75272 /* SwapMatching.swift in Sources */,
 				057F746E2E696DD600E5CCB3 /* SwapVCLanguage.swift in Sources */,
 				053022002E7803BC00B23226 /* SendVCTextFields.swift in Sources */,
 				05117ADA2EA732FC00A5E4E6 /* Page.swift in Sources */,

--- a/ios/bittr/Cache/CacheManager.swift
+++ b/ios/bittr/Cache/CacheManager.swift
@@ -424,7 +424,7 @@ class CacheManager: NSObject {
         return allTransactions
     }
     
-    static func storeLightningTransaction(thisTransaction:Transaction) {
+    static func storeLightningTransaction(_ thisTransaction:Transaction) {
         
         let envKey = EnvironmentConfig.cacheKey(for: "lightning")
         

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -94,7 +94,7 @@ extension HomeViewController {
                 
                 // Cache succeeded Lightning payments.
                 if thisTransaction.isLightning, eachPayment.status == .succeeded {
-                    CacheManager.storeLightningTransaction(thisTransaction: thisTransaction)
+                    CacheManager.storeLightningTransaction(thisTransaction)
                 }
             }
             
@@ -215,7 +215,7 @@ extension HomeViewController {
                 // This is a channel funding transaction.
                 let thisTransaction = eachTransaction.createTransaction(coreVC: self.coreVC, isFundingTransaction: true)
                 self.newTransactions += [thisTransaction]
-                CacheManager.storeLightningTransaction(thisTransaction: thisTransaction)
+                CacheManager.storeLightningTransaction(thisTransaction)
             }
         }
         
@@ -596,181 +596,5 @@ extension PaymentKind {
         default:
             return false
         }
-    }
-}
-
-extension [Transaction] {
-    
-    func performSwapMatching() -> [Transaction] {
-        
-        // Create a mutable array of Transactions.
-        var currentTransactions = self
-        
-        // Look for lightning and onchain transactions with matching swap descriptions
-        let swapTransactions = NSMutableDictionary()
-        
-        for eachTransaction in currentTransactions where eachTransaction.lnDescription.contains("Swap") {
-            if var existingTransactions = swapTransactions[eachTransaction.lnDescription] as? [Transaction] {
-                existingTransactions += [eachTransaction]
-                swapTransactions.setValue(existingTransactions, forKey: eachTransaction.lnDescription)
-            } else {
-                swapTransactions.setValue([eachTransaction], forKey: eachTransaction.lnDescription)
-            }
-        }
-        
-        // Process completed swaps
-        for (eachSwapID, eachSetOfTransactions) in swapTransactions {
-            if (eachSetOfTransactions as! [Transaction]).count == 2 {
-                // Completed swap.
-                Log.info("Found completed swap.")
-                print("Swap ID: \(eachSwapID)")
-                
-                let thisSwapID = (eachSwapID as! String)
-                let firstTransaction = (eachSetOfTransactions as! [Transaction])[0]
-                let secondTransaction = (eachSetOfTransactions as! [Transaction])[1]
-                
-                if thisSwapID.contains(firstTransaction.id), firstTransaction.swapStatus == .succeeded {
-                    // This is already a completed Swap transaction.
-                    for (index, eachTransaction) in currentTransactions.enumerated().reversed() where secondTransaction.id == eachTransaction.id {
-                        currentTransactions.remove(at: index)
-                    }
-                    CacheManager.storeLightningTransaction(thisTransaction: firstTransaction)
-                } else if thisSwapID.contains(secondTransaction.id), secondTransaction.swapStatus == .succeeded {
-                    // This is already a completed Swap transaction.
-                    for (index, eachTransaction) in currentTransactions.enumerated().reversed() where firstTransaction.id == eachTransaction.id {
-                        currentTransactions.remove(at: index)
-                    }
-                    CacheManager.storeLightningTransaction(thisTransaction: secondTransaction)
-                } else {
-                    
-                    let swapTransaction = Transaction()
-                    swapTransaction.id = thisSwapID.replacingOccurrences(of: "Swap lightning to onchain ", with: "").replacingOccurrences(of: "Swap onchain to lightning ", with: "")
-                    swapTransaction.isSwap = true
-                    swapTransaction.boltzSwapId = CacheManager.getSwapID(dateID: thisSwapID) ?? "Unavailable"
-                    swapTransaction.lnDescription = thisSwapID
-                    
-                    // Amount and fees.
-                    swapTransaction.sent = firstTransaction.received + secondTransaction.received - firstTransaction.sent - secondTransaction.sent
-
-                    // Per-leg fees live on Transaction.fee (onchain network fee for
-                    // the onchain leg, lightning routing fee for an outbound
-                    // lightning leg). The home row renders cost as
-                    // (received - sent - fee), so without this the user-paid fee
-                    // on either side gets dropped from the displayed swap cost.
-                    // Inbound legs have fee = 0, so summing both is safe.
-                    swapTransaction.fee = firstTransaction.fee + secondTransaction.fee
-                    
-                    // Direction.
-                    swapTransaction.swapDirection = thisSwapID.contains("onchain to lightning") ? .onchainToLightning : .lightningToOnchain
-                    swapTransaction.isLightning = thisSwapID.contains("lightning to onchain")
-                    
-                    for eachTransaction in (eachSetOfTransactions as! [Transaction]) {
-                        if eachTransaction.isLightning {
-                            // Lightning payment
-                            if eachTransaction.isSwap {
-                                swapTransaction.lightningID = eachTransaction.lightningID
-                            } else {
-                                swapTransaction.lightningID = eachTransaction.id
-                            }
-                            swapTransaction.channelId = eachTransaction.channelId
-                            if swapTransaction.swapDirection == .onchainToLightning {
-                                swapTransaction.timestamp = eachTransaction.timestamp
-                                swapTransaction.received = eachTransaction.received
-                            } else {
-                                swapTransaction.sent = eachTransaction.sent
-                            }
-                        } else {
-                            // Onchain transaction
-                            if eachTransaction.isSwap {
-                                swapTransaction.onchainID = eachTransaction.onchainID
-                            } else {
-                                swapTransaction.onchainID = eachTransaction.id
-                            }
-                            swapTransaction.height = eachTransaction.height
-                            if swapTransaction.swapDirection == .lightningToOnchain {
-                                swapTransaction.timestamp = eachTransaction.timestamp
-                                swapTransaction.received = eachTransaction.received - eachTransaction.sent
-                            } else {
-                                swapTransaction.sent = eachTransaction.sent - eachTransaction.received
-                            }
-                        }
-                    }
-                    
-                    if !firstTransaction.isLightning, !secondTransaction.isLightning {
-                        // Both transactions are onchain. This is a failed normal swap.
-                        swapTransaction.timestamp = firstTransaction.timestamp
-                        swapTransaction.sent = firstTransaction.sent + secondTransaction.sent
-                        swapTransaction.received = firstTransaction.received + secondTransaction.received
-                        swapTransaction.swapStatus = .failed
-                        
-                        if (firstTransaction.received - firstTransaction.sent) < (secondTransaction.received - secondTransaction.sent) {
-                            // The 2nd transaction is the refund.
-                            swapTransaction.onchainID = firstTransaction.id
-                            swapTransaction.lightningID = secondTransaction.id
-                        } else {
-                            // The 1st transaction is the refund.
-                            swapTransaction.onchainID = secondTransaction.id
-                            swapTransaction.lightningID = firstTransaction.id
-                        }
-                    }
-                    
-                    // Remove the individual transactions and add the combined swap transaction
-                    let transactionIDs = [firstTransaction.id, secondTransaction.id]
-                    for (index, eachTransaction) in currentTransactions.enumerated().reversed() where transactionIDs.contains(eachTransaction.id) {
-                        currentTransactions.remove(at: index)
-                    }
-                    
-                    currentTransactions += [swapTransaction]
-                    CacheManager.storeLightningTransaction(thisTransaction: swapTransaction)
-                }
-                
-            } else if (eachSetOfTransactions as! [Transaction]).count == 1, !(eachSetOfTransactions as! [Transaction])[0].isSwap {
-                // These are pending swap transactions.
-                Log.info("Found pending swap.")
-                print("Swap ID: \(eachSwapID)")
-                
-                let thisTransaction = (eachSetOfTransactions as! [Transaction])[0]
-                let thisSwapID = (eachSwapID as! String)
-                
-                if let suggestedSwapStatus = CacheManager.getSuggestedSwapStatus(dateID: thisSwapID) {
-                    thisTransaction.isSuggestedSwap = true
-                    thisTransaction.swapStatus = suggestedSwapStatus
-                    thisTransaction.swapDirection = thisSwapID.contains("onchain to lightning") ? .onchainToLightning : .lightningToOnchain
-                    thisTransaction.boltzSwapId = CacheManager.getSwapID(dateID: thisSwapID) ?? "Unavailable"
-                    continue
-                }
-                
-                let swapTransaction = Transaction()
-                swapTransaction.isSwap = true
-                swapTransaction.swapStatus = .pending
-                swapTransaction.boltzSwapId = CacheManager.getSwapID(dateID: thisSwapID) ?? "Unavailable"
-                swapTransaction.lnDescription = thisSwapID
-                
-                swapTransaction.timestamp = thisTransaction.timestamp
-                swapTransaction.sent = thisTransaction.sent
-                swapTransaction.received = thisTransaction.received
-                swapTransaction.isLightning = thisTransaction.isLightning
-                swapTransaction.id = thisSwapID.replacingOccurrences(of: "Swap lightning to onchain ", with: "").replacingOccurrences(of: "Swap onchain to lightning ", with: "")
-                
-                swapTransaction.swapDirection = thisSwapID.contains("onchain to lightning") ? .onchainToLightning : .lightningToOnchain
-                
-                if swapTransaction.isLightning {
-                    swapTransaction.lightningID = thisTransaction.id
-                    swapTransaction.channelId = thisTransaction.channelId
-                } else {
-                    swapTransaction.onchainID = thisTransaction.id
-                    swapTransaction.height = thisTransaction.height
-                }
-                
-                // Remove the individual transactions and add the combined swap transaction
-                for (index, eachTransaction) in currentTransactions.enumerated().reversed() where eachTransaction.id == thisTransaction.id {
-                    currentTransactions.remove(at: index)
-                }
-                
-                currentTransactions += [swapTransaction]
-            }
-        }
-        
-        return currentTransactions
     }
 }

--- a/ios/bittr/Home/SwapMatching.swift
+++ b/ios/bittr/Home/SwapMatching.swift
@@ -5,7 +5,7 @@
 //  Created by Tom Melters on 7/21/26.
 //
 
-import UIKit
+import Foundation
 
 extension [Transaction] {
     
@@ -22,19 +22,18 @@ extension [Transaction] {
         
         for (swapID, pairedTransactions) in swapGroups {
             if pairedTransactions.count == 2 {
-                handleCompletedSwap(swapID: swapID, first: pairedTransactions[0], second: pairedTransactions[1], in: &currentTransactions)
+                Self.handleCompletedSwap(swapID: swapID, first: pairedTransactions[0], second: pairedTransactions[1], in: &currentTransactions)
             } else if pairedTransactions.count == 1, !pairedTransactions[0].isSwap {
-                handlePendingSwap(swapID: swapID, leg: pairedTransactions[0], in: &currentTransactions)
+                Self.handlePendingSwap(swapID: swapID, leg: pairedTransactions[0], in: &currentTransactions)
             }
         }
         
         return currentTransactions
     }
     
-    private func handleCompletedSwap(swapID: String, first: Transaction, second: Transaction, in currentTransactions: inout [Transaction]) {
-        Log.info("Found completed swap.")
-        print("Swap ID: \(swapID)")
-        
+    private static func handleCompletedSwap(swapID: String, first: Transaction, second: Transaction, in currentTransactions: inout [Transaction]) {
+        Log.info("Found completed swap. Swap ID: \(swapID)")
+
         if swapID.contains(first.id), first.swapStatus == .succeeded {
             // `first` is already the completed swap transaction; drop the other leg.
             currentTransactions.removeAll { $0.id == second.id }
@@ -48,7 +47,7 @@ extension [Transaction] {
             return
         }
         
-        let swapTransaction = makeCompletedSwapTransaction(swapID: swapID, first: first, second: second)
+        let swapTransaction = Self.makeCompletedSwapTransaction(swapID: swapID, first: first, second: second)
         
         // Replace the two individual legs with the combined swap transaction.
         let legIDs = [first.id, second.id]
@@ -57,7 +56,7 @@ extension [Transaction] {
         CacheManager.storeLightningTransaction(swapTransaction)
     }
     
-    private func makeCompletedSwapTransaction(swapID: String, first: Transaction, second: Transaction) -> Transaction {
+    private static func makeCompletedSwapTransaction(swapID: String, first: Transaction, second: Transaction) -> Transaction {
         
         let swapTransaction = Transaction()
         swapTransaction.id = swapID.replacingOccurrences(of: "Swap lightning to onchain ", with: "").replacingOccurrences(of: "Swap onchain to lightning ", with: "")
@@ -67,6 +66,12 @@ extension [Transaction] {
         
         // Amount and fees.
         swapTransaction.sent = first.received + second.received - first.sent - second.sent
+
+        // Per-leg fees live on Transaction.fee (onchain network fee for the
+        // onchain leg, lightning routing fee for an outbound lightning leg).
+        // The home row renders cost as (received - sent - fee), so without this
+        // the user-paid fee on either side gets dropped from the displayed swap
+        // cost. Inbound legs have fee = 0, so summing both is safe.
         swapTransaction.fee = first.fee + second.fee
         
         // Direction.
@@ -118,10 +123,9 @@ extension [Transaction] {
         return swapTransaction
     }
     
-    private func handlePendingSwap(swapID: String, leg: Transaction, in currentTransactions: inout [Transaction]) {
-        Log.info("Found pending swap.")
-        print("Swap ID: \(swapID)")
-        
+    private static func handlePendingSwap(swapID: String, leg: Transaction, in currentTransactions: inout [Transaction]) {
+        Log.info("Found pending swap. Swap ID: \(swapID)")
+
         if let suggestedSwapStatus = CacheManager.getSuggestedSwapStatus(dateID: swapID) {
             leg.isSuggestedSwap = true
             leg.swapStatus = suggestedSwapStatus

--- a/ios/bittr/Home/SwapMatching.swift
+++ b/ios/bittr/Home/SwapMatching.swift
@@ -1,0 +1,159 @@
+//
+//  SwapMatching.swift
+//  bittr
+//
+//  Created by Tom Melters on 7/21/26.
+//
+
+import UIKit
+
+extension [Transaction] {
+    
+    func performSwapMatching() -> [Transaction] {
+        
+        // Gather all transactions.
+        var currentTransactions = self
+        
+        // Create pairs of swap transactions.
+        var swapGroups: [String: [Transaction]] = [:]
+        for eachTransaction in currentTransactions where eachTransaction.lnDescription.contains("Swap") {
+            swapGroups[eachTransaction.lnDescription, default: []].append(eachTransaction)
+        }
+        
+        for (swapID, pairedTransactions) in swapGroups {
+            if pairedTransactions.count == 2 {
+                handleCompletedSwap(swapID: swapID, first: pairedTransactions[0], second: pairedTransactions[1], in: &currentTransactions)
+            } else if pairedTransactions.count == 1, !pairedTransactions[0].isSwap {
+                handlePendingSwap(swapID: swapID, leg: pairedTransactions[0], in: &currentTransactions)
+            }
+        }
+        
+        return currentTransactions
+    }
+    
+    private func handleCompletedSwap(swapID: String, first: Transaction, second: Transaction, in currentTransactions: inout [Transaction]) {
+        Log.info("Found completed swap.")
+        print("Swap ID: \(swapID)")
+        
+        if swapID.contains(first.id), first.swapStatus == .succeeded {
+            // `first` is already the completed swap transaction; drop the other leg.
+            currentTransactions.removeAll { $0.id == second.id }
+            CacheManager.storeLightningTransaction(first)
+            return
+        }
+        if swapID.contains(second.id), second.swapStatus == .succeeded {
+            // `second` is already the completed swap transaction; drop the other leg.
+            currentTransactions.removeAll { $0.id == first.id }
+            CacheManager.storeLightningTransaction(second)
+            return
+        }
+        
+        let swapTransaction = makeCompletedSwapTransaction(swapID: swapID, first: first, second: second)
+        
+        // Replace the two individual legs with the combined swap transaction.
+        let legIDs = [first.id, second.id]
+        currentTransactions.removeAll { legIDs.contains($0.id) }
+        currentTransactions.append(swapTransaction)
+        CacheManager.storeLightningTransaction(swapTransaction)
+    }
+    
+    private func makeCompletedSwapTransaction(swapID: String, first: Transaction, second: Transaction) -> Transaction {
+        
+        let swapTransaction = Transaction()
+        swapTransaction.id = swapID.replacingOccurrences(of: "Swap lightning to onchain ", with: "").replacingOccurrences(of: "Swap onchain to lightning ", with: "")
+        swapTransaction.isSwap = true
+        swapTransaction.boltzSwapId = CacheManager.getSwapID(dateID: swapID) ?? "Unavailable"
+        swapTransaction.lnDescription = swapID
+        
+        // Amount and fees.
+        swapTransaction.sent = first.received + second.received - first.sent - second.sent
+        swapTransaction.fee = first.fee + second.fee
+        
+        // Direction.
+        swapTransaction.swapDirection = swapID.contains("onchain to lightning") ? .onchainToLightning : .lightningToOnchain
+        swapTransaction.isLightning = swapID.contains("lightning to onchain")
+        
+        for leg in [first, second] {
+            if leg.isLightning {
+                // Lightning payment
+                swapTransaction.lightningID = leg.isSwap ? leg.lightningID : leg.id
+                swapTransaction.channelId = leg.channelId
+                if swapTransaction.swapDirection == .onchainToLightning {
+                    swapTransaction.timestamp = leg.timestamp
+                    swapTransaction.received = leg.received
+                } else {
+                    swapTransaction.sent = leg.sent
+                }
+            } else {
+                // Onchain transaction
+                swapTransaction.onchainID = leg.isSwap ? leg.onchainID : leg.id
+                swapTransaction.height = leg.height
+                if swapTransaction.swapDirection == .lightningToOnchain {
+                    swapTransaction.timestamp = leg.timestamp
+                    swapTransaction.received = leg.received - leg.sent
+                } else {
+                    swapTransaction.sent = leg.sent - leg.received
+                }
+            }
+        }
+        
+        if !first.isLightning, !second.isLightning {
+            // Both transactions are onchain. This is a failed normal swap.
+            swapTransaction.timestamp = first.timestamp
+            swapTransaction.sent = first.sent + second.sent
+            swapTransaction.received = first.received + second.received
+            swapTransaction.swapStatus = .failed
+            
+            if (first.received - first.sent) < (second.received - second.sent) {
+                // The 2nd transaction is the refund.
+                swapTransaction.onchainID = first.id
+                swapTransaction.lightningID = second.id
+            } else {
+                // The 1st transaction is the refund.
+                swapTransaction.onchainID = second.id
+                swapTransaction.lightningID = first.id
+            }
+        }
+        
+        return swapTransaction
+    }
+    
+    private func handlePendingSwap(swapID: String, leg: Transaction, in currentTransactions: inout [Transaction]) {
+        Log.info("Found pending swap.")
+        print("Swap ID: \(swapID)")
+        
+        if let suggestedSwapStatus = CacheManager.getSuggestedSwapStatus(dateID: swapID) {
+            leg.isSuggestedSwap = true
+            leg.swapStatus = suggestedSwapStatus
+            leg.swapDirection = swapID.contains("onchain to lightning") ? .onchainToLightning : .lightningToOnchain
+            leg.boltzSwapId = CacheManager.getSwapID(dateID: swapID) ?? "Unavailable"
+            return
+        }
+        
+        let swapTransaction = Transaction()
+        swapTransaction.isSwap = true
+        swapTransaction.swapStatus = .pending
+        swapTransaction.boltzSwapId = CacheManager.getSwapID(dateID: swapID) ?? "Unavailable"
+        swapTransaction.lnDescription = swapID
+        
+        swapTransaction.timestamp = leg.timestamp
+        swapTransaction.sent = leg.sent
+        swapTransaction.received = leg.received
+        swapTransaction.isLightning = leg.isLightning
+        swapTransaction.id = swapID.replacingOccurrences(of: "Swap lightning to onchain ", with: "").replacingOccurrences(of: "Swap onchain to lightning ", with: "")
+        
+        swapTransaction.swapDirection = swapID.contains("onchain to lightning") ? .onchainToLightning : .lightningToOnchain
+        
+        if swapTransaction.isLightning {
+            swapTransaction.lightningID = leg.id
+            swapTransaction.channelId = leg.channelId
+        } else {
+            swapTransaction.onchainID = leg.id
+            swapTransaction.height = leg.height
+        }
+        
+        // Replace the individual leg with the combined swap transaction.
+        currentTransactions.removeAll { $0.id == leg.id }
+        currentTransactions.append(swapTransaction)
+    }
+}

--- a/ios/bittr/Move, Send, Receive/SendVC/SendLightning.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/SendLightning.swift
@@ -385,7 +385,7 @@ extension UIViewController {
         
         // Create transaction.
         let newTransaction = thisPayment.createTransaction(coreVC: coreVC, bittrTransactions: nil)
-        CacheManager.storeLightningTransaction(thisTransaction: newTransaction)
+        CacheManager.storeLightningTransaction(newTransaction)
         
         // Add invoice to Transactions table.
         sendVC?.completedTransaction = newTransaction

--- a/ios/bittr/Notifications/HandlePaymentNotification.swift
+++ b/ios/bittr/Notifications/HandlePaymentNotification.swift
@@ -383,7 +383,7 @@ extension CoreViewController {
                                 self.homeVC!.tappedTransaction = newTransaction
                                 self.homeVC!.performSegue(withIdentifier: "HomeToTransaction", sender: self)
                             }
-                            CacheManager.storeLightningTransaction(thisTransaction: newTransaction)
+                            CacheManager.storeLightningTransaction(newTransaction)
                         }
                     }
                 }
@@ -462,7 +462,7 @@ extension CoreViewController {
         DispatchQueue.main.async {
             // Add and cache transaction.
             self.homeVC?.addLightningTransaction(thisTransaction: thisTransaction, paymentDetails: paymentDetails)
-            CacheManager.storeLightningTransaction(thisTransaction: thisTransaction)
+            CacheManager.storeLightningTransaction(thisTransaction)
             
             // Launch TransactionVC after ReceiveVC has dismissed.
             let presentTransactionVC = { [weak self] in


### PR DESCRIPTION
Move performSwapMatching out of LoadWalletData into SwapMatching.swift and rewrite it off a typed [String: [Transaction]] instead of an NSMutableDictionary with ~10 force-casts. 

The 172-line method becomes a small orchestrator plus handleCompletedSwap / makeCompletedSwapTransaction / handlePendingSwap helpers; grouping order, reference-mutation of suggested swaps, and the combined-swap accounting are all preserved.

Also drop the redundant argument label on storeLightningTransaction (storeLightningTransaction(_:)) and update its call sites.