### PR TITLE
Retry transient errSecMissingEntitlement on Keychain reads

### DIFF
--- a/ios/bittr/Helpers/SecureStore.swift
+++ b/ios/bittr/Helpers/SecureStore.swift
@@ -122,6 +122,11 @@ enum SecureStore {
         }
     }
 
+    /// Retry schedule (seconds) for a transient read failure — see below.
+    /// Three retries with escalating backoff, ~210 ms of blocking in the worst
+    /// case, which only ever elapses when every attempt fails.
+    private static let readRetryDelays: [TimeInterval] = [0.03, 0.06, 0.12]
+
     static func getData(account: String) throws -> Data? {
         let query: [String: Any] = [
             kSecClass as String:                     kSecClassGenericPassword,
@@ -132,16 +137,30 @@ enum SecureStore {
             kSecUseDataProtectionKeychain as String: true,
         ]
 
-        var result: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        // errSecMissingEntitlement (-34018) is returned spuriously when the
+        // Keychain is queried very early in the launch cycle — a cold launch,
+        // or an OS background launch — before securityd has finished wiring up the
+        // app's keychain-access-group entitlement. It is transient and clears
+        // within a few tens of milliseconds, so we briefly retry rather than
+        // surfacing a failure that isn't real. Every other status (including a
+        // genuine, persistent -34018) is thrown on the final attempt.
+        var attempt = 0
+        while true {
+            var result: CFTypeRef?
+            let status = SecItemCopyMatching(query as CFDictionary, &result)
 
-        switch status {
-        case errSecSuccess:
-            return result as? Data
-        case errSecItemNotFound:
-            return nil
-        default:
-            throw SecureStoreError.unexpectedStatus(status)
+            switch status {
+            case errSecSuccess:
+                return result as? Data
+            case errSecItemNotFound:
+                return nil
+            case errSecMissingEntitlement where attempt < readRetryDelays.count:
+                Thread.sleep(forTimeInterval: readRetryDelays[attempt])
+                attempt += 1
+                continue
+            default:
+                throw SecureStoreError.unexpectedStatus(status)
+            }
         }
     }
 


### PR DESCRIPTION
This is a fix for **this Sentry error**: https://bittr.sentry.io/issues/7636076407/?project=4507055778758656

This error was thrown in **CacheManager row 820**.

**Reason for Sentry error**
SecItemCopyMatching can spuriously return errSecMissingEntitlement (-34018) when queried very early in the launch cycle — a cold launch or an OS background launch (the app declares fetch/remote-notification) — before securityd has finished wiring up the app's keychain-access-group entitlement. This surfaced as SecureStoreError.unexpectedStatus(-34018) from walletSecretsPresence() at CoreViewController launch.

**The fix: 3 quick retries before throwing an error**
Add a bounded retry inside SecureStore.getData for that status only (3 retries, ~210 ms worst case), so a transient failure isn't reported as a real one. Success, not-found, and every other status (including a persistent -34018 after retries) behave as before.