### PR TITLE
Minor refactor to Swap file

### DIFF
--- a/ios/bittr/Cache/WalletCache.swift
+++ b/ios/bittr/Cache/WalletCache.swift
@@ -66,7 +66,6 @@ extension CacheManager {
             return WalletCache()
         }
         var cache = WalletCache()
-        cache.balance = legacy["balance"] as? String
         cache.satsBalance = legacy["satsbalance"] as? String
         cache.conversion = legacy["conversion"] as? String
         cache.eurValue = legacy["eurvalue"] as? CGFloat
@@ -88,7 +87,6 @@ extension CacheManager {
 }
 
 struct WalletCache: Codable {
-    var balance: String?
     var satsBalance: String?
     var conversion: String?
     var eurValue: CGFloat?

--- a/ios/bittr/Swaps/Swap Manager/SwapManager.swift
+++ b/ios/bittr/Swaps/Swap Manager/SwapManager.swift
@@ -510,7 +510,6 @@ class SwapManager: NSObject {
                             swapVC.thisSwap!.claimLeafOutput = claimLeafOutput
                             swapVC.thisSwap!.refundLeafOutput = refundLeafOutput
                             swapVC.thisSwap!.refundPublicKey = refundPublicKey
-                            swapVC.thisSwap!.sentLightningPaymentID = randomPreimage.hexEncodedString()
                             self.saveSwapDetailsToFile(swapID: swapID, swapDictionary: swapVC.thisSwap!.toDictionary())
                             
                             // Store transaction details in cache.
@@ -625,26 +624,6 @@ class SwapManager: NSObject {
         
         print("Updated swap file with lockup transaction for ID: \(swapID)")
             
-    }
-    
-    static func updateSwapFileWithFees(swapID: String, totalFees: Int, userAmount: Int, direction: Int) {
-        
-        // Load existing swap details
-        guard let existingSwapDetails = loadSwapDetailsFromFile(swapID: swapID) else {
-            print("Could not load existing swap details for ID: \(swapID)")
-            return
-        }
-        
-        // Create a mutable copy and add the fees information
-        let updatedSwapDetails = existingSwapDetails.mutableCopy() as! NSMutableDictionary
-        updatedSwapDetails.setValue(totalFees, forKey: "totalFees")
-        updatedSwapDetails.setValue(userAmount, forKey: "userAmount")
-        updatedSwapDetails.setValue(direction, forKey: "direction")
-        
-        // Save the updated swap details back to file
-        self.saveSwapDetailsToFile(swapID: swapID, swapDictionary: updatedSwapDetails)
-        
-        print("Updated swap file with fees for ID: \(swapID)")
     }
     
     static func addOnchainTransactionToUI(transactionId:String, swapVC:SwapStatusViewController) {

--- a/ios/bittr/Swaps/Swap.swift
+++ b/ios/bittr/Swaps/Swap.swift
@@ -93,69 +93,41 @@ class Swap: NSObject {
     // MARK: - Cache conversions
     
     // Convert to NSDictionary.
+    // setValue removes the key when handed nil, so optionals need no guarding.
     func toDictionary() -> NSDictionary {
-        
-        var onchainToLightning = true
-        if self.swapDirection == .lightningToOnchain { onchainToLightning = false }
-        let swapDictionary:NSMutableDictionary = ["dateID":self.dateID, "onchainToLightning":onchainToLightning, "satoshisAmount":self.satoshisAmount, "isSuggested":self.isSuggested]
-        if self.createdInvoice != nil {
-            swapDictionary.setValue(self.createdInvoice!, forKey: "createdInvoice")
-        }
-        if self.privateKey != nil {
-            swapDictionary.setValue(self.privateKey!, forKey: "privateKey")
-        }
-        if self.boltzID != nil {
-            swapDictionary.setValue(self.boltzID!, forKey: "boltzID")
-        }
-        if self.boltzOnchainAddress != nil {
-            swapDictionary.setValue(self.boltzOnchainAddress!, forKey: "boltzOnchainAddress")
-        }
-        if self.boltzExpectedAmount != nil {
-            swapDictionary.setValue(self.boltzExpectedAmount!, forKey: "boltzExpectedAmount")
-        }
-        if self.onchainFees != nil {
-            swapDictionary.setValue(self.onchainFees!, forKey: "onchainFees")
-        }
-        if self.lightningFees != nil {
-            swapDictionary.setValue(self.lightningFees!, forKey: "lightningFees")
-        }
-        if self.feeHigh != nil {
-            swapDictionary.setValue(self.feeHigh!, forKey: "feeHigh")
-        }
-        if self.claimTransactionFee != nil {
-            swapDictionary.setValue(self.claimTransactionFee!, forKey: "claimTransactionFee")
-        }
-        if self.sentOnchainTransactionID != nil {
-            swapDictionary.setValue(self.sentOnchainTransactionID!, forKey: "sentOnchainTransactionID")
-        }
-        if self.boltzOnchainAddress != nil {
-            swapDictionary.setValue(self.boltzOnchainAddress!, forKey: "boltzOnchainAddress")
-        }
-        if self.refundPublicKey != nil {
-            swapDictionary.setValue(self.refundPublicKey!, forKey: "refundPublicKey")
-        }
-        if self.claimLeafOutput != nil {
-            swapDictionary.setValue(self.claimLeafOutput!, forKey: "claimLeafOutput")
-        }
-        if self.refundLeafOutput != nil {
-            swapDictionary.setValue(self.refundLeafOutput!, forKey: "refundLeafOutput")
-        }
-        if self.claimPublicKey != nil {
-            swapDictionary.setValue(self.claimPublicKey!, forKey: "claimPublicKey")
-        }
-        if self.preimage != nil {
-            swapDictionary.setValue(self.preimage!, forKey: "preimage")
-        }
-        if self.destinationAddress != nil {
-            swapDictionary.setValue(self.destinationAddress!, forKey: "destinationAddress")
-        }
-        if self.boltzInvoice != nil {
-            swapDictionary.setValue(self.boltzInvoice!, forKey: "boltzInvoice")
-        }
-        if self.lockupTx != nil {
-            swapDictionary.setValue(self.lockupTx!, forKey: "lockupTx")
-        }
-        
+
+        let swapDictionary = NSMutableDictionary()
+        swapDictionary.setValue(self.dateID, forKey: "dateID")
+        swapDictionary.setValue(self.swapDirection == .onchainToLightning, forKey: "onchainToLightning")
+        swapDictionary.setValue(self.satoshisAmount, forKey: "satoshisAmount")
+        swapDictionary.setValue(self.isSuggested, forKey: "isSuggested")
+        swapDictionary.setValue(self.createdInvoice, forKey: "createdInvoice")
+        swapDictionary.setValue(self.privateKey, forKey: "privateKey")
+
+        // Boltz reply
+        swapDictionary.setValue(self.boltzID, forKey: "boltzID")
+        swapDictionary.setValue(self.boltzExpectedAmount, forKey: "boltzExpectedAmount")
+
+        // Fees
+        swapDictionary.setValue(self.onchainFees, forKey: "onchainFees")
+        swapDictionary.setValue(self.lightningFees, forKey: "lightningFees")
+        swapDictionary.setValue(self.feeHigh, forKey: "feeHigh")
+        swapDictionary.setValue(self.claimTransactionFee, forKey: "claimTransactionFee")
+
+        // Onchain to Lightning
+        swapDictionary.setValue(self.sentOnchainTransactionID, forKey: "sentOnchainTransactionID")
+        swapDictionary.setValue(self.boltzOnchainAddress, forKey: "boltzOnchainAddress")
+        swapDictionary.setValue(self.refundPublicKey, forKey: "refundPublicKey")
+        swapDictionary.setValue(self.claimLeafOutput, forKey: "claimLeafOutput")
+        swapDictionary.setValue(self.refundLeafOutput, forKey: "refundLeafOutput")
+        swapDictionary.setValue(self.claimPublicKey, forKey: "claimPublicKey")
+
+        // Lightning to Onchain
+        swapDictionary.setValue(self.preimage, forKey: "preimage")
+        swapDictionary.setValue(self.destinationAddress, forKey: "destinationAddress")
+        swapDictionary.setValue(self.boltzInvoice, forKey: "boltzInvoice")
+        swapDictionary.setValue(self.lockupTx, forKey: "lockupTx")
+
         return swapDictionary
     }
     
@@ -166,14 +138,13 @@ extension NSDictionary {
     func toSwap() -> Swap {
         
         let thisSwap = Swap()
+
+        // These four have non-nil defaults, so a missing key must leave them be.
         if let dateID = self["dateID"] as? String {
             thisSwap.dateID = dateID
         }
         if let onchainToLightning = self["onchainToLightning"] as? Bool {
-            thisSwap.swapDirection = .onchainToLightning
-            if !onchainToLightning {
-                thisSwap.swapDirection = .lightningToOnchain
-            }
+            thisSwap.swapDirection = onchainToLightning ? .onchainToLightning : .lightningToOnchain
         }
         if let satoshisAmount = self["satoshisAmount"] as? Int {
             thisSwap.satoshisAmount = satoshisAmount
@@ -181,63 +152,35 @@ extension NSDictionary {
         if let isSuggested = self["isSuggested"] as? Bool {
             thisSwap.isSuggested = isSuggested
         }
-        if let createdInvoice = self["createdInvoice"] as? String {
-            thisSwap.createdInvoice = createdInvoice
-        }
-        if let privateKey = self["privateKey"] as? String {
-            thisSwap.privateKey = privateKey
-        }
-        if let boltzID = self["boltzID"] as? String {
-            thisSwap.boltzID = boltzID
-        }
-        if let boltzOnchainAddress = self["boltzOnchainAddress"] as? String {
-            thisSwap.boltzOnchainAddress = boltzOnchainAddress
-        }
-        if let boltzExpectedAmount = self["boltzExpectedAmount"] as? Int {
-            thisSwap.boltzExpectedAmount = boltzExpectedAmount
-        }
-        if let onchainFees = self["onchainFees"] as? Int {
-            thisSwap.onchainFees = onchainFees
-        }
-        if let lightningFees = self["lightningFees"] as? Int {
-            thisSwap.lightningFees = lightningFees
-        }
-        if let feeHigh = self["feeHigh"] as? Float {
-            thisSwap.feeHigh = feeHigh
-        }
-        if let claimTransactionFee = self["claimTransactionFee"] as? Int {
-            thisSwap.claimTransactionFee = claimTransactionFee
-        }
-        if let sentOnchainTransactionID = self["sentOnchainTransactionID"] as? String {
-            thisSwap.sentOnchainTransactionID = sentOnchainTransactionID
-        }
-        if let boltzOnchainAddress = self["boltzOnchainAddress"] as? String {
-            thisSwap.boltzOnchainAddress = boltzOnchainAddress
-        }
-        if let refundPublicKey = self["refundPublicKey"] as? String {
-            thisSwap.refundPublicKey = refundPublicKey
-        }
-        if let claimLeafOutput = self["claimLeafOutput"] as? String {
-            thisSwap.claimLeafOutput = claimLeafOutput
-        }
-        if let refundLeafOutput = self["refundLeafOutput"] as? String {
-            thisSwap.refundLeafOutput = refundLeafOutput
-        }
-        if let claimPublicKey = self["claimPublicKey"] as? String {
-            thisSwap.claimPublicKey = claimPublicKey
-        }
-        if let preimage = self["preimage"] as? String {
-            thisSwap.preimage = preimage
-        }
-        if let destinationAddress = self["destinationAddress"] as? String {
-            thisSwap.destinationAddress = destinationAddress
-        }
-        if let boltzInvoice = self["boltzInvoice"] as? String {
-            thisSwap.boltzInvoice = boltzInvoice
-        }
-        if let lockupTx = self["lockupTx"] as? String {
-            thisSwap.lockupTx = lockupTx
-        }
+
+        // The rest start out nil, so assigning a failed cast is a no-op.
+        thisSwap.createdInvoice = self["createdInvoice"] as? String
+        thisSwap.privateKey = self["privateKey"] as? String
+
+        // Boltz reply
+        thisSwap.boltzID = self["boltzID"] as? String
+        thisSwap.boltzExpectedAmount = self["boltzExpectedAmount"] as? Int
+
+        // Fees
+        thisSwap.onchainFees = self["onchainFees"] as? Int
+        thisSwap.lightningFees = self["lightningFees"] as? Int
+        thisSwap.feeHigh = self["feeHigh"] as? Float
+        thisSwap.claimTransactionFee = self["claimTransactionFee"] as? Int
+
+        // Onchain to Lightning
+        thisSwap.sentOnchainTransactionID = self["sentOnchainTransactionID"] as? String
+        thisSwap.boltzOnchainAddress = self["boltzOnchainAddress"] as? String
+        thisSwap.refundPublicKey = self["refundPublicKey"] as? String
+        thisSwap.claimLeafOutput = self["claimLeafOutput"] as? String
+        thisSwap.refundLeafOutput = self["refundLeafOutput"] as? String
+        thisSwap.claimPublicKey = self["claimPublicKey"] as? String
+
+        // Lightning to Onchain
+        thisSwap.preimage = self["preimage"] as? String
+        thisSwap.destinationAddress = self["destinationAddress"] as? String
+        thisSwap.boltzInvoice = self["boltzInvoice"] as? String
+        thisSwap.lockupTx = self["lockupTx"] as? String
+
         return thisSwap
     }
 }

--- a/ios/bittr/Swaps/Swap.swift
+++ b/ios/bittr/Swaps/Swap.swift
@@ -35,7 +35,6 @@ class Swap: NSObject {
     var claimPublicKey:String?
     
     // Lightning to Onchain
-    var sentLightningPaymentID:String?
     var preimage:String?
     var destinationAddress:String?
     var boltzInvoice:String?

--- a/ios/bittr/Swaps/SwapVC/SwapViewController.swift
+++ b/ios/bittr/Swaps/SwapVC/SwapViewController.swift
@@ -280,10 +280,6 @@ class SwapViewController: UIViewController, UITextFieldDelegate, UNUserNotificat
         // Show swap status.
         self.showStatusView()
         
-        // Update swap file.
-        let direction = (self.thisSwap!.swapDirection == .lightningToOnchain) ? 1 : 0
-        SwapManager.updateSwapFileWithFees(swapID: self.thisSwap!.boltzID!, totalFees: self.thisSwap!.maximumTotalFees, userAmount: self.thisSwap!.satoshisAmount, direction: direction)
-        
         // Send payment.
         if self.thisSwap!.swapDirection == .onchainToLightning {
             SentrySDK.metrics.count(key: "swap.onchaintolightning.initiated")

--- a/ios/bittr/Transaction/Transaction.swift
+++ b/ios/bittr/Transaction/Transaction.swift
@@ -17,7 +17,6 @@ class Transaction: NSObject {
     var received = 0
     var sent = 0
     var timestamp = 0
-    var note = ""
     
     // Onchain
     var height:Int?
@@ -116,8 +115,7 @@ extension PaymentDetails {
             }
         }
         
-        // Note and Description.
-        thisTransaction.note = CacheManager.getTransactionNote(txid: thisTransaction.id)
+        // Description.
         thisTransaction.lnDescription = CacheManager.getInvoiceDescription(preimage: thisTransaction.id)
         
         // Check if transaction is Bittr.


### PR DESCRIPTION
toDictionary and toSwap were 142 lines of near-identical blocks, one pair per field. NSMutableDictionary.setValue already removes the key when handed a nil value, so the `if x != nil { setValue(x!) }` guards were redundant; and every optional property starts out nil on a fresh Swap, so `if let x = d[k] as? T { swap.x = x }` is just `swap.x = d[k] as? T`. Both collapse to one line per field, grouped to match the property declarations.