### PR TITLE
Quote lightning-to-onchain swap fees as a range

### DIFF
--- a/ios/bittr/Extensions/String.swift
+++ b/ios/bittr/Extensions/String.swift
@@ -19,25 +19,31 @@ extension String {
     }
     
     func addSpaces() -> String {
-        
+
         var balanceValue = self
         if balanceValue.fixDecimals().contains(Locale.current.decimalSeparator!) {
             balanceValue = String(self.fixDecimals().split(separator: Locale.current.decimalSeparator!)[0])
         }
-        
+
+        // Group with a non-breaking space. A plain space is a legal line-break
+        // opportunity, so a wrapping label could split "1 213" into "1" and
+        // "213" on separate lines and read as two numbers. Output is display
+        // only — no call site parses it back — so the narrower space is safe.
+        let separator = "\u{00A0}"
+
         switch balanceValue.count {
         case 4:
-            balanceValue = balanceValue[0] + " " + balanceValue[1..<4]
+            balanceValue = balanceValue[0] + separator + balanceValue[1..<4]
         case 5:
-            balanceValue = balanceValue[0..<2] + " " + balanceValue[2..<5]
+            balanceValue = balanceValue[0..<2] + separator + balanceValue[2..<5]
         case 6:
-            balanceValue = balanceValue[0..<3] + " " + balanceValue[3..<6]
+            balanceValue = balanceValue[0..<3] + separator + balanceValue[3..<6]
         case 7:
-            balanceValue = balanceValue[0] + " " + balanceValue[1..<4] + " " + balanceValue[4..<7]
+            balanceValue = balanceValue[0] + separator + balanceValue[1..<4] + separator + balanceValue[4..<7]
         case 8:
-            balanceValue = balanceValue[0..<2] + " " + balanceValue[2..<5] + " " + balanceValue[5..<8]
+            balanceValue = balanceValue[0..<2] + separator + balanceValue[2..<5] + separator + balanceValue[5..<8]
         case 9:
-            balanceValue = balanceValue[0..<3] + " " + balanceValue[3..<6] + " " + balanceValue[6..<9]
+            balanceValue = balanceValue[0..<3] + separator + balanceValue[3..<6] + separator + balanceValue[6..<9]
         default:
             balanceValue = balanceValue[0..<balanceValue.count]
         }

--- a/ios/bittr/Language.swift
+++ b/ios/bittr/Language.swift
@@ -330,6 +330,7 @@ class Language: NSObject {
             "nodatareceived": "No data was received",
             "swapamountexceeded": "You can only move up to <amount> satoshis at a time. Please enter an amount within this limit.",
             "swapfunds3": "The expected fee to move <b><amount> satoshis</b> (<convertedamount>) is <b><feesamount> satoshis</b> (<convertedfees>).",
+            "swapfunds3range": "The expected fee to move <b><amount> satoshis</b> (<convertedamount>) is between <b><feesamountmin> and <feesamount> satoshis</b> (<convertedfees>).",
             "onchaintolightningexplanation": "\n\nIt may take around <b>10 minutes</b> to complete this swap. You may close the app in the meantime.\n\nIf the swap fails, some of the paid fees may not be refundable.",
             "wishtoproceed": "Do you wish to proceed?",
             "proceed": "Proceed",

--- a/ios/bittr/Swaps/Swap.swift
+++ b/ios/bittr/Swaps/Swap.swift
@@ -41,6 +41,42 @@ class Swap: NSObject {
     var boltzInvoice:String?
     var lockupTx:String?
     
+    
+    // MARK: - Fees
+    
+    var definiteFees:Int {
+        if self.swapDirection == .lightningToOnchain {
+            return (self.onchainFees ?? 0)
+        } else {
+            return (self.onchainFees ?? 0) + (self.lightningFees ?? 0) + (self.claimTransactionFee ?? 0)
+        }
+    }
+    
+    var maximumRoutingFee:Int {
+        guard self.swapDirection == .lightningToOnchain else { return 0 }
+        return self.lightningFees ?? 0
+    }
+    
+    var hasVariableFee:Bool {
+        return self.maximumRoutingFee > 0
+    }
+    
+    var minimumTotalFees:Int {
+        return self.definiteFees + (self.hasVariableFee ? 1 : 0)
+    }
+    
+    var maximumTotalFees:Int {
+        return self.definiteFees + self.maximumRoutingFee
+    }
+    
+    func formattedTotalFees() -> String {
+        guard self.hasVariableFee else { return "\(self.maximumTotalFees)".addSpaces() }
+        return "\(self.minimumTotalFees)".addSpaces() + " - " + "\(self.maximumTotalFees)".addSpaces()
+    }
+    
+    
+    // MARK: - Cache conversions
+    
     // Convert to NSDictionary.
     func toDictionary() -> NSDictionary {
         

--- a/ios/bittr/Swaps/Swap.swift
+++ b/ios/bittr/Swaps/Swap.swift
@@ -46,8 +46,14 @@ class Swap: NSObject {
     
     var definiteFees:Int {
         if self.swapDirection == .lightningToOnchain {
+            // The claim fee is deliberately absent: lightningToOnchain adds it to
+            // the amount requested from Boltz, so onchainFees — the invoice spread
+            // — already contains it. Adding it here would count it twice.
             return (self.onchainFees ?? 0)
         } else {
+            // claimTransactionFee is always nil on this side: in an onchain-to-
+            // lightning swap Boltz claims the locked funds, so the user never
+            // broadcasts a claim transaction. The term is kept for symmetry.
             return (self.onchainFees ?? 0) + (self.lightningFees ?? 0) + (self.claimTransactionFee ?? 0)
         }
     }
@@ -57,16 +63,25 @@ class Swap: NSObject {
         return self.lightningFees ?? 0
     }
     
-    var hasVariableFee:Bool {
+    /// A route has to be paid for, so the total isn't fully known up front.
+    private var hasRoutingFee:Bool {
         return self.maximumRoutingFee > 0
     }
     
     var minimumTotalFees:Int {
-        return self.definiteFees + (self.hasVariableFee ? 1 : 0)
+        // Assume a route costs at least 1 sat whenever one is needed.
+        return self.definiteFees + (self.hasRoutingFee ? 1 : 0)
     }
     
     var maximumTotalFees:Int {
         return self.definiteFees + self.maximumRoutingFee
+    }
+    
+    /// True only when the two ends of the range actually differ. A maximum routing
+    /// fee of exactly 1 sat leaves minimum equal to maximum, and quoting "between
+    /// X and X" reads as a bug rather than a range.
+    var hasVariableFee:Bool {
+        return self.minimumTotalFees < self.maximumTotalFees
     }
     
     func formattedTotalFees() -> String {

--- a/ios/bittr/Swaps/SwapStatusVC/SwapStatusViewController.swift
+++ b/ios/bittr/Swaps/SwapStatusVC/SwapStatusViewController.swift
@@ -106,9 +106,9 @@ class SwapStatusViewController: UIViewController {
         // Amount
         self.confirmAmountLabel.text = "\(self.thisSwap!.satoshisAmount)".addSpaces() + " sats"
         
-        // Fees
-        let totalFees = (self.thisSwap!.onchainFees ?? 0) + (self.thisSwap!.lightningFees ?? 0) + (self.thisSwap!.claimTransactionFee ?? 0)
-        self.confirmFeesLabel.text = "\(totalFees)".addSpaces() + " sats"
+        // Fees.
+        // Lightning-to-onchain fees contain a variable range for the invoice payment.
+        self.confirmFeesLabel.text = self.thisSwap!.formattedTotalFees() + " sats"
         
         // Status
         self.confirmStatusSpinner.startAnimating()

--- a/ios/bittr/Swaps/SwapVC/SwapViewController.swift
+++ b/ios/bittr/Swaps/SwapVC/SwapViewController.swift
@@ -229,17 +229,22 @@ class SwapViewController: UIViewController, UITextFieldDelegate, UNUserNotificat
         
         let bitcoinValue = BitcoinManager.shared.bittrWallet.getCorrectBitcoinValue()
         
-        // Calculate total fees including claim transaction fee for lightning-to-onchain swaps
-        // For lightning-to-onchain swaps, the claim transaction fee is included in the on-chain amount
-        // so the user receives exactly what they input
-        let totalFees = self.thisSwap!.onchainFees! + self.thisSwap!.lightningFees! + (self.thisSwap!.claimTransactionFee ?? 0)
+        // For a lightning-to-onchain swap the routing fee isn't known until the
+        // payment finds a route, so the total is a range and the message reads
+        // "between X and Y". Everything else — the claim transaction and Boltz's
+        // spread — is quoted up front.
+        let feesMinimum = "\(self.thisSwap!.minimumTotalFees)".addSpaces()
+        let feesAmount = "\(self.thisSwap!.maximumTotalFees)".addSpaces()
+        let messageID = self.thisSwap!.hasVariableFee ? "swapfunds3range" : "swapfunds3"
         
         // Fiat fee, rounded to two decimals and formatted with the device's
         // decimal separator (e.g. "0,50" in comma locales).
-        let convertedFees = (totalFees.inBTC() * bitcoinValue.currentValue).twoDecimals().toString()
+        let convertedMinimum = (self.thisSwap!.minimumTotalFees.inBTC() * bitcoinValue.currentValue).twoDecimals().toString()
+        let convertedMaximum = (self.thisSwap!.maximumTotalFees.inBTC() * bitcoinValue.currentValue).twoDecimals().toString()
+        let convertedFees = convertedMinimum == convertedMaximum ? convertedMaximum : "\(convertedMinimum) - \(convertedMaximum)"
         let convertedAmount = "\(Int((self.thisSwap!.satoshisAmount.inBTC()*bitcoinValue.currentValue).rounded()))"
         
-        let message = Language.getWord(withID: "swapfunds3").replacingOccurrences(of: "<feesamount>", with: "\(totalFees)".addSpaces()).replacingOccurrences(of: "<convertedfees>", with: "\(bitcoinValue.chosenCurrency) \(convertedFees)").replacingOccurrences(of: "<amount>", with: "\(self.thisSwap!.satoshisAmount)".addSpaces()).replacingOccurrences(of: "<convertedamount>", with: "\(bitcoinValue.chosenCurrency) \(convertedAmount)")
+        let message = Language.getWord(withID: messageID).replacingOccurrences(of: "<feesamountmin>", with: feesMinimum).replacingOccurrences(of: "<feesamount>", with: feesAmount).replacingOccurrences(of: "<convertedfees>", with: "\(bitcoinValue.chosenCurrency) \(convertedFees)").replacingOccurrences(of: "<amount>", with: "\(self.thisSwap!.satoshisAmount)".addSpaces()).replacingOccurrences(of: "<convertedamount>", with: "\(bitcoinValue.chosenCurrency) \(convertedAmount)")
         let doYouWishToProceed = Language.getWord(withID: "wishtoproceed")
         let cautionMessage:String
         if self.swapDirection == .onchainToLightning {
@@ -277,7 +282,7 @@ class SwapViewController: UIViewController, UITextFieldDelegate, UNUserNotificat
         
         // Update swap file.
         let direction = (self.thisSwap!.swapDirection == .lightningToOnchain) ? 1 : 0
-        SwapManager.updateSwapFileWithFees(swapID: self.thisSwap!.boltzID!, totalFees: (self.thisSwap!.onchainFees ?? 0) + (self.thisSwap!.lightningFees ?? 0) + (self.thisSwap!.claimTransactionFee ?? 0), userAmount: self.thisSwap!.satoshisAmount, direction: direction)
+        SwapManager.updateSwapFileWithFees(swapID: self.thisSwap!.boltzID!, totalFees: self.thisSwap!.maximumTotalFees, userAmount: self.thisSwap!.satoshisAmount, direction: direction)
         
         // Send payment.
         if self.thisSwap!.swapDirection == .onchainToLightning {


### PR DESCRIPTION
**Problem**
When performing a lightning-to-onchain swap, the quoted **expected fee** was usually much higher than the eventual **actual fee**. 
This is due to lightning routing fees turning out lower than the potential maximum.

**Solution**
Same as in ConfirmSendVC, **show expected fees as a range**.
For lightning-to-onchain swaps:
- the **alert** now says "The expected fee to move X satoshis (€ X) is between X and X satoshis (EUR X - X). Do you wish to proceed?" 
- the **SwapStatusVC** says "X - X satoshis".