### PR TITLE
Fix and rotate the LDK Node log file

### DIFF
--- a/ios/bittr/BitcoinManager.swift
+++ b/ios/bittr/BitcoinManager.swift
@@ -116,8 +116,8 @@ class BitcoinManager {
     
     func didStartLDK() -> Bool {
         
-        // Delete previous LDK Node log.
-        try? FileManager.deleteLDKNodeLogLatestFile()
+        // Rotate the previous LDK Node log.
+        try? FileManager.rotateLDKNodeLog()
         
         // Congifure LDK Node settings.
         let correctListeningAddresses = EnvironmentConfig.isDevelopment ? ["0.0.0.0:19735"] : ["0.0.0.0:9735"]

--- a/ios/bittr/Extensions/FileManager.swift
+++ b/ios/bittr/Extensions/FileManager.swift
@@ -9,8 +9,11 @@ import Foundation
 
 extension FileManager {
     
-    // Rotates the LDK Node log before `start`: keeps the active log small and loadable in Log View, while preserving the previous session as `ldk_node_previous.log` so a crash or channel close can still be investigated after a relaunch.
-    static func deleteLDKNodeLogLatestFile() throws {
+    // Rotates the LDK Node log before `start`: keeps the active log small and
+    // loadable in Log View, while preserving the previous session as
+    // `ldk_node_previous.log` so a crash or channel close can still be
+    // investigated after a relaunch.
+    static func rotateLDKNodeLog() throws {
         let documentsURL = URL(fileURLWithPath: NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0])
         let current = documentsURL.appendingPathComponent("ldk_node.log")
         guard FileManager.default.fileExists(atPath: current.path) else { return }

--- a/ios/bittr/Extensions/FileManager.swift
+++ b/ios/bittr/Extensions/FileManager.swift
@@ -9,10 +9,13 @@ import Foundation
 
 extension FileManager {
     
-    // Deletes log file before `start` to keep log file small and loadable in Log View
+    // Rotates the LDK Node log before `start`: keeps the active log small and loadable in Log View, while preserving the previous session as `ldk_node_previous.log` so a crash or channel close can still be investigated after a relaunch.
     static func deleteLDKNodeLogLatestFile() throws {
-        let documentsPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
-        let logFilePath = URL(fileURLWithPath: documentsPath).appendingPathComponent("logs/ldk_node_latest.log").path
-        try FileManager.default.removeItem(atPath: logFilePath)
+        let documentsURL = URL(fileURLWithPath: NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0])
+        let current = documentsURL.appendingPathComponent("ldk_node.log")
+        guard FileManager.default.fileExists(atPath: current.path) else { return }
+        let previous = documentsURL.appendingPathComponent("ldk_node_previous.log")
+        try? FileManager.default.removeItem(at: previous)
+        try FileManager.default.moveItem(at: current, to: previous)
     }
 }


### PR DESCRIPTION
deleteLDKNodeLogLatestFile pointed at logs/ldk_node_latest.log, a path LDK Node never writes — the real file is ldk_node.log in the Documents dir — so the pre-start removal silently failed every launch and the log grew without bound.

Point it at the real file, and rotate rather than hard-delete: the previous session is preserved as ldk_node_previous.log so a crash or channel close can still be investigated after a relaunch.