### PR TITLE
Fix Academy locked-lesson blur render + live dark-mode repaint

### DIFF
--- a/ios/bittr/Academy/Academy/AcademyVC/AcademyViewController.swift
+++ b/ios/bittr/Academy/Academy/AcademyVC/AcademyViewController.swift
@@ -31,6 +31,9 @@ class AcademyViewController: UIViewController, UITableViewDelegate, UITableViewD
         self.academyTableView.rowHeight = UITableView.automaticDimension
         self.academyTableView.estimatedRowHeight = 300
         
+        // Repaint on dark-mode change, like the app's other screens.
+        NotificationCenter.default.addObserver(self, selector: #selector(changeColors), name: NSNotification.Name(rawValue: "changecolors"), object: nil)
+
         // Get Academy levels.
         self.getLevels()
         self.changeColors()
@@ -132,7 +135,7 @@ class AcademyViewController: UIViewController, UITableViewDelegate, UITableViewD
         }
     }
     
-    func changeColors() {
+    @objc func changeColors() {
         self.view.backgroundColor = Colors.getColor("yelloworblue3")
         self.headerLabel.textColor = Colors.getColor("blackorwhite")
     }

--- a/ios/bittr/Academy/Academy/AcademyVC/LessonCollectionViewCell.swift
+++ b/ios/bittr/Academy/Academy/AcademyVC/LessonCollectionViewCell.swift
@@ -35,7 +35,10 @@ class LessonCollectionViewCell: UICollectionViewCell {
         
         // Resistance priority.
         self.lessonTitle.setContentCompressionResistancePriority(.required, for: .vertical)
-        
+
+        // Repaint on dark-mode change, like the app's other list cells.
+        NotificationCenter.default.addObserver(self, selector: #selector(changeColors), name: NSNotification.Name(rawValue: "changecolors"), object: nil)
+
         // Color management.
         self.changeColors()
     }
@@ -64,8 +67,8 @@ class LessonCollectionViewCell: UICollectionViewCell {
         }
     }
     
-    func changeColors() {
-        
+    @objc func changeColors() {
+
         self.lessonTitle.textColor = Colors.getColor("blackorwhite")
         
         if CacheManager.darkModeIsOn() {

--- a/ios/bittr/Academy/Academy/AcademyVC/LessonCollectionViewCell.swift
+++ b/ios/bittr/Academy/Academy/AcademyVC/LessonCollectionViewCell.swift
@@ -81,19 +81,6 @@ class BlurEffect: UIVisualEffectView {
 
     var blurAnimator = UIViewPropertyAnimator(duration: 1, curve: .linear)
 
-    // Whether the blur is already built for the current attachment. Repeated
-    // "setupblur" posts are then no-ops: rebuilding a UIVisualEffectView blur
-    // is an expensive filter regeneration on the main thread, and the
-    // notification fans out to EVERY live instance per post (posted per
-    // willDisplay, per menu navigation, per foreground) — during a wallet
-    // reset's academy re-render that multiplied into a full main-thread hang
-    // (watchdog kill), even after the per-instance animator-accumulation fix.
-    // The blur is appearance-independent (overrideUserInterfaceStyle .light),
-    // so the only event that genuinely needs a rebuild is returning from the
-    // background, where iOS can drop a paused animator's effect — handled by
-    // clearing the flag on willEnterForeground.
-    private var isConfigured = false
-
     override func didMoveToSuperview() {
         guard let superview = superview else {
             // Removed from the hierarchy (removeBlur / cell reuse): stop
@@ -101,33 +88,20 @@ class BlurEffect: UIVisualEffectView {
             // don't keep doing effect work on every "setupblur" post.
             NotificationCenter.default.removeObserver(self)
             self.blurAnimator.stopAnimation(true)
-            self.isConfigured = false
             return
         }
         self.backgroundColor = .clear
         self.frame = superview.bounds
-        self.isConfigured = false
         self.setupBlur()
 
         // didMoveToSuperview can run more than once — never stack observers.
         NotificationCenter.default.removeObserver(self)
         NotificationCenter.default.addObserver(self, selector: #selector(setupBlur), name: NSNotification.Name(rawValue: "setupblur"), object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(invalidateBlur), name: UIApplication.willEnterForegroundNotification, object: nil)
-    }
-
-    @objc private func invalidateBlur() {
-        // Backgrounding can tear down the paused animator's effect — let the
-        // next "setupblur" post (SceneDelegate posts one on foregrounding)
-        // rebuild it.
-        self.isConfigured = false
     }
 
     @objc private func setupBlur() {
         // Detached instances have no business animating.
         guard self.superview != nil else { return }
-        // Already built for this attachment — see isConfigured.
-        guard !self.isConfigured else { return }
-        self.isConfigured = true
 
         self.blurAnimator.stopAnimation(true)
         self.effect = nil

--- a/ios/bittr/Academy/Academy/AcademyVC/LessonCollectionViewCell.swift
+++ b/ios/bittr/Academy/Academy/AcademyVC/LessonCollectionViewCell.swift
@@ -81,6 +81,18 @@ class BlurEffect: UIVisualEffectView {
 
     var blurAnimator = UIViewPropertyAnimator(duration: 1, curve: .linear)
 
+    // The size the blur was last built at. Rebuilding a UIVisualEffectView blur
+    // is an expensive main-thread filter regeneration, and the "setupblur"
+    // notification fans out to EVERY attached instance per post (per willDisplay,
+    // per menu navigation, per foreground) — so a re-render storm (e.g. a wallet
+    // reset re-rendering the academy) could multiply into a main-thread hang.
+    // Keying the rebuild on size fixes both problems at once: the effect is built
+    // once at the real, post-layout tile size (not the premature
+    // didMoveToSuperview size, which AutoLayout then stretched into oversized,
+    // blocky patches), and repeated same-size posts become no-ops. Cleared on
+    // detach and on foregrounding (where iOS can drop the paused effect).
+    private var blurredSize: CGSize?
+
     override func didMoveToSuperview() {
         guard let superview = superview else {
             // Removed from the hierarchy (removeBlur / cell reuse): stop
@@ -88,20 +100,45 @@ class BlurEffect: UIVisualEffectView {
             // don't keep doing effect work on every "setupblur" post.
             NotificationCenter.default.removeObserver(self)
             self.blurAnimator.stopAnimation(true)
+            self.blurredSize = nil
             return
         }
         self.backgroundColor = .clear
         self.frame = superview.bounds
-        self.setupBlur()
+        // Don't build here: the frame is still the pre-layout size. layoutSubviews
+        // builds it once the real tile size is known.
+        self.setNeedsLayout()
 
         // didMoveToSuperview can run more than once — never stack observers.
         NotificationCenter.default.removeObserver(self)
         NotificationCenter.default.addObserver(self, selector: #selector(setupBlur), name: NSNotification.Name(rawValue: "setupblur"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(invalidateBlur), name: UIApplication.willEnterForegroundNotification, object: nil)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // Build/rebuild only when the on-screen size actually changed — this is
+        // what renders the blur at the correct, post-layout size.
+        if self.blurredSize != self.bounds.size {
+            self.setupBlur()
+        }
+    }
+
+    @objc private func invalidateBlur() {
+        // Backgrounding can tear down the paused animator's effect — force one
+        // rebuild on the next setupblur post / layout pass.
+        self.blurredSize = nil
+        self.setNeedsLayout()
     }
 
     @objc private func setupBlur() {
-        // Detached instances have no business animating.
-        guard self.superview != nil else { return }
+        // Detached instances have no business animating; a zero size isn't laid
+        // out yet.
+        guard self.superview != nil, self.bounds.size != .zero else { return }
+        // Already built for this size — see blurredSize. Makes repeated
+        // "setupblur" posts (and re-render storms) cheap no-ops.
+        guard self.blurredSize != self.bounds.size else { return }
+        self.blurredSize = self.bounds.size
 
         self.blurAnimator.stopAnimation(true)
         self.effect = nil

--- a/ios/bittr/Academy/Academy/AcademyVC/LevelTableViewCell.swift
+++ b/ios/bittr/Academy/Academy/AcademyVC/LevelTableViewCell.swift
@@ -37,7 +37,8 @@ class LevelTableViewCell: UITableViewCell, UICollectionViewDelegate, UICollectio
         
         // Notification management.
         NotificationCenter.default.addObserver(self, selector: #selector(reloadCollectionView), name: NSNotification.Name(rawValue: "reloadcollectionview"), object: nil)
-        
+        NotificationCenter.default.addObserver(self, selector: #selector(changeColors), name: NSNotification.Name(rawValue: "changecolors"), object: nil)
+
         // Color management.
         self.changeColors()
     }
@@ -182,8 +183,8 @@ class LevelTableViewCell: UITableViewCell, UICollectionViewDelegate, UICollectio
         }
     }
     
-    func changeColors() {
-        
+    @objc func changeColors() {
+
         self.cardView.backgroundColor = Colors.getColor("yelloworblue2")
         self.levelLabel.textColor = Colors.getColor("whiteoryellow")
         self.countLabel.textColor = Colors.getColor("whiteoryellow")


### PR DESCRIPTION
Fixes the Academy locked-lesson blur render, and — while in the same files — a pre-existing dark-mode repaint gap.

## 1. Blur render (the original fix)

`f2e17d3`'s "build each locked-lesson blur once per attachment" (`isConfigured`) froze the blur at the size it had in `didMoveToSuperview`, which runs during `cellForItemAt` before the cell is laid out. AutoLayout then stretched that premature, low-resolution render up to the tile size, producing oversized, misaligned, blocky blur patches.

Rather than reverting to rebuild-on-every-post (which renders correctly but reintroduces the main-thread hang the `isConfigured` guard was added to prevent — rebuilding a `UIVisualEffectView` blur is an expensive filter regeneration, and `"setupblur"` fans out to every attached instance per post), the rebuild is now **keyed on size**:

- The blur is built in `layoutSubviews`, once the real post-layout tile size is known — correct render.
- Repeated same-size `"setupblur"` posts (and re-render storms, e.g. a wallet reset re-rendering the academy) become cheap no-ops — keeps the watchdog-hang protection.
- Foreground still forces one rebuild (`invalidateBlur` clears the cached size), since backgrounding can drop the paused effect.

The valuable half of the earlier work — recreating the animator instead of accumulating `addAnimations` blocks — is preserved.

## 2. Live dark-mode repaint (pre-existing gap, fixed here)

The Academy screen and its cells only set colors in `viewDidLoad` / `awakeFromNib` and subscribed to no repaint notification, so toggling dark mode in Settings left the Academy showing stale colors until cells were re-created by scrolling. Every other list screen (Home, Settings, Pin, History cells, …) already observes `"changecolors"` and repaints.

`AcademyViewController`, `LevelTableViewCell`, and `LessonCollectionViewCell` now observe `"changecolors"` and re-run `changeColors`, matching the app-wide pattern — so returning to the Academy after a dark-mode change shows the correct colors immediately. The blur tiles stay light-pinned by design; only the card/text/tint colors flip.
