### PR TITLE
Present the QuestionVC from the top-most view controller

### DIFF
--- a/ios/bittr/Base.lproj/Main.storyboard
+++ b/ios/bittr/Base.lproj/Main.storyboard
@@ -829,7 +829,6 @@
                         <outlet property="walletView" destination="LZ5-LN-ll3" id="YCy-ng-lAQ"/>
                         <outlet property="yearLabel" destination="IaO-Gf-3C2" id="OrV-1q-QoO"/>
                         <outlet property="yearView" destination="gSx-Va-0OK" id="zr4-cO-epd"/>
-                        <segue destination="b12-fa-pJV" kind="show" identifier="CoreToQuestion" id="KXI-1X-aAi"/>
                         <segue destination="4ca-QY-6dF" kind="show" identifier="CoreToArticle" id="o32-HH-NM5"/>
                         <segue destination="SiB-n5-gpJ" kind="show" identifier="CoreToSwap" id="ahR-EC-NqA"/>
                     </connections>
@@ -8163,7 +8162,7 @@
         <!--Question View Controller-->
         <scene sceneID="ZcY-D9-jzP">
             <objects>
-                <viewController id="b12-fa-pJV" customClass="QuestionViewController" customModule="bittr" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="b12-fa-pJV" storyboardIdentifier="Question" customClass="QuestionViewController" customModule="bittr" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="1jQ-RR-3Ix">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="793"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/ios/bittr/Core/CoreViewController.swift
+++ b/ios/bittr/Core/CoreViewController.swift
@@ -56,11 +56,6 @@ class CoreViewController: UIViewController {
     var tappedArticle:String?
     var downloadedAcademy:[Level]?
     
-    // QuestionVC
-    var tappedQuestion = ""
-    var tappedAnswer = ""
-    var tappedType:String?
-    
     // Top bar
     @IBOutlet weak var animationContainer: UIView!
     @IBOutlet weak var finalLogoDarkMode: UIImageView!

--- a/ios/bittr/Core/LaunchQuestion.swift
+++ b/ios/bittr/Core/LaunchQuestion.swift
@@ -10,13 +10,33 @@ import UIKit
 extension CoreViewController {
 
     func launchQuestion(question:String, answer:String, type:String?) {
+        guard let presenter = Self.topMostViewController() else {
+            Log.info("launchQuestion: no view controller available to present from.")
+            return
+        }
         
-        // Launch QuestionVC.
-        self.tappedQuestion = question
-        self.tappedAnswer = answer
-        self.tappedType = type
+        let storyboard = UIStoryboard(name: "Main", bundle: Bundle.main)
+        guard let questionVC = storyboard.instantiateViewController(withIdentifier: "Question") as? QuestionViewController else { return }
+        questionVC.headerText = question
+        questionVC.answerText = answer
+        questionVC.questionType = type
+        questionVC.coreVC = self
         
-        self.performSegue(withIdentifier: "CoreToQuestion", sender: self)
+        Log.info("launchQuestion presenting from \(presenter), app active: \(UIApplication.shared.applicationState == .active)")
+        
+        presenter.present(questionVC, animated: true)
+    }
+    
+    private static func topMostViewController() -> UIViewController? {
+        let keyWindow = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+        var top = keyWindow?.rootViewController
+        while let presented = top?.presentedViewController {
+            top = presented
+        }
+        return top
     }
     
 }

--- a/ios/bittr/Core/Navigation.swift
+++ b/ios/bittr/Core/Navigation.swift
@@ -92,13 +92,6 @@ extension CoreViewController {
                 homeVC.coreVC = self
                 self.homeVC = homeVC
             }
-        } else if segue.identifier == "CoreToQuestion" {
-            if let questionVC = segue.destination as? QuestionViewController {
-                questionVC.headerText = self.tappedQuestion
-                questionVC.answerText = self.tappedAnswer
-                questionVC.coreVC = self
-                questionVC.questionType = self.tappedType
-            }
         } else if segue.identifier == "CoreToArticle" {
             if let oneArticleVC = segue.destination as? ArticleViewController, self.tappedArticle != nil {
                 let article = self.allArticles?[self.tappedArticle!] ?? Article()


### PR DESCRIPTION
launchQuestion fired a CoreToQuestion segue from CoreViewController, which sits at the root beneath the Home / Move / Swap modal chain. Presenting from a controller that is buried under other modals is unreliable (and impossible mid-transition), so the screen silently failed to appear over deeper modals — e.g. the channel-closed alert during a swap.

Instead, instantiate QuestionViewController by storyboard id and present it from the top-most presented controller, whose view is always frontmost and can always present. This makes every launchQuestion call site robust regardless of what is on screen.

Remove the now-dead path: the CoreToQuestion segue, its prepare(for:) branch in Navigation, and the tappedQuestion/Answer/Type properties.