### PR TITLE
Refactor maximum sendable onchain satoshis in SendVC and SwapVC

### DIFF
--- a/ios/bittr/BDKManager.swift
+++ b/ios/bittr/BDKManager.swift
@@ -9,6 +9,12 @@ import Foundation
 import BitcoinDevKit
 import Sentry
 
+struct OnchainDrainPreview {
+    let sendableSats:UInt64
+    let feeSats:UInt64
+    let vsize:UInt64
+}
+
 extension BitcoinManager {
     
     func didStartBDK() -> Bool {
@@ -271,12 +277,74 @@ extension BitcoinManager {
         return true
     }
     
-    func getSize(address:String, amountSats:Int) throws -> UInt64 {
+    func getSize(address:String, amountSats:Int, selectedVbyte:Float?) throws -> UInt64 {
         
-        let tx = try self.getTx(address: address, amountSats: amountSats, selectedVbyte: nil)
+        let tx = try self.getTx(address: address, amountSats: amountSats, selectedVbyte: selectedVbyte)
         let size = tx.vsize()
         
         return size
+    }
+    
+    // MARK: - Onchain maximum
+    
+    // Get a placeholder output script to calculate fees before knowing the recipient.
+    static var largestCommonOutputScript: Script {
+        Script(rawOutputScript: [0x51, 0x20] + [UInt8](repeating: 0, count: 32))
+    }
+    
+    // Get maximum sendable onchain transaction.
+    func previewOnchainDrain(toScript script:Script, satPerVb:UInt64) throws -> OnchainDrainPreview {
+        guard let wallet = self.bdkWallet else {
+            throw WalletError.walletNotInitiated
+        }
+        
+        // Minimum 1 sat/vB.
+        let feeRate = try FeeRate.fromSatPerVb(satVb: max(satPerVb, 1))
+        
+        let psbt = try TxBuilder()
+            .drainWallet()
+            .drainTo(script: script)
+            .feeRate(feeRate: feeRate)
+            .finish(wallet: wallet)
+        let _ = try wallet.sign(psbt: psbt, signOptions: nil)
+        let tx = try psbt.extractTx()
+        
+        // drainTo produces exactly one output, so its value is the maximum.
+        guard let drainOutput = tx.output().first else {
+            throw WalletError.walletNotInitiated
+        }
+        
+        return OnchainDrainPreview(sendableSats: drainOutput.value, feeSats: try psbt.fee(), vsize: tx.vsize())
+    }
+    
+    // Calculate the maximum sendable onchain amount, with or without known recipient.
+    func maximumSendableOnchainDrain(toAddress address:String?, satPerVb:UInt64) throws -> OnchainDrainPreview {
+
+        let script:Script
+        if let address = address,
+           let parsed = try? Address(address: address, network: EnvironmentConfig.bitcoinDevKitNetwork) {
+            // Recipient is known.
+            script = parsed.scriptPubkey()
+        } else {
+            // Recipient is unknown.
+            script = BitcoinManager.largestCommonOutputScript
+        }
+        
+        let preview = try self.previewOnchainDrain(toScript: script, satPerVb: satPerVb)
+        
+        // Verify that LDKNode agrees with BDK's maximum sendable onchain amount.
+        let spendable = UInt64(max(BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable, 0))
+        guard spendable > 0, preview.sendableSats + preview.feeSats > spendable else {
+            // LDKNode's maximum sendable onchain amount is lower than BDK's.
+            // Therefore, stick with LDKNode as the source of truth.
+            return preview
+        }
+        let clamped = spendable > preview.feeSats ? spendable - preview.feeSats : 0
+        return OnchainDrainPreview(sendableSats: clamped, feeSats: preview.feeSats, vsize: preview.vsize)
+    }
+    
+    func maximumSendableOnchainSats(toAddress address:String?, satPerVb:UInt64) throws -> UInt64 {
+        return try self.maximumSendableOnchainDrain(toAddress: address, satPerVb: satPerVb).sendableSats
     }
     
     func getTx(address:String, amountSats:Int, selectedVbyte:Float?) throws -> BitcoinDevKit.Transaction {
@@ -297,8 +365,9 @@ extension BitcoinManager {
         let address = try Address(address: address, network: network)
         let script = address.scriptPubkey()
         var txBuilder = TxBuilder().addRecipient(script: script, amount: BitcoinDevKit.Amount.fromSat(satoshi: UInt64(amountSats)))
-        if selectedVbyte != nil {
-            txBuilder = txBuilder.feeRate(feeRate: try FeeRate.fromSatPerVb(satVb: UInt64(selectedVbyte!)))
+        if let selectedVbyte = selectedVbyte {
+            // Minimum 1 sat/Vbyte.
+            txBuilder = txBuilder.feeRate(feeRate: try FeeRate.fromSatPerVb(satVb: max(UInt64(selectedVbyte), 1)))
         }
         let details = try txBuilder.finish(wallet: self.bdkWallet!)
         let _ = try self.bdkWallet!.sign(psbt: details, signOptions: nil)

--- a/ios/bittr/BDKManager.swift
+++ b/ios/bittr/BDKManager.swift
@@ -311,7 +311,7 @@ extension BitcoinManager {
         
         // drainTo produces exactly one output, so its value is the maximum.
         guard let drainOutput = tx.output().first else {
-            throw WalletError.walletNotInitiated
+            throw WalletError.drainProducedNoOutput
         }
         
         return OnchainDrainPreview(sendableSats: drainOutput.value, feeSats: try psbt.fee(), vsize: tx.vsize())
@@ -333,10 +333,20 @@ extension BitcoinManager {
         let preview = try self.previewOnchainDrain(toScript: script, satPerVb: satPerVb)
         
         // Verify that LDKNode agrees with BDK's maximum sendable onchain amount.
-        let spendable = UInt64(max(BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable, 0))
-        guard spendable > 0, preview.sendableSats + preview.feeSats > spendable else {
-            // LDKNode's maximum sendable onchain amount is lower than BDK's.
-            // Therefore, stick with LDKNode as the source of truth.
+        // BDK knows nothing about the reserve LDK Node holds back for anchor
+        // channels, so it will happily drain it; LDK's spendable balance is the
+        // authority on what may actually leave.
+        guard let loadedSpendable = BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable else {
+            // Balances haven't been read yet, so there's nothing to clamp
+            // against. Note this is NOT the same as a spendable balance of zero,
+            // which clamps to zero below.
+            return preview
+        }
+
+        let spendable = UInt64(max(loadedSpendable, 0))
+        guard preview.sendableSats + preview.feeSats > spendable else {
+            // BDK is already at or under LDKNode's spendable balance, so it's
+            // the more conservative of the two. Stick with it.
             return preview
         }
         let clamped = spendable > preview.feeSats ? spendable - preview.feeSats : 0

--- a/ios/bittr/BitcoinManager.swift
+++ b/ios/bittr/BitcoinManager.swift
@@ -600,14 +600,29 @@ class BitcoinManager {
         }
     }
     
+    // The user intends to send an onchain transaction, not emptying their funds.
     func sendOnchainPayment(address:String, amountSats:UInt64, feeRateSatVb:UInt64) throws -> String {
+        guard let node = self.ldkNode else { throw WalletError.walletNotInitiated }
         
-        // Set fee rate.
-        let feeRate = LDKNode.FeeRate.fromSatPerVbUnchecked(satVb: feeRateSatVb)
+        // Set fee rate (minimum 1sat/Vbyte).
+        let feeRate = LDKNode.FeeRate.fromSatPerVbUnchecked(satVb: max(feeRateSatVb, 1))
         
         // Broadcast transaction.
-        guard let node = self.ldkNode else { throw WalletError.walletNotInitiated }
         let onchainID = try node.onchainPayment().sendToAddress(address: address, amountSats: amountSats, feeRate: feeRate)
+        
+        // Return transaction ID.
+        return onchainID.description
+    }
+    
+    // The user intends to empty their onchain funds.
+    func sendAllOnchainPayment(address:String, feeRateSatVb:UInt64) throws -> String {
+        guard let node = self.ldkNode else { throw WalletError.walletNotInitiated }
+        
+        // Set fee rate (minimum 1sat/Vbyte).
+        let feeRate = LDKNode.FeeRate.fromSatPerVbUnchecked(satVb: max(feeRateSatVb, 1))
+        
+        // Broadcast transaction.
+        let onchainID = try node.onchainPayment().sendAllToAddress(address: address, retainReserve: true, feeRate: feeRate)
         
         // Return transaction ID.
         return onchainID.description

--- a/ios/bittr/BitcoinManager.swift
+++ b/ios/bittr/BitcoinManager.swift
@@ -765,6 +765,8 @@ struct FeeEstimates {
 enum WalletError: Error {
     case walletNotInitiated
     case clientNotInitiated
+    /// A drain PSBT finished but carried no output, so there is no maximum to read.
+    case drainProducedNoOutput
 }
 
 extension FileManager {

--- a/ios/bittr/Helpers/BittrWallet.swift
+++ b/ios/bittr/Helpers/BittrWallet.swift
@@ -13,7 +13,10 @@ class BittrWallet: NSObject {
     // Balance
     var satoshisLightning:Int = 0
     var satoshisOnchain:Int = 0
-    var satoshisOnchainSpendable:Int = 0
+    // nil until loadWalletData has read it from LDK Node. Kept optional so
+    // "not loaded yet" stays distinguishable from "genuinely nothing spendable"
+    // — the two need opposite handling when clamping a drain.
+    var satoshisOnchainSpendable:Int?
     
     // Channels
     var lightningChannels = [ChannelDetails]()

--- a/ios/bittr/Helpers/BittrWallet.swift
+++ b/ios/bittr/Helpers/BittrWallet.swift
@@ -13,6 +13,7 @@ class BittrWallet: NSObject {
     // Balance
     var satoshisLightning:Int = 0
     var satoshisOnchain:Int = 0
+    var satoshisOnchainSpendable:Int = 0
     
     // Channels
     var lightningChannels = [ChannelDetails]()

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -38,7 +38,9 @@ extension HomeViewController {
         let allTransactions = BitcoinManager.shared.listPayments()
         
         // Get onchain balance.
-        let satoshisOnchain = Int(node.listBalances().totalOnchainBalanceSats)
+        let balances = node.listBalances()
+        let satoshisOnchain = Int(balances.totalOnchainBalanceSats)
+        let satoshisOnchainSpendable = Int(balances.spendableOnchainBalanceSats)
         
         // Apply the snapshot to the shared wallet on the main thread.
         let apply = {
@@ -46,6 +48,7 @@ extension HomeViewController {
             BitcoinManager.shared.bittrWallet.lightningChannels = lightningChannels
             BitcoinManager.shared.bittrWallet.allTransactions = allTransactions
             BitcoinManager.shared.bittrWallet.satoshisOnchain = satoshisOnchain
+            BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable = satoshisOnchainSpendable
 
             Task {
                 // Check whether transactions were Bittr purchases.

--- a/ios/bittr/Home/ReloadWallet.swift
+++ b/ios/bittr/Home/ReloadWallet.swift
@@ -48,7 +48,7 @@ extension HomeViewController {
         self.calculatedInvestments = 0
         self.calculatedCurrentValue = 0
         BitcoinManager.shared.bittrWallet.satoshisOnchain = 0
-        BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable = 0
+        BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable = nil
         BitcoinManager.shared.bittrWallet.satoshisLightning = 0
         
         self.noTransactionsLabel.alpha = 0

--- a/ios/bittr/Home/ReloadWallet.swift
+++ b/ios/bittr/Home/ReloadWallet.swift
@@ -48,6 +48,7 @@ extension HomeViewController {
         self.calculatedInvestments = 0
         self.calculatedCurrentValue = 0
         BitcoinManager.shared.bittrWallet.satoshisOnchain = 0
+        BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable = 0
         BitcoinManager.shared.bittrWallet.satoshisLightning = 0
         
         self.noTransactionsLabel.alpha = 0

--- a/ios/bittr/Move, Send, Receive/SendVC/Confirm/ConfirmSendViewController.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/Confirm/ConfirmSendViewController.swift
@@ -143,11 +143,12 @@ class ConfirmSendViewController: UIViewController {
             
             // Check fee availability
             let lowestSats:Float = self.sendVC!.feePerVbLow*self.sendVC!.confirmTxSize
-            let availableSatsForFee:Float = Float(BitcoinManager.shared.bittrWallet.satoshisOnchain - self.sendVC!.confirmSatoshis)
+            let availableSatsForFee:Float = Float(BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable - self.sendVC!.confirmSatoshis)
             if lowestSats > availableSatsForFee {
                 // There aren't enough sats available to pay for the cheapest fee.
+                // Calculate the cheapest possible fee (minimum 1sat/Vbyte).
                 let availableSatsPerVb:Float = availableSatsForFee / self.sendVC!.confirmTxSize
-                self.maxAvailableFeePerVb = Float(Int(availableSatsPerVb * 10))/10
+                self.maxAvailableFeePerVb = max(Float(Int(availableSatsPerVb * 10))/10, 1)
                 
                 self.timeSlow.text = Language.getWord(withID: "slow")
                 self.highlightFee(.low)
@@ -248,8 +249,14 @@ class ConfirmSendViewController: UIViewController {
     
     func canAffordFees() -> Bool {
         
-        if (self.selectedFeeInSats + self.sendVC!.confirmSatoshis) > BitcoinManager.shared.bittrWallet.satoshisOnchain {
-            self.showAlert(presentingController: self, title: Language.getWord(withID: "balance2"), message: Language.getWord(withID: "insufficientonchainbalance").replacingOccurrences(of: "<fee>", with: "\(BitcoinManager.shared.bittrWallet.satoshisOnchain) sats"), buttons: [Language.getWord(withID: "updateamount"), Language.getWord(withID: "close")], actions: [#selector(self.handleAmountChange), nil])
+        if self.sendVC!.isSendingMaximum {
+            // A balance draining transaction will manage to afford the appropriate fee.
+            return true
+        }
+        
+        let spendable = BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable
+        if (self.selectedFeeInSats + self.sendVC!.confirmSatoshis) > spendable {
+            self.showAlert(presentingController: self, title: Language.getWord(withID: "balance2"), message: Language.getWord(withID: "insufficientonchainbalance").replacingOccurrences(of: "<fee>", with: "\(spendable) sats"), buttons: [Language.getWord(withID: "updateamount"), Language.getWord(withID: "close")], actions: [#selector(self.handleAmountChange), nil])
             return false
         } else {
             return true
@@ -266,8 +273,8 @@ class ConfirmSendViewController: UIViewController {
     @objc func handleAmountChange() {
         self.hideAlert()
         
-        // New amount.
-        self.sendVC!.confirmSatoshis = BitcoinManager.shared.bittrWallet.satoshisOnchain-self.selectedFeeInSats
+        // New amount (at least 0 satoshis).
+        self.sendVC!.confirmSatoshis = max(BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable - self.selectedFeeInSats, 0)
         
         // Update SendVC amount text field.
         self.sendVC!.amountTextField.text = self.sendVC!.confirmSatoshis.inBTC().formattedBitcoin()

--- a/ios/bittr/Move, Send, Receive/SendVC/Confirm/ConfirmSendViewController.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/Confirm/ConfirmSendViewController.swift
@@ -143,7 +143,7 @@ class ConfirmSendViewController: UIViewController {
             
             // Check fee availability
             let lowestSats:Float = self.sendVC!.feePerVbLow*self.sendVC!.confirmTxSize
-            let availableSatsForFee:Float = Float(BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable - self.sendVC!.confirmSatoshis)
+            let availableSatsForFee:Float = Float((BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable ?? 0) - self.sendVC!.confirmSatoshis)
             if lowestSats > availableSatsForFee {
                 // There aren't enough sats available to pay for the cheapest fee.
                 // Calculate the cheapest possible fee (minimum 1sat/Vbyte).
@@ -223,6 +223,15 @@ class ConfirmSendViewController: UIViewController {
             self.selectedFeeInSats = Int(self.sendVC!.confirmTxSize * (self.maxAvailableFeePerVb ?? self.sendVC!.feePerVbLow))
         }
         
+        // A drain sends whatever is left after the fee, so its amount moves with
+        // the selected rate. Restate it, otherwise picking a higher fee leaves
+        // the screen quoting the amount from the rate it was calculated at.
+        if self.sendVC!.isSendingMaximum, let drainTotal = self.sendVC!.drainTotalSats {
+            self.sendVC!.confirmSatoshis = max(drainTotal - self.selectedFeeInSats, 0)
+            self.amountLabel.text = self.sendVC!.confirmSatoshis.inBTC().formattedBitcoin() + " BTC"
+            self.amountFiatLabel.text = self.formattedFiatAmount()
+        }
+
         self.selectedFee = tappedFee
         self.highlightFee(tappedFee)
         guard self.canAffordFees() else { return }
@@ -254,7 +263,7 @@ class ConfirmSendViewController: UIViewController {
             return true
         }
         
-        let spendable = BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable
+        let spendable = BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable ?? 0
         if (self.selectedFeeInSats + self.sendVC!.confirmSatoshis) > spendable {
             self.showAlert(presentingController: self, title: Language.getWord(withID: "balance2"), message: Language.getWord(withID: "insufficientonchainbalance").replacingOccurrences(of: "<fee>", with: "\(spendable) sats"), buttons: [Language.getWord(withID: "updateamount"), Language.getWord(withID: "close")], actions: [#selector(self.handleAmountChange), nil])
             return false
@@ -274,7 +283,7 @@ class ConfirmSendViewController: UIViewController {
         self.hideAlert()
         
         // New amount (at least 0 satoshis).
-        self.sendVC!.confirmSatoshis = max(BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable - self.selectedFeeInSats, 0)
+        self.sendVC!.confirmSatoshis = max((BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable ?? 0) - self.selectedFeeInSats, 0)
         
         // Update SendVC amount text field.
         self.sendVC!.amountTextField.text = self.sendVC!.confirmSatoshis.inBTC().formattedBitcoin()

--- a/ios/bittr/Move, Send, Receive/SendVC/Send/SendSwitch.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/Send/SendSwitch.swift
@@ -12,6 +12,8 @@ extension SendViewController {
     func resetFields() {
         self.toTextField.text = nil
         self.amountTextField.text = nil
+        self.didTapAvailable = false
+        self.isSendingMaximum = false
     }
     
     func updateLabels() {

--- a/ios/bittr/Move, Send, Receive/SendVC/Send/SendVCTextFields.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/Send/SendVCTextFields.swift
@@ -10,6 +10,12 @@ import LightningDevKit
 
 extension SendViewController {
     
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        // Reset didTapAvailable boolean upon manual changes.
+        if textField == self.amountTextField { self.didTapAvailable = false }
+        return true
+    }
+    
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         // Same logic as doneButtonTapped for return key
         if textField == self.toTextField {

--- a/ios/bittr/Move, Send, Receive/SendVC/Send/SendViewController.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/Send/SendViewController.swift
@@ -81,6 +81,9 @@ class SendViewController: UIViewController, UITextFieldDelegate, OnchainSyncFail
     var maximumSendableOnchainSats:Int?
     var didTapAvailable = false // User has tapped the maximum available onchain amount.
     var isSendingMaximum = false // User intends to empty their onchain funds.
+    // Drain amount + its fee, so the confirm screen can restate the amount when
+    // the user switches fee rate — a drain is whatever is left after the fee.
+    var drainTotalSats:Int?
     var completedTransaction:Transaction?
     var onchainAmountInSatoshis:Int = 0
     var bitcoinQR = ""
@@ -185,21 +188,31 @@ class SendViewController: UIViewController, UITextFieldDelegate, OnchainSyncFail
                 self.bdkWalletUnavailable()
             } else {
                 Log.info("BDK wallet is available.")
-                self.bdkSpinner.stopAnimating()
-                
+
                 // Ensure current fee rates have been fetched.
                 guard self.feePerVbMedium > 0 else {
                     self.bdkSpinner.startAnimating()
                     Task { await self.fetchFeeEstimatesThenSetSendAllLabel() }
                     return
                 }
-                
-                // Calculate maximum sendable onchain amount.
+
+                // Calculate maximum sendable onchain amount off the main thread:
+                // this builds and signs a drain PSBT, which is real crypto work
+                // and grows with the number of UTXOs. Keep the spinner up until
+                // there's a number to show.
                 // Minimum 0 satoshis. Minimum 1 sat/Vbyte.
-                self.maximumSendableOnchainSats = self.getMaximumSendableSats(satPerVb: UInt64(max(self.feePerVbMedium, 1)))
-                    ?? max(BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable, 0)
-                
-                self.availableAmount.text = Language.getWord(withID:"youcansend").replacingOccurrences(of: "<amount>", with: "\(self.maximumSendableOnchainSats!)".addSpaces())
+                self.bdkSpinner.startAnimating()
+                let satPerVb = UInt64(max(self.feePerVbMedium, 1))
+                DispatchQueue.global(qos: .userInitiated).async {
+                    let sendable = self.getMaximumSendableSats(satPerVb: satPerVb)
+                        ?? max(BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable ?? 0, 0)
+
+                    DispatchQueue.main.async {
+                        self.bdkSpinner.stopAnimating()
+                        self.maximumSendableOnchainSats = sendable
+                        self.availableAmount.text = Language.getWord(withID:"youcansend").replacingOccurrences(of: "<amount>", with: "\(sendable)".addSpaces())
+                    }
+                }
             }
         } else {
             // Set "Send all" for lightning payments.
@@ -219,7 +232,7 @@ class SendViewController: UIViewController, UITextFieldDelegate, OnchainSyncFail
             
             guard let feeEstimates = feeEstimates else {
                 Log.info("Could not fetch recommended fees; quoting the spendable balance instead.")
-                let spendable = max(BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable, 0)
+                let spendable = max(BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable ?? 0, 0)
                 self.availableAmount.text = Language.getWord(withID:"youcansend").replacingOccurrences(of: "<amount>", with: "\(spendable)".addSpaces())
                 return
             }
@@ -369,7 +382,7 @@ class SendViewController: UIViewController, UITextFieldDelegate, OnchainSyncFail
         
         if self.onchainOrLightning == .onchain {
             // Regular - use satoshis for onchain too
-            let sendableInSatoshis:Int = self.maximumSendableOnchainSats ?? max(BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable, 0)
+            let sendableInSatoshis:Int = self.maximumSendableOnchainSats ?? max(BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable ?? 0, 0)
             self.amountTextField.text = "\(sendableInSatoshis)"
             self.btcLabel.text = "Sats"
             self.selectedCurrency = .satoshis

--- a/ios/bittr/Move, Send, Receive/SendVC/Send/SendViewController.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/Send/SendViewController.swift
@@ -78,7 +78,9 @@ class SendViewController: UIViewController, UITextFieldDelegate, OnchainSyncFail
     
     // Variables
     var coreVC:CoreViewController?
-    var maximumSendableOnchainBtc:Double?
+    var maximumSendableOnchainSats:Int?
+    var didTapAvailable = false // User has tapped the maximum available onchain amount.
+    var isSendingMaximum = false // User intends to empty their onchain funds.
     var completedTransaction:Transaction?
     var onchainAmountInSatoshis:Int = 0
     var bitcoinQR = ""
@@ -185,17 +187,51 @@ class SendViewController: UIViewController, UITextFieldDelegate, OnchainSyncFail
                 Log.info("BDK wallet is available.")
                 self.bdkSpinner.stopAnimating()
                 
-                if self.maximumSendableOnchainBtc == nil {
-                    self.maximumSendableOnchainBtc = self.getMaximumSendableSats() ?? BitcoinManager.shared.bittrWallet.satoshisOnchain.inBTC()
+                // Ensure current fee rates have been fetched.
+                guard self.feePerVbMedium > 0 else {
+                    self.bdkSpinner.startAnimating()
+                    Task { await self.fetchFeeEstimatesThenSetSendAllLabel() }
+                    return
                 }
-                let sendableInSatoshis:Int = CGFloat(self.maximumSendableOnchainBtc!).inSatoshis()
-                self.availableAmount.text = Language.getWord(withID:"youcansend").replacingOccurrences(of: "<amount>", with: "\(sendableInSatoshis)".addSpaces())
+                
+                // Calculate maximum sendable onchain amount.
+                // Minimum 0 satoshis. Minimum 1 sat/Vbyte.
+                self.maximumSendableOnchainSats = self.getMaximumSendableSats(satPerVb: UInt64(max(self.feePerVbMedium, 1)))
+                    ?? max(BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable, 0)
+                
+                self.availableAmount.text = Language.getWord(withID:"youcansend").replacingOccurrences(of: "<amount>", with: "\(self.maximumSendableOnchainSats!)".addSpaces())
             }
         } else {
             // Set "Send all" for lightning payments.
             self.bdkSpinner.stopAnimating()
             let lightningSats = (BitcoinManager.shared.bittrWallet.lightningChannels.getActiveChannel()?.outboundCapacityMsat ?? 0)/1000
             self.availableAmount.text = Language.getWord(withID:"youcansend").replacingOccurrences(of: "<amount>", with: "\(lightningSats)".addSpaces())
+        }
+    }
+    
+    func fetchFeeEstimatesThenSetSendAllLabel() async {
+        Log.info("Will download fee estimates.")
+        
+        let feeEstimates = await BitcoinManager.shared.getFeeEstimates()
+        
+        await MainActor.run {
+            self.bdkSpinner.stopAnimating()
+            
+            guard let feeEstimates = feeEstimates,
+                  let economyFee = feeEstimates["economyFee"] as? Double,
+                  let hourFee = feeEstimates["hourFee"] as? Double,
+                  let fastestFee = feeEstimates["fastestFee"] as? Double else {
+                Log.info("Could not fetch recommended fees; quoting the spendable balance instead.")
+                let spendable = max(BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable, 0)
+                self.availableAmount.text = Language.getWord(withID:"youcansend").replacingOccurrences(of: "<amount>", with: "\(spendable)".addSpaces())
+                return
+            }
+            
+            self.feePerVbLow = Float(economyFee)
+            self.feePerVbMedium = Float(hourFee)
+            self.feePerVbHigh = Float(fastestFee)
+            
+            self.setSendAllLabel()
         }
     }
     
@@ -336,10 +372,11 @@ class SendViewController: UIViewController, UITextFieldDelegate, OnchainSyncFail
         
         if self.onchainOrLightning == .onchain {
             // Regular - use satoshis for onchain too
-            let sendableInSatoshis:Int = CGFloat(self.maximumSendableOnchainBtc ?? BitcoinManager.shared.bittrWallet.satoshisOnchain.inBTC()).inSatoshis()
+            let sendableInSatoshis:Int = self.maximumSendableOnchainSats ?? max(BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable, 0)
             self.amountTextField.text = "\(sendableInSatoshis)"
             self.btcLabel.text = "Sats"
             self.selectedCurrency = .satoshis
+            self.didTapAvailable = true
         } else {
             // Instant
             let sendableInSatoshis:Int = Int((BitcoinManager.shared.bittrWallet.lightningChannels.getActiveChannel()?.outboundCapacityMsat ?? 0)/1000)

--- a/ios/bittr/Move, Send, Receive/SendVC/Send/SendViewController.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/Send/SendViewController.swift
@@ -217,19 +217,16 @@ class SendViewController: UIViewController, UITextFieldDelegate, OnchainSyncFail
         await MainActor.run {
             self.bdkSpinner.stopAnimating()
             
-            guard let feeEstimates = feeEstimates,
-                  let economyFee = feeEstimates["economyFee"] as? Double,
-                  let hourFee = feeEstimates["hourFee"] as? Double,
-                  let fastestFee = feeEstimates["fastestFee"] as? Double else {
+            guard let feeEstimates = feeEstimates else {
                 Log.info("Could not fetch recommended fees; quoting the spendable balance instead.")
                 let spendable = max(BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable, 0)
                 self.availableAmount.text = Language.getWord(withID:"youcansend").replacingOccurrences(of: "<amount>", with: "\(spendable)".addSpaces())
                 return
             }
-            
-            self.feePerVbLow = Float(economyFee)
-            self.feePerVbMedium = Float(hourFee)
-            self.feePerVbHigh = Float(fastestFee)
+
+            self.feePerVbLow = Float(feeEstimates.economy)
+            self.feePerVbMedium = Float(feeEstimates.hour)
+            self.feePerVbHigh = Float(feeEstimates.fastest)
             
             self.setSendAllLabel()
         }

--- a/ios/bittr/Move, Send, Receive/SendVC/SendOnchain.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/SendOnchain.swift
@@ -47,8 +47,14 @@ extension SendViewController {
         }
         self.onchainAmountInSatoshis = (enteredAmount/divideBy).inSatoshis()
         
+        // Check whether user intends to empty their onchain funds.
+        if let quotedMaximum = self.maximumSendableOnchainSats, self.onchainAmountInSatoshis == quotedMaximum {
+            // The entered amount matches the maximum sendable onchain funds.
+            self.didTapAvailable = true
+        }
+        
         // Check balance.
-        guard self.onchainAmountInSatoshis <= BitcoinManager.shared.bittrWallet.satoshisOnchain else {
+        guard self.onchainAmountInSatoshis <= BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable else {
             Log.info("Insufficient onchain balance.")
             Log.info("Check if we have sufficient Lightning balance for a swap.")
             
@@ -99,10 +105,26 @@ extension SendViewController {
             self.feePerVbMedium = Float(feeEstimates.hour)
             self.feePerVbHigh = Float(feeEstimates.fastest)
             
+            // Check the maximum sendable onchain amount.
+            let drain = try? BitcoinManager.shared.maximumSendableOnchainDrain(toAddress: enteredAddress, satPerVb: UInt64(max(self.feePerVbMedium, 1)))
+            
+            // Check whether the user intends to empty their onchain funds.
+            if self.didTapAvailable, let drain = drain {
+                self.onchainAmountInSatoshis = Int(drain.sendableSats)
+                self.confirmSatoshis = Int(drain.sendableSats)
+                self.isSendingMaximum = true
+            } else {
+                self.isSendingMaximum = drain != nil && self.onchainAmountInSatoshis >= Int(drain!.sendableSats)
+            }
+            
             // Get transaction size.
             let size:UInt64
             do {
-                size = try BitcoinManager.shared.getSize(address: enteredAddress, amountSats: self.onchainAmountInSatoshis)
+                if self.isSendingMaximum, let drain = drain {
+                    size = drain.vsize
+                } else {
+                    size = try BitcoinManager.shared.getSize(address: enteredAddress, amountSats: self.onchainAmountInSatoshis, selectedVbyte: self.feePerVbMedium)
+                }
             } catch {
                 Log.info("Error: \(error.localizedDescription)")
                 
@@ -192,18 +214,23 @@ extension ConfirmSendViewController {
         self.confirmLabel.alpha = 0
         self.confirmSpinner.startAnimating()
         
-        // Get fees.
+        // Get fees (minimum 1 sat/Vbyte).
         var selectedVbyte:Float
         switch self.selectedFee {
         case .medium: selectedVbyte = self.sendVC!.feePerVbMedium
         case .high: selectedVbyte = self.sendVC!.feePerVbHigh
         default: selectedVbyte = self.maxAvailableFeePerVb ?? self.sendVC!.feePerVbLow
         }
+        let feeRateSatVb = max(UInt64(selectedVbyte), 1)
         
         // Broadcast transaction.
         let txid:String
         do {
-            txid = try BitcoinManager.shared.sendOnchainPayment(address: self.sendVC!.confirmAddress, amountSats: UInt64(self.sendVC!.confirmSatoshis), feeRateSatVb: UInt64(selectedVbyte))
+            if self.sendVC!.isSendingMaximum {
+                txid = try BitcoinManager.shared.sendAllOnchainPayment(address: self.sendVC!.confirmAddress, feeRateSatVb: feeRateSatVb)
+            } else {
+                txid = try BitcoinManager.shared.sendOnchainPayment(address: self.sendVC!.confirmAddress, amountSats: UInt64(self.sendVC!.confirmSatoshis), feeRateSatVb: feeRateSatVb)
+            }
         } catch {
             Log.info("Transaction error: \(error.localizedDescription)")
 
@@ -263,48 +290,27 @@ extension ConfirmSendViewController {
 
 extension UIViewController {
     
-    func getMaximumSendableSats() -> Double? {
+    func getMaximumSendableSats(toAddress:String? = nil, satPerVb:UInt64) -> Int? {
         
         do {
-            let actualAddress = BitcoinManager.shared.getAddress(atIndex: 0)
-            
-            // Create PSBT, which will throw an error.
-            _ = try BitcoinManager.shared.getPsbt(address: actualAddress, amountSats: BitcoinManager.shared.bittrWallet.satoshisOnchain, selectedVbyte: nil)
-            return nil
+            let sendable = try BitcoinManager.shared.maximumSendableOnchainSats(toAddress: toAddress, satPerVb: satPerVb)
+            return Int(sendable)
         } catch {
+            Log.info("Could not compute maximum sendable amount: \(error.localizedDescription)")
+            
             if let bdkError = error as? BitcoinDevKit.CreateTxError {
                 switch bdkError {
-                case .InsufficientFunds(needed: let needed, available: _):
-                    let btcOnchain = BitcoinManager.shared.bittrWallet.satoshisOnchain.inBTC()
-                    let neededAmount:Double = Int(needed).inBTC()
-                    let minimumFees:Double = neededAmount - btcOnchain
-                    let spendableBtcAmount = btcOnchain - minimumFees
-                    if spendableBtcAmount < 0 {
-                        return 0
-                    } else {
-                        return spendableBtcAmount
+                case .CoinSelection, .InsufficientFunds:
+                    if BitcoinManager.shared.bittrWallet.satoshisOnchain > 0 {
+                        Log.info("BDK looks stale (LDK Node onchain balance: \(BitcoinManager.shared.bittrWallet.satoshisOnchain), BDK rejected the drain).")
                     }
-                case .CoinSelection(errorMessage: let errorMessage):
-                    if errorMessage.contains("Insufficient funds") {
-                        let btcOnchain = BitcoinManager.shared.bittrWallet.satoshisOnchain.inBTC()
-                        let neededAmount:Double = String(error.localizedDescription.split(separator: " ")[7]).toNumber()
-                        let minimumFees:Double = neededAmount - btcOnchain
-                        let spendableBtcAmount = btcOnchain - minimumFees
-                        if spendableBtcAmount < 0 {
-                            return 0
-                        } else if spendableBtcAmount > btcOnchain {
-                            return nil
-                        } else {
-                            return spendableBtcAmount
-                        }
-                    } else {
-                        return nil
+                default:
+                    SentrySDK.capture(error: error) { scope in
+                        scope.setExtra(value: "getMaximumSendableSats", key: "context")
                     }
-                default: return nil
                 }
-            } else {
-                return nil
             }
+            return nil
         }
     }
     

--- a/ios/bittr/Move, Send, Receive/SendVC/SendOnchain.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/SendOnchain.swift
@@ -54,7 +54,7 @@ extension SendViewController {
         }
         
         // Check balance.
-        guard self.onchainAmountInSatoshis <= BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable else {
+        guard self.onchainAmountInSatoshis <= (BitcoinManager.shared.bittrWallet.satoshisOnchainSpendable ?? 0) else {
             Log.info("Insufficient onchain balance.")
             Log.info("Check if we have sufficient Lightning balance for a swap.")
             
@@ -108,13 +108,23 @@ extension SendViewController {
             // Check the maximum sendable onchain amount.
             let drain = try? BitcoinManager.shared.maximumSendableOnchainDrain(toAddress: enteredAddress, satPerVb: UInt64(max(self.feePerVbMedium, 1)))
             
-            // Check whether the user intends to empty their onchain funds.
-            if self.didTapAvailable, let drain = drain {
+            // Check whether the user intends to empty their onchain funds —
+            // either by tapping the quoted maximum, or by typing an amount at or
+            // above it (the balance guard above only rejects amounts over the
+            // spendable balance, and the drain maximum sits a fee below that).
+            //
+            // Either way, restate the amount as the drain figure. sendAllToAddress
+            // ignores confirmSatoshis and sends whatever is left after the fee, so
+            // leaving the typed amount in place would let the confirmation screen
+            // promise a number the wallet never broadcasts.
+            if let drain = drain, self.didTapAvailable || self.onchainAmountInSatoshis >= Int(drain.sendableSats) {
                 self.onchainAmountInSatoshis = Int(drain.sendableSats)
                 self.confirmSatoshis = Int(drain.sendableSats)
+                self.drainTotalSats = Int(drain.sendableSats + drain.feeSats)
                 self.isSendingMaximum = true
             } else {
-                self.isSendingMaximum = drain != nil && self.onchainAmountInSatoshis >= Int(drain!.sendableSats)
+                self.drainTotalSats = nil
+                self.isSendingMaximum = false
             }
             
             // Get transaction size.
@@ -221,7 +231,9 @@ extension ConfirmSendViewController {
         case .high: selectedVbyte = self.sendVC!.feePerVbHigh
         default: selectedVbyte = self.maxAvailableFeePerVb ?? self.sendVC!.feePerVbLow
         }
-        let feeRateSatVb = max(UInt64(selectedVbyte), 1)
+        // Clamp before converting: UInt64(_:) traps on a negative or NaN Float,
+        // so max() has to run on the Float side to actually guard anything.
+        let feeRateSatVb = UInt64(max(selectedVbyte, 1))
         
         // Broadcast transaction.
         let txid:String

--- a/ios/bittr/Swaps/Swap Manager/SwapManager.swift
+++ b/ios/bittr/Swaps/Swap Manager/SwapManager.swift
@@ -236,7 +236,7 @@ class SwapManager: NSObject {
             var size:UInt64
             do {
                 // Calculate transaction size.
-                size = try BitcoinManager.shared.getSize(address: ongoingSwap.boltzOnchainAddress!, amountSats: ongoingSwap.boltzExpectedAmount!)
+                size = try BitcoinManager.shared.getSize(address: ongoingSwap.boltzOnchainAddress!, amountSats: ongoingSwap.boltzExpectedAmount!, selectedVbyte: swapVC.highestFeePerVbyte)
             } catch {
                 Log.info("Error: \(error.localizedDescription)")
 

--- a/ios/bittr/Swaps/SwapVC/SendableAmount.swift
+++ b/ios/bittr/Swaps/SwapVC/SendableAmount.swift
@@ -82,11 +82,6 @@ extension SwapViewController {
                 // Calculate available channel space.
                 let availableChannelSpace:Int = Int(activeChannel!.channelValueSats) - Int(activeChannel!.outboundCapacityMsat/1000) - Int(activeChannel!.unspendablePunishmentReserve ?? 0) - Int(activeChannel!.counterpartyUnspendablePunishmentReserve)
                 
-                // Calculate available onchain satoshis minus fast fee.
-                // Calculate maximum sendable onchain amount at lowest fee.
-                let maximumSendableOnchainBtc = self.getMaximumSendableSats() ?? BitcoinManager.shared.bittrWallet.satoshisOnchain.inBTC()
-                let maximumSendableOnchainSats = CGFloat(maximumSendableOnchainBtc).inSatoshis()
-                
                 self.availableAmountLabel.text = Language.getWord(withID: "satsatatime").replacingOccurrences(of: "<amount>", with: "0")
                 self.bdkSpinner.startAnimating()
                 
@@ -107,13 +102,14 @@ extension SwapViewController {
                     // Select highest fee.
                     self.highestFeePerVbyte = Float(feeEstimates.fastest)
                     
-                    // Get own onchain address.
-                    let actualAddress:String = BitcoinManager.shared.getAddress(atIndex: 0)
-                    
-                    var sizeinVbytes:UInt64
+                    // Calculate maximum sendable onchain satoshis.
+                    let sendableSatoshis:Int
                     do {
-                        // Calculate transaction size.
-                        sizeinVbytes = try BitcoinManager.shared.getSize(address: actualAddress, amountSats: maximumSendableOnchainSats)
+                        let preview = try BitcoinManager.shared.previewOnchainDrain(
+                            toScript: BitcoinManager.largestCommonOutputScript,
+                            satPerVb: UInt64(max(self.highestFeePerVbyte!, 1))
+                        )
+                        sendableSatoshis = Int(preview.sendableSats)
                     } catch {
                         Log.info("Error: \(error.localizedDescription)")
 
@@ -153,12 +149,6 @@ extension SwapViewController {
                         }
                         return
                     }
-                    
-                    // Calculate highest fee in satoshis.
-                    let satoshisFee:Int = Int(self.highestFeePerVbyte! * Float(sizeinVbytes))
-                    
-                    // Onchain satoshis minus highest fee.
-                    let sendableSatoshis = BitcoinManager.shared.bittrWallet.satoshisOnchain - satoshisFee
                     
                     // Set label.
                     DispatchQueue.main.async {

--- a/ios/bittr/Swaps/SwapVC/SendableAmount.swift
+++ b/ios/bittr/Swaps/SwapVC/SendableAmount.swift
@@ -105,8 +105,14 @@ extension SwapViewController {
                     // Calculate maximum sendable onchain satoshis.
                     let sendableSatoshis:Int
                     do {
-                        let preview = try BitcoinManager.shared.previewOnchainDrain(
-                            toScript: BitcoinManager.largestCommonOutputScript,
+                        // Go through maximumSendableOnchainDrain rather than
+                        // previewOnchainDrain: BDK will happily drain the reserve
+                        // LDK Node holds back for anchor channels, and only the
+                        // former clamps against LDK's spendable balance. The
+                        // recipient isn't known yet, so this quotes against the
+                        // heaviest common output script.
+                        let preview = try BitcoinManager.shared.maximumSendableOnchainDrain(
+                            toAddress: nil,
                             satPerVb: UInt64(max(self.highestFeePerVbyte!, 1))
                         )
                         sendableSatoshis = Int(preview.sendableSats)


### PR DESCRIPTION
- In the **SendVC** and **SwapVC**, the estimation of **maximum sendable onchain funds** was clumsy and error-prone. This has been refactored.
- Maximum possible drain is now calculated using **BDK's built-in drainWallet() function**.
- For estimates where no address is yet known, estimations are done based on heaviest possible address.
- All calculations now guard for a **minimum amount of 0 satoshis**, and a **minimum fee of 1 sat/Vbyte**.
- Outcomes guard against LDKNode's own **listBalances().spendableOnchainBalanceSats** number.
- **Up-to-date fee rates** now get **downloaded immediately** upon opening SendVC or SwapVC (instead of after clicking Next).
- When the user intends to drain their onchain funds, we now broadcast the transaction using **LDKNode's built-in sendAllToAddress()** function. So the transaction won't fail, as the sendable amount is calculated by LDKNode automatically in combination with the fee rate that the user has selected.