### PR TITLE
Minor LoadWalletData refactoring

### DIFF
--- a/ios/bittr.xcodeproj/project.pbxproj
+++ b/ios/bittr.xcodeproj/project.pbxproj
@@ -36,6 +36,9 @@
 		05117AF72EAA754800A5E4E6 /* Demo Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05117AF62EAA754500A5E4E6 /* Demo Data.swift */; };
 		05117AF92EAB74A100A5E4E6 /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05117AF82EAB749F00A5E4E6 /* Image.swift */; };
 		05117B9E2EDEC6AC00A5E4E6 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05117B9D2EDEC6AA00A5E4E6 /* Log.swift */; };
+		0514BC5330109C3F00BC05A2 /* PaymentDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0514BC5230109C3B00BC05A2 /* PaymentDetails.swift */; };
+		0514BC553010A17D00BC05A2 /* PaymentKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0514BC543010A17B00BC05A2 /* PaymentKind.swift */; };
+		0514BC573010A1AF00BC05A2 /* UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0514BC563010A1AE00BC05A2 /* UILabel.swift */; };
 		051AB88B2F5E816B00DFC39F /* ConfirmSendViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 051AB88A2F5E816B00DFC39F /* ConfirmSendViewController.swift */; };
 		051AB88F2F5E8FB400DFC39F /* ConfirmLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 051AB88E2F5E8FB100DFC39F /* ConfirmLanguage.swift */; };
 		051BE0882B641D41009CED5B /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 051BE0872B641D41009CED5B /* Reachability.swift */; };
@@ -251,6 +254,9 @@
 		05117AF62EAA754500A5E4E6 /* Demo Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Demo Data.swift"; sourceTree = "<group>"; };
 		05117AF82EAB749F00A5E4E6 /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		05117B9D2EDEC6AA00A5E4E6 /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
+		0514BC5230109C3B00BC05A2 /* PaymentDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentDetails.swift; sourceTree = "<group>"; };
+		0514BC543010A17B00BC05A2 /* PaymentKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentKind.swift; sourceTree = "<group>"; };
+		0514BC563010A1AE00BC05A2 /* UILabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UILabel.swift; sourceTree = "<group>"; };
 		051AB88A2F5E816B00DFC39F /* ConfirmSendViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmSendViewController.swift; sourceTree = "<group>"; };
 		051AB88E2F5E8FB100DFC39F /* ConfirmLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmLanguage.swift; sourceTree = "<group>"; };
 		051BE0872B641D41009CED5B /* Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
@@ -547,6 +553,9 @@
 		052E98C02F1638F2000035A8 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				0514BC563010A1AE00BC05A2 /* UILabel.swift */,
+				0514BC543010A17B00BC05A2 /* PaymentKind.swift */,
+				0514BC5230109C3B00BC05A2 /* PaymentDetails.swift */,
 				37FC16D12FAD1B05002578B2 /* UIView+AppTag.swift */,
 				057F63712F62716000CE1B3E /* Event.swift */,
 				05E305382F5189D6003DE7CF /* UIView.swift */,
@@ -1201,6 +1210,7 @@
 				05E483502D29049D007A5834 /* ValueViewController.swift in Sources */,
 				05A8BD802B750A40002F0282 /* HandlePaymentNotification.swift in Sources */,
 				0554035F2CB82B2E006F27CA /* ReceiveVCLanguage.swift in Sources */,
+				0514BC553010A17D00BC05A2 /* PaymentKind.swift in Sources */,
 				05D5D0E72A66825000A1E771 /* BitcoinManager.swift in Sources */,
 				05CF933A2A1E711B0084A221 /* Signup3ViewController.swift in Sources */,
 				05622A6B2DB8BA3700D91066 /* CallsManager.swift in Sources */,
@@ -1283,6 +1293,7 @@
 				05F418EC2BAC12C0005CFAD0 /* HandleBittrNotification.swift in Sources */,
 				051BE0882B641D41009CED5B /* Reachability.swift in Sources */,
 				05C3C08729CCB55600C1E695 /* SceneDelegate.swift in Sources */,
+				0514BC573010A1AF00BC05A2 /* UILabel.swift in Sources */,
 				053021AE2E701EDA00B23226 /* HandleLightningAddressNotification.swift in Sources */,
 				05906EA22C43C54A0053F7DB /* ReceiveLightning.swift in Sources */,
 				057E6E8B2A14DDBC00B37026 /* Article.swift in Sources */,
@@ -1299,6 +1310,7 @@
 				052DC6932AA853B700CD59B0 /* Transaction.swift in Sources */,
 				053021AC2E7017A400B23226 /* CoreVCLanguage.swift in Sources */,
 				05A8BD8A2B750FAF002F0282 /* LoadWalletData.swift in Sources */,
+				0514BC5330109C3F00BC05A2 /* PaymentDetails.swift in Sources */,
 				05F31CC52B8802DB00AAA342 /* LaunchQuestion.swift in Sources */,
 				051D77932A9DFCCE002107C0 /* Restore3ViewController.swift in Sources */,
 				05980B542A46F7E4001F312F /* BittrWallet.swift in Sources */,

--- a/ios/bittr/Cache/CacheManager.swift
+++ b/ios/bittr/Cache/CacheManager.swift
@@ -451,7 +451,7 @@ class CacheManager: NSObject {
         
         if let cachedData = UserDefaults.standard.value(forKey: EnvironmentConfig.cacheKey(for: "lightning")) as? NSDictionary {
             var allTransactions = [NSMutableDictionary]()
-            for (transactionId, transactionData) in cachedData {
+            for (_, transactionData) in cachedData {
                 allTransactions.append((transactionData as! NSDictionary).mutableCopy() as! NSMutableDictionary)
             }
             let parsedTransactions = self.getTransactions(transactionsDict: allTransactions)

--- a/ios/bittr/Extensions/PaymentDetails.swift
+++ b/ios/bittr/Extensions/PaymentDetails.swift
@@ -1,0 +1,36 @@
+//
+//  PaymentDetails.swift
+//  bittr
+//
+//  Created by Tom Melters on 7/22/26.
+//
+
+import UIKit
+import LDKNode
+
+extension PaymentDetails {
+    
+    func hasSucceeded() -> Bool {
+        if self.status == .succeeded {
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    func isPendingOutbound() -> Bool {
+        if self.status == .pending && self.direction == .outbound && (Int((self.amountMsat ?? 0)/1000) > 0 || Int((self.feePaidMsat ?? 0)/1000) > 0) {
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    func isUnconfirmedOnchainInbound() -> Bool {
+        if self.status == .pending && self.kind.isOnchain && self.direction == .inbound {
+            return true
+        } else {
+            return false
+        }
+    }
+}

--- a/ios/bittr/Extensions/PaymentKind.swift
+++ b/ios/bittr/Extensions/PaymentKind.swift
@@ -1,0 +1,39 @@
+//
+//  PaymentKind.swift
+//  bittr
+//
+//  Created by Tom Melters on 7/22/26.
+//
+
+import UIKit
+import LDKNode
+
+extension PaymentKind {
+    
+    var transactionID: String? {
+        switch self {
+        case .onchain(let txID, _):
+            return txID
+        case .bolt11(_, let preimage, _):
+            return preimage
+        case .bolt11Jit(_, let preimage, _, _, _):
+            return preimage
+        case .spontaneous(_, let preimage):
+            return preimage
+        case .bolt12Offer(hash: _, preimage: let preimage, secret: _, offerId: _, payerNote: _, quantity: _):
+            return preimage
+        case .bolt12Refund(hash: _, preimage: let preimage, secret: _, payerNote: _, quantity: _):
+            return preimage
+        }
+    }
+    
+    var isOnchain: Bool {
+        switch self {
+        case .onchain(_, _):
+            return true
+        default:
+            return false
+        }
+    }
+    
+}

--- a/ios/bittr/Extensions/String.swift
+++ b/ios/bittr/Extensions/String.swift
@@ -236,6 +236,9 @@ extension String {
             let offer = try LDKNode.Offer.fromStr(offerStr: self)
             return offer
         } catch {
+            // Reached from isValidInvoice while parsing pasted/scanned input, so
+            // keep the breadcrumb for a malformed lno string.
+            Log.info("Could not generate BOLT12 offer.")
             return nil
         }
     }

--- a/ios/bittr/Extensions/String.swift
+++ b/ios/bittr/Extensions/String.swift
@@ -231,15 +231,11 @@ extension String {
     }
     
     func bolt12Offer() -> LDKNode.Offer? {
-        if self.lowercased().hasPrefix("lno") {
-            do {
-                let offer = try LDKNode.Offer.fromStr(offerStr: self)
-                return offer
-            } catch {
-                Log.info("Could not generate BOLT12 offer.")
-                return nil
-            }
-        } else {
+        guard self.lowercased().hasPrefix("lno") else { return nil }
+        do {
+            let offer = try LDKNode.Offer.fromStr(offerStr: self)
+            return offer
+        } catch {
             return nil
         }
     }

--- a/ios/bittr/Extensions/UILabel.swift
+++ b/ios/bittr/Extensions/UILabel.swift
@@ -1,0 +1,28 @@
+//
+//  UILabel.swift
+//  bittr
+//
+//  Created by Tom Melters on 7/22/26.
+//
+
+import UIKit
+
+extension UILabel {
+    
+    func adjustedFont()->UIFont {
+        guard let txt = text else {
+            return self.font
+        }
+        let attributes: [NSAttributedString.Key: Any] = [.font: self.font]
+        let attributedString = NSAttributedString(string: txt, attributes: attributes)
+        let drawingContext = NSStringDrawingContext()
+        drawingContext.minimumScaleFactor = self.minimumScaleFactor
+        attributedString.boundingRect(with: bounds.size,
+                                      options: [.usesLineFragmentOrigin,.usesFontLeading],
+                                      context: drawingContext)
+
+        let fontSize = font.pointSize * drawingContext.actualScaleFactor
+        return font.withSize(CGFloat(floor(Double(fontSize))))
+    }
+    
+}

--- a/ios/bittr/Home/FetchAndPrint.swift
+++ b/ios/bittr/Home/FetchAndPrint.swift
@@ -12,19 +12,12 @@ func isConnectedToPeer() -> Bool {
     
     let peers = BitcoinManager.shared.listPeers()
     var peerIsConnected = false
-    for eachPeer in peers {
-        if eachPeer.nodeId == EnvironmentConfig.lightningNodeId, eachPeer.isConnected {
-            peerIsConnected = true
-        }
+    for eachPeer in peers where eachPeer.nodeId == EnvironmentConfig.lightningNodeId && eachPeer.isConnected {
+        peerIsConnected = true
     }
     
-    if peerIsConnected {
-        Log.info("Did successfully check peer connection.")
-        return true
-    } else {
-        Log.info("Not connected to peer.")
-        return false
-    }
+    Log.info(peerIsConnected ? "Did successfully check peer connection." : "Not connected to peer.")
+    return peerIsConnected
 }
 
 extension HomeViewController {

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -515,7 +515,9 @@ extension HomeViewController {
             for eachIbanEntity in BitcoinManager.shared.bittrWallet.ibanEntities where eachIbanEntity.yourUniqueCode != "" {
                 userHasBittrAccount = true
             }
-            // Skip payout check when a wipe / PIN reset is in progress.
+            // Skip the payout check when a wipe / PIN reset is in progress: the
+            // node is about to be torn down, so signing a message against it
+            // would race the teardown (force-unwrap of a nil ldkNode).
             if userHasBittrAccount, !self.coreVC!.resettingPin, !self.coreVC!.removingWalletForIncorrectPin {
                 Log.info("Check for pending payout.")
                 self.coreVC!.checkPendingPayout()

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -89,10 +89,10 @@ extension HomeViewController {
         // Create new transaction entities.
         for eachPayment in BitcoinManager.shared.bittrWallet.allTransactions {
             // Add succeeded new payments to table.
-            if !self.cachedLightningIds.contains(eachPayment.kind.transactionID ?? eachPayment.id), (eachPayment.status == .succeeded || (eachPayment.status == .pending && eachPayment.direction == .outbound && (Int((eachPayment.amountMsat ?? 0)/1000) > 0 || Int((eachPayment.feePaidMsat ?? 0)/1000) > 0)) || (eachPayment.status == .pending && eachPayment.kind.isOnchain && eachPayment.direction == .inbound)) {
+            if !self.cachedLightningIds.contains(eachPayment.kind.transactionID ?? eachPayment.id), (eachPayment.hasSucceeded() || eachPayment.isPendingOutbound() || eachPayment.isUnconfirmedOnchainInbound()) {
                 
                 // Create transaction.
-                let thisTransaction = eachPayment.createTransaction(coreVC: self.coreVC, bittrTransactions: self.bittrTransactions)
+                let thisTransaction = eachPayment.createTransaction(bittrTransactions: self.bittrTransactions)
                 self.newTransactions += [thisTransaction]
                 
                 // Cache succeeded Lightning payments.
@@ -102,16 +102,11 @@ extension HomeViewController {
             }
             
             // Make sure there are no duplicate transactions.
-            if eachPayment.kind.transactionID != nil {
-                if self.cachedLightningIds.contains(eachPayment.kind.transactionID!), self.cachedLightningIds.contains(eachPayment.id) {
-                    for (index, eachTransaction) in self.newTransactions.enumerated().reversed() {
-                        if eachTransaction.id == eachPayment.id {
-                            self.newTransactions.remove(at: index)
-                        }
-                    }
+            if eachPayment.kind.transactionID != nil, self.cachedLightningIds.contains(eachPayment.kind.transactionID!), self.cachedLightningIds.contains(eachPayment.id) {
+                for (index, eachTransaction) in self.newTransactions.enumerated().reversed() where eachTransaction.id == eachPayment.id {
+                    self.newTransactions.remove(at: index)
                 }
             }
-            
         }
         
         // Check for matching swap transactions.
@@ -216,7 +211,7 @@ extension HomeViewController {
             
             if let cachedFundingTxID = CacheManager.getTxoID(), eachTransaction.txId == cachedFundingTxID {
                 // This is a channel funding transaction.
-                let thisTransaction = eachTransaction.createTransaction(coreVC: self.coreVC, isFundingTransaction: true)
+                let thisTransaction = eachTransaction.createTransaction(isFundingTransaction: true)
                 self.newTransactions += [thisTransaction]
                 CacheManager.storeLightningTransaction(thisTransaction)
             }
@@ -434,19 +429,9 @@ extension HomeViewController {
             let transactionValue = eachTransaction.received.inBTC()
             var correctConversion = bitcoinValue.currentValue
 
-            let transactionCurrency:String = {
-                if eachTransaction.currency == "EUR" {
-                    return "€"
-                } else {
-                    return "CHF"
-                }
-            }()
+            let transactionCurrency = eachTransaction.currency == "EUR" ? "€" : "CHF"
             if transactionCurrency != bitcoinValue.chosenCurrency {
-                if transactionCurrency == "€" {
-                    correctConversion = BitcoinManager.shared.bittrWallet.valueInEUR ?? 0
-                } else {
-                    correctConversion = BitcoinManager.shared.bittrWallet.valueInCHF ?? 0
-                }
+                correctConversion = transactionCurrency == "€" ? (BitcoinManager.shared.bittrWallet.valueInEUR ?? 0) : (BitcoinManager.shared.bittrWallet.valueInCHF ?? 0)
             }
 
             var transactionProfit = (transactionValue*correctConversion) - eachTransaction.fiatNetAmount
@@ -468,11 +453,7 @@ extension HomeViewController {
     
     func showProfitLabel(currencySymbol:String, accumulatedProfit:Int, accumulatedInvestments:Int, accumulatedCurrentValue:Int) {
         
-        if accumulatedInvestments != 0 {
-            self.balanceCardGainLabel.text = "\(Int(((CGFloat(accumulatedProfit)/CGFloat(accumulatedInvestments))*100).rounded())) %".replacingOccurrences(of: "-", with: "")
-        } else {
-            self.balanceCardGainLabel.text = "0 %"
-        }
+        self.balanceCardGainLabel.text = (accumulatedInvestments == 0) ? "0 %" : "\(Int(((CGFloat(accumulatedProfit)/CGFloat(accumulatedInvestments))*100).rounded())) %".replacingOccurrences(of: "-", with: "")
 
         // Only reveal the profit once the balance is known.
         self.balanceCardGainLabel.alpha = self.balanceLabel.alpha
@@ -531,14 +512,10 @@ extension HomeViewController {
             }
         } else {
             var userHasBittrAccount = false
-            for eachIbanEntity in BitcoinManager.shared.bittrWallet.ibanEntities {
-                if eachIbanEntity.yourUniqueCode != "" {
-                    userHasBittrAccount = true
-                }
+            for eachIbanEntity in BitcoinManager.shared.bittrWallet.ibanEntities where eachIbanEntity.yourUniqueCode != "" {
+                userHasBittrAccount = true
             }
-            // Skip the payout check when a wipe / PIN reset is in progress: the
-            // node is about to be torn down, so signing a message against it
-            // would race the teardown (force-unwrap of a nil ldkNode).
+            // Skip payout check when a wipe / PIN reset is in progress.
             if userHasBittrAccount, !self.coreVC!.resettingPin, !self.coreVC!.removingWalletForIncorrectPin {
                 Log.info("Check for pending payout.")
                 self.coreVC!.checkPendingPayout()
@@ -554,50 +531,4 @@ extension HomeViewController {
         }
     }
 
-}
-
-extension UILabel{
-    func adjustedFont()->UIFont {
-        guard let txt = text else {
-            return self.font
-        }
-        let attributes: [NSAttributedString.Key: Any] = [.font: self.font]
-        let attributedString = NSAttributedString(string: txt, attributes: attributes)
-        let drawingContext = NSStringDrawingContext()
-        drawingContext.minimumScaleFactor = self.minimumScaleFactor
-        attributedString.boundingRect(with: bounds.size,
-                                      options: [.usesLineFragmentOrigin,.usesFontLeading],
-                                      context: drawingContext)
-
-        let fontSize = font.pointSize * drawingContext.actualScaleFactor
-        return font.withSize(CGFloat(floor(Double(fontSize))))
-    }
-}
-
-extension PaymentKind {
-    var transactionID: String? {
-        switch self {
-        case .onchain(let txID, _):
-            return txID
-        case .bolt11(_, let preimage, _):
-            return preimage
-        case .bolt11Jit(_, let preimage, _, _, _):
-            return preimage
-        case .spontaneous(_, let preimage):
-            return preimage
-        case .bolt12Offer(hash: _, preimage: let preimage, secret: _, offerId: _, payerNote: _, quantity: _):
-            return preimage
-        case .bolt12Refund(hash: _, preimage: let preimage, secret: _, payerNote: _, quantity: _):
-            return preimage
-        }
-    }
-    
-    var isOnchain: Bool {
-        switch self {
-        case .onchain(_, _):
-            return true
-        default:
-            return false
-        }
-    }
 }

--- a/ios/bittr/Move, Send, Receive/SendVC/Send/AddressParsing.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/Send/AddressParsing.swift
@@ -87,42 +87,32 @@ extension String {
     
     func extractBitcoinAddress() -> String? {
         let components = self.components(separatedBy: CharacterSet(charactersIn: "&:?="))
-        for eachComponent in components {
-            if eachComponent.isValidBitcoinAddress() {
-                return eachComponent
-            }
+        for eachComponent in components where eachComponent.isValidBitcoinAddress() {
+            return eachComponent
         }
         return nil
     }
     
     func extractLightningInvoice() -> String? {
         let components = self.components(separatedBy: CharacterSet(charactersIn: "&:?="))
-        for eachComponent in components {
-            if eachComponent.isValidInvoice() {
-                return eachComponent
-            }
+        for eachComponent in components where eachComponent.isValidInvoice() {
+            return eachComponent
         }
         return nil
     }
     
     func extractLNURL() -> String? {
         let components = self.components(separatedBy: CharacterSet(charactersIn: "&:?="))
-        for eachComponent in components {
-            if eachComponent.isValidEmail() {
-                return eachComponent
-            } else if eachComponent.hasPrefix("lnurl") {
-                return eachComponent
-            }
+        for eachComponent in components where (eachComponent.isValidEmail() || eachComponent.hasPrefix("lnurl")) {
+            return eachComponent
         }
         return nil
     }
     
     func extractAmount() -> Int? {
         let components = self.components(separatedBy: CharacterSet(charactersIn: "&:?"))
-        for eachComponent in components {
-            if eachComponent.contains("amount=") {
-                return eachComponent.replacingOccurrences(of: "amount=", with: "").toNumber().inSatoshis()
-            }
+        for eachComponent in components where eachComponent.contains("amount=") {
+            return eachComponent.replacingOccurrences(of: "amount=", with: "").toNumber().inSatoshis()
         }
         return nil
     }
@@ -141,19 +131,16 @@ extension String {
     }
     
     func isValidInvoice() -> Bool {
-        if self.hasPrefix("ln") {
-            let bolt11Invoice = Bolt11Invoice.fromStr(s: self)
-            if bolt11Invoice.isOk(), bolt11Invoice.getValue() != nil {
+        guard self.hasPrefix("ln") else { return false }
+        let bolt11Invoice = Bolt11Invoice.fromStr(s: self)
+        if bolt11Invoice.isOk(), bolt11Invoice.getValue() != nil {
+            return true
+        } else {
+            if let _ = self.bolt12Offer() {
                 return true
             } else {
-                if let _ = self.bolt12Offer() {
-                    return true
-                } else {
-                    return false
-                }
+                return false
             }
-        } else {
-            return false
         }
     }
 }

--- a/ios/bittr/Move, Send, Receive/SendVC/SendLightning.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/SendLightning.swift
@@ -384,7 +384,7 @@ extension UIViewController {
         }
         
         // Create transaction.
-        let newTransaction = thisPayment.createTransaction(coreVC: coreVC, bittrTransactions: nil)
+        let newTransaction = thisPayment.createTransaction(bittrTransactions: nil)
         CacheManager.storeLightningTransaction(newTransaction)
         
         // Add invoice to Transactions table.

--- a/ios/bittr/Move, Send, Receive/SendVC/SendOnchain.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/SendOnchain.swift
@@ -288,7 +288,7 @@ extension ConfirmSendViewController {
             if success {
                 for eachTransaction in BitcoinManager.shared.bittrWallet.allTransactions {
                     if eachTransaction.kind.transactionID == self.newTxId {
-                        self.sendVC!.completedTransaction = eachTransaction.createTransaction(coreVC: self.coreVC!, bittrTransactions: nil)
+                        self.sendVC!.completedTransaction = eachTransaction.createTransaction(bittrTransactions: nil)
                         self.sendVC!.performSegue(withIdentifier: "SendToTransaction", sender: self)
                     }
                 }

--- a/ios/bittr/Notifications/HandlePaymentNotification.swift
+++ b/ios/bittr/Notifications/HandlePaymentNotification.swift
@@ -306,7 +306,7 @@ extension CoreViewController {
                         self.checkPaymentWithBittr(paymentPreimage: paymentDetails.kind.transactionID ?? paymentDetails.id, paymentDetails: paymentDetails, isFundingTransaction: false)
                     } else {
                         // This is a normal incoming payment.
-                        let thisTransaction = paymentDetails.createTransaction(coreVC: self, bittrTransactions: nil)
+                        let thisTransaction = paymentDetails.createTransaction(bittrTransactions: nil)
                         self.launchTransactionVC(thisTransaction: thisTransaction, paymentDetails: paymentDetails)
                     }
                 }
@@ -363,7 +363,7 @@ extension CoreViewController {
                 if let paymentDetails = BitcoinManager.shared.getPaymentDetails(paymentHash: paymentHash) {
                     
                     // Create transaction item.
-                    let newTransaction = paymentDetails.createTransaction(coreVC: self, bittrTransactions: nil)
+                    let newTransaction = paymentDetails.createTransaction(bittrTransactions: nil)
                     if feePaidMsat != nil, Int(feePaidMsat!/1000) > 0 {
                         CacheManager.storePaymentFees(preimage: newTransaction.id, fees: Int(feePaidMsat!/1000))
                         newTransaction.fee = Int(feePaidMsat!/1000)
@@ -534,14 +534,14 @@ extension CoreViewController {
                             }
                             
                             // Create transaction object.
-                            let thisTransaction = bittrApiTransactions.first!.createTransaction(coreVC: self, isFundingTransaction: isFundingTransaction)
+                            let thisTransaction = bittrApiTransactions.first!.createTransaction(isFundingTransaction: isFundingTransaction)
                             self.launchTransactionVC(thisTransaction: thisTransaction, paymentDetails: nil)
                         }
                     } else {
                         Log.info("channelPending: Received no transaction details from Bittr API.")
                         print("Funding txid: \(paymentPreimage)")
                         if paymentDetails != nil {
-                            let thisTransaction = paymentDetails!.createTransaction(coreVC: self, bittrTransactions: nil)
+                            let thisTransaction = paymentDetails!.createTransaction(bittrTransactions: nil)
                             self.launchTransactionVC(thisTransaction: thisTransaction, paymentDetails: paymentDetails!)
                         }
                     }
@@ -552,7 +552,7 @@ extension CoreViewController {
                             scope.setExtra(value: "HandlePaymentNotification row 453", key: "context")
                         }
                         if paymentDetails != nil {
-                            let thisTransaction = paymentDetails!.createTransaction(coreVC: self, bittrTransactions: nil)
+                            let thisTransaction = paymentDetails!.createTransaction(bittrTransactions: nil)
                             self.launchTransactionVC(thisTransaction: thisTransaction, paymentDetails: paymentDetails!)
                         }
                     }

--- a/ios/bittr/Transaction/Transaction.swift
+++ b/ios/bittr/Transaction/Transaction.swift
@@ -69,7 +69,7 @@ enum SwapStatus {
 
 extension PaymentDetails {
     
-    func createTransaction(coreVC:CoreViewController?, bittrTransactions:[String:BittrTransaction]?) -> Transaction {
+    func createTransaction(bittrTransactions:[String:BittrTransaction]?) -> Transaction {
         
         // Create transaction object.
         let thisTransaction = Transaction()
@@ -152,7 +152,7 @@ extension PaymentDetails {
 
 extension BittrTransaction {
     
-    func createTransaction(coreVC:CoreViewController?, isFundingTransaction:Bool) -> Transaction {
+    func createTransaction(isFundingTransaction:Bool) -> Transaction {
         
         // Create transaction object.
         let thisTransaction = Transaction()


### PR DESCRIPTION
LoadWalletData.swift carried three extensions that had nothing to do with loading wallet data: PaymentKind (transactionID, isOnchain), a UILabel font helper, and the payment-status predicates used to decide which payments reach the table. Move them to Extensions/, where the rest of the codebase looks for that kind of thing, and name the status checks — hasSucceeded, isPendingOutbound, isUnconfirmedOnchainInbound — so the filter reads as three conditions rather than one long boolean.

createTransaction took a coreVC it never used, on both the PaymentDetails and the BittrTransaction overload. Dropped, along with the argument at every call site.

The rest is local tidying with no behaviour change: `for ... where` in place of a loop wrapping a single if, ternaries for two-branch assignments, and flattened nesting in isValidInvoice and bolt12Offer.