### PR TITLE
Show pending lightning balances from channel closures

### DIFF
--- a/ios/bittr/AlertManager.swift
+++ b/ios/bittr/AlertManager.swift
@@ -196,6 +196,10 @@ extension UIViewController {
             yellowCard.addConstraints([messageLabelLeft, messageLabelRight, messageLabelTop])
             messageLabel.addConstraints([messageLabelHeight])
             
+            // Check whether to stack buttons vertically or horizontally.
+            let titlesFitSideBySide = buttons.allSatisfy { eachButton in eachButton.count < 16 }
+            let stackButtonsVertically = buttons.count > 2 || (buttons.count == 2 && !titlesFitSideBySide)
+            
             // Buttons stack
             let buttonsStack = UIView()
             buttonsStack.translatesAutoresizingMaskIntoConstraints = false
@@ -203,10 +207,10 @@ extension UIViewController {
             buttonsStack.backgroundColor = .clear
             yellowCard.addSubview(buttonsStack)
             let buttonsStackHeight:NSLayoutConstraint = {
-                if buttons.count < 3 {
-                    return NSLayoutConstraint(item: buttonsStack, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 50)
-                } else {
+                if stackButtonsVertically {
                     return NSLayoutConstraint(item: buttonsStack, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 50*CGFloat(buttons.count))
+                } else {
+                    return NSLayoutConstraint(item: buttonsStack, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 50)
                 }
             }()
             let buttonsStackLeft = NSLayoutConstraint(item: buttonsStack, attribute: .leading, relatedBy: .equal, toItem: yellowCard, attribute: .leading, multiplier: 1, constant: 15)
@@ -232,7 +236,7 @@ extension UIViewController {
                 let closeViewHeight = NSLayoutConstraint(item: closeView, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 40)
                 
                 let closeViewWidth:NSLayoutConstraint = {
-                    if buttons.count == 2 {
+                    if buttons.count == 2, !stackButtonsVertically {
                         return NSLayoutConstraint(item: closeView, attribute: .width, relatedBy: .equal, toItem: buttonsStack, attribute: .width, multiplier: 0.5, constant: -5)
                     } else {
                         return NSLayoutConstraint(item: closeView, attribute: .width, relatedBy: .equal, toItem: buttonsStack, attribute: .width, multiplier: 1, constant: 0)
@@ -240,7 +244,7 @@ extension UIViewController {
                 }()
                 
                 let closeViewLeft:NSLayoutConstraint = {
-                    if buttons.count == 2, index == 1 {
+                    if buttons.count == 2, !stackButtonsVertically, index == 1 {
                         return NSLayoutConstraint(item: closeView, attribute: .leading, relatedBy: .equal, toItem: buttonsStack, attribute: .leading, multiplier: 1, constant: (buttonsStack.bounds.width/2) + 5)
                     } else {
                         return NSLayoutConstraint(item: closeView, attribute: .leading, relatedBy: .equal, toItem: buttonsStack, attribute: .leading, multiplier: 1, constant: 0)
@@ -248,7 +252,7 @@ extension UIViewController {
                 }()
                 
                 let closeViewBottom:NSLayoutConstraint = {
-                    if buttons.count > 2, index > 0 {
+                    if stackButtonsVertically, index > 0 {
                         return NSLayoutConstraint(item: closeView, attribute: .bottom, relatedBy: .equal, toItem: buttonsStack, attribute: .bottom, multiplier: 1, constant: CGFloat(index)*(-50) - 10)
                     } else {
                         return NSLayoutConstraint(item: closeView, attribute: .bottom, relatedBy: .equal, toItem: buttonsStack, attribute: .bottom, multiplier: 1, constant: -10)
@@ -267,16 +271,12 @@ extension UIViewController {
                 buttonLabel.textColor = Colors.getColor("blackorwhite")
                 buttonLabel.textAlignment = .center
                 buttonLabel.isAccessibilityElement = false
-                buttonLabel.adjustsFontSizeToFitWidth = true
-                buttonLabel.minimumScaleFactor = 0.7
                 closeView.addSubview(buttonLabel)
                 let buttonLabelCenterX = NSLayoutConstraint(item: buttonLabel, attribute: .centerX, relatedBy: .equal, toItem: closeView, attribute: .centerX, multiplier: 1, constant: 0)
                 let buttonLabelCenterY = NSLayoutConstraint(item: buttonLabel, attribute: .centerY, relatedBy: .equal, toItem: closeView, attribute: .centerY, multiplier: 1, constant: 1)
-                let buttonLabelLeft = NSLayoutConstraint(item: buttonLabel, attribute: .leading, relatedBy: .greaterThanOrEqual, toItem: closeView, attribute: .leading, multiplier: 1, constant: 8)
-                let buttonLabelRight = NSLayoutConstraint(item: buttonLabel, attribute: .trailing, relatedBy: .lessThanOrEqual, toItem: closeView, attribute: .trailing, multiplier: 1, constant: -8)
                 let buttonLabelHeight = NSLayoutConstraint(item: buttonLabel, attribute: .height, relatedBy: .greaterThanOrEqual, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 0)
                 let buttonLabelWidth = NSLayoutConstraint(item: buttonLabel, attribute: .width, relatedBy: .greaterThanOrEqual, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 0)
-                closeView.addConstraints([buttonLabelCenterX, buttonLabelCenterY, buttonLabelLeft, buttonLabelRight])
+                closeView.addConstraints([buttonLabelCenterX, buttonLabelCenterY])
                 buttonLabel.addConstraints([buttonLabelHeight, buttonLabelWidth])
                 
                 // Main button

--- a/ios/bittr/AlertManager.swift
+++ b/ios/bittr/AlertManager.swift
@@ -267,12 +267,16 @@ extension UIViewController {
                 buttonLabel.textColor = Colors.getColor("blackorwhite")
                 buttonLabel.textAlignment = .center
                 buttonLabel.isAccessibilityElement = false
+                buttonLabel.adjustsFontSizeToFitWidth = true
+                buttonLabel.minimumScaleFactor = 0.7
                 closeView.addSubview(buttonLabel)
                 let buttonLabelCenterX = NSLayoutConstraint(item: buttonLabel, attribute: .centerX, relatedBy: .equal, toItem: closeView, attribute: .centerX, multiplier: 1, constant: 0)
                 let buttonLabelCenterY = NSLayoutConstraint(item: buttonLabel, attribute: .centerY, relatedBy: .equal, toItem: closeView, attribute: .centerY, multiplier: 1, constant: 1)
+                let buttonLabelLeft = NSLayoutConstraint(item: buttonLabel, attribute: .leading, relatedBy: .greaterThanOrEqual, toItem: closeView, attribute: .leading, multiplier: 1, constant: 8)
+                let buttonLabelRight = NSLayoutConstraint(item: buttonLabel, attribute: .trailing, relatedBy: .lessThanOrEqual, toItem: closeView, attribute: .trailing, multiplier: 1, constant: -8)
                 let buttonLabelHeight = NSLayoutConstraint(item: buttonLabel, attribute: .height, relatedBy: .greaterThanOrEqual, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 0)
                 let buttonLabelWidth = NSLayoutConstraint(item: buttonLabel, attribute: .width, relatedBy: .greaterThanOrEqual, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 0)
-                closeView.addConstraints([buttonLabelCenterX, buttonLabelCenterY])
+                closeView.addConstraints([buttonLabelCenterX, buttonLabelCenterY, buttonLabelLeft, buttonLabelRight])
                 buttonLabel.addConstraints([buttonLabelHeight, buttonLabelWidth])
                 
                 // Main button

--- a/ios/bittr/BitcoinManager.swift
+++ b/ios/bittr/BitcoinManager.swift
@@ -465,8 +465,12 @@ class BitcoinManager {
             // Light sync BDK.
             _ = self.lightSyncBdkWallet()
             
+            // Check pending balances.
+            let balances = node.listBalances()
+            let pendingClosureSatoshis = balances.pendingClosureSatoshis(openChannelIds: self.listChannels().map { $0.channelId })
+            
             // Check if any changes have been found.
-            if self.bittrWallet.satoshisOnchain != Int(node.listBalances().totalOnchainBalanceSats) || self.bittrWallet.allTransactions.count != self.listPayments().count {
+            if self.bittrWallet.satoshisOnchain != Int(balances.totalOnchainBalanceSats) || self.bittrWallet.pendingBalancesFromChannelClosures != pendingClosureSatoshis || self.bittrWallet.allTransactions.count != self.listPayments().count {
                 Log.info("Did find updates in light sync.")
                 
                 Task {

--- a/ios/bittr/Helpers/BittrWallet.swift
+++ b/ios/bittr/Helpers/BittrWallet.swift
@@ -12,11 +12,9 @@ class BittrWallet: NSObject {
 
     // Balance
     var satoshisLightning:Int = 0
+    var pendingBalancesFromChannelClosures:Int = 0
     var satoshisOnchain:Int = 0
-    // nil until loadWalletData has read it from LDK Node. Kept optional so
-    // "not loaded yet" stays distinguishable from "genuinely nothing spendable"
-    // — the two need opposite handling when clamping a drain.
-    var satoshisOnchainSpendable:Int?
+    var satoshisOnchainSpendable:Int? // nil until loadWalletData has read it from LDK Node.
     
     // Channels
     var lightningChannels = [ChannelDetails]()

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -42,9 +42,13 @@ extension HomeViewController {
         let satoshisOnchain = Int(balances.totalOnchainBalanceSats)
         let satoshisOnchainSpendable = Int(balances.spendableOnchainBalanceSats)
         
+        // Get funds from closed channels that are still settling back on-chain.
+        let pendingBalancesFromChannelClosures = balances.pendingBalancesFromChannelClosures.totalSatoshis()
+        
         // Apply the snapshot to the shared wallet on the main thread.
         let apply = {
             BitcoinManager.shared.bittrWallet.satoshisLightning = satoshisLightning
+            BitcoinManager.shared.bittrWallet.pendingBalancesFromChannelClosures = pendingBalancesFromChannelClosures
             BitcoinManager.shared.bittrWallet.lightningChannels = lightningChannels
             BitcoinManager.shared.bittrWallet.allTransactions = allTransactions
             BitcoinManager.shared.bittrWallet.satoshisOnchain = satoshisOnchain
@@ -533,4 +537,21 @@ extension HomeViewController {
         }
     }
 
+}
+
+extension [PendingSweepBalance] {
+    
+    func totalSatoshis() -> Int {
+        
+        var totalSatoshis = 0
+        for eachBalance in self {
+            switch eachBalance {
+            case .pendingBroadcast(_, let amountSatoshis),
+                 .broadcastAwaitingConfirmation(_, _, _, let amountSatoshis),
+                 .awaitingThresholdConfirmations(_, _, _, _, let amountSatoshis):
+                totalSatoshis += Int(amountSatoshis)
+            }
+        }
+        return totalSatoshis
+    }
 }

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -541,7 +541,7 @@ extension HomeViewController {
 
 extension BalanceDetails {
     func pendingClosureSatoshis(openChannelIds:[ChannelId]) -> Int {
-        return self.lightningBalances.totalSatoshis(excludingChannels: openChannelIds)
+        return self.lightningBalances.forceClosedSatoshis(excludingChannels: openChannelIds)
             + self.pendingBalancesFromChannelClosures.unbroadcastSatoshis()
     }
 }
@@ -563,16 +563,14 @@ extension [PendingSweepBalance] {
 
 extension [LightningBalance] {
     
-    func totalSatoshis(excludingChannels openChannelIds:[ChannelId]) -> Int {
+    func forceClosedSatoshis(excludingChannels openChannelIds:[ChannelId]) -> Int {
         
         var totalSatoshis = 0
         for eachBalance in self {
             switch eachBalance {
-            case .claimableAwaitingConfirmations(_, _, _, _, .coopClose):
-                // Don't include cooperative closes, because those funds already count towards the onchain balance.
-                break
-            case .claimableOnChannelClose(let channelId, _, let amountSatoshis, _, _, _, _, _),
-                 .claimableAwaitingConfirmations(let channelId, _, let amountSatoshis, _, _),
+            case .claimableAwaitingConfirmations(let channelId, _, let amountSatoshis, _, .holderForceClosed),
+                 .claimableAwaitingConfirmations(let channelId, _, let amountSatoshis, _, .counterpartyForceClosed),
+                 .claimableAwaitingConfirmations(let channelId, _, let amountSatoshis, _, .htlc),
                  .contentiousClaimable(let channelId, _, let amountSatoshis, _, _, _),
                  .maybeTimeoutClaimableHtlc(let channelId, _, let amountSatoshis, _, _, _),
                  .maybePreimageClaimableHtlc(let channelId, _, let amountSatoshis, _, _),
@@ -580,6 +578,9 @@ extension [LightningBalance] {
                 if !openChannelIds.contains(channelId) {
                     totalSatoshis += Int(amountSatoshis)
                 }
+            case .claimableOnChannelClose, .claimableAwaitingConfirmations:
+                // Don't include cooperative closes, because those funds already count towards the onchain balance.
+                break
             }
         }
         return totalSatoshis

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -45,7 +45,7 @@ extension HomeViewController {
         // Gather pending lightning balances.
         let openChannelIds = lightningChannels.map { $0.channelId }
         let pendingBalancesFromChannelClosures = balances.lightningBalances.totalSatoshis(excludingChannels: openChannelIds)
-            + balances.pendingBalancesFromChannelClosures.totalSatoshis()
+            + balances.pendingBalancesFromChannelClosures.unbroadcastSatoshis()
         
         // Apply the snapshot to the shared wallet on the main thread.
         let apply = {
@@ -543,15 +543,13 @@ extension HomeViewController {
 
 extension [PendingSweepBalance] {
     
-    func totalSatoshis() -> Int {
+    func unbroadcastSatoshis() -> Int {
         
         var totalSatoshis = 0
         for eachBalance in self {
             switch eachBalance {
-            case .pendingBroadcast(_, let amountSatoshis),
-                 .broadcastAwaitingConfirmation(_, _, _, let amountSatoshis),
-                 .awaitingThresholdConfirmations(_, _, _, _, let amountSatoshis):
-                totalSatoshis += Int(amountSatoshis)
+            case .pendingBroadcast(_, let amountSatoshis): totalSatoshis += Int(amountSatoshis)
+            case .broadcastAwaitingConfirmation, .awaitingThresholdConfirmations: break
             }
         }
         return totalSatoshis

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -42,8 +42,10 @@ extension HomeViewController {
         let satoshisOnchain = Int(balances.totalOnchainBalanceSats)
         let satoshisOnchainSpendable = Int(balances.spendableOnchainBalanceSats)
         
-        // Get funds from closed channels that are still settling back on-chain.
-        let pendingBalancesFromChannelClosures = balances.pendingBalancesFromChannelClosures.totalSatoshis()
+        // Gather pending lightning balances.
+        let openChannelIds = lightningChannels.map { $0.channelId }
+        let pendingBalancesFromChannelClosures = balances.lightningBalances.totalSatoshis(excludingChannels: openChannelIds)
+            + balances.pendingBalancesFromChannelClosures.totalSatoshis()
         
         // Apply the snapshot to the shared wallet on the main thread.
         let apply = {
@@ -550,6 +552,28 @@ extension [PendingSweepBalance] {
                  .broadcastAwaitingConfirmation(_, _, _, let amountSatoshis),
                  .awaitingThresholdConfirmations(_, _, _, _, let amountSatoshis):
                 totalSatoshis += Int(amountSatoshis)
+            }
+        }
+        return totalSatoshis
+    }
+}
+
+extension [LightningBalance] {
+    
+    func totalSatoshis(excludingChannels openChannelIds:[ChannelId]) -> Int {
+        
+        var totalSatoshis = 0
+        for eachBalance in self {
+            switch eachBalance {
+            case .claimableOnChannelClose(let channelId, _, let amountSatoshis, _, _, _, _, _),
+                 .claimableAwaitingConfirmations(let channelId, _, let amountSatoshis, _, _),
+                 .contentiousClaimable(let channelId, _, let amountSatoshis, _, _, _),
+                 .maybeTimeoutClaimableHtlc(let channelId, _, let amountSatoshis, _, _, _),
+                 .maybePreimageClaimableHtlc(let channelId, _, let amountSatoshis, _, _),
+                 .counterpartyRevokedOutputClaimable(let channelId, _, let amountSatoshis):
+                if !openChannelIds.contains(channelId) {
+                    totalSatoshis += Int(amountSatoshis)
+                }
             }
         }
         return totalSatoshis

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -43,9 +43,7 @@ extension HomeViewController {
         let satoshisOnchainSpendable = Int(balances.spendableOnchainBalanceSats)
         
         // Gather pending lightning balances.
-        let openChannelIds = lightningChannels.map { $0.channelId }
-        let pendingBalancesFromChannelClosures = balances.lightningBalances.totalSatoshis(excludingChannels: openChannelIds)
-            + balances.pendingBalancesFromChannelClosures.unbroadcastSatoshis()
+        let pendingBalancesFromChannelClosures = balances.pendingClosureSatoshis(openChannelIds: lightningChannels.map { $0.channelId })
         
         // Apply the snapshot to the shared wallet on the main thread.
         let apply = {
@@ -539,6 +537,13 @@ extension HomeViewController {
         }
     }
 
+}
+
+extension BalanceDetails {
+    func pendingClosureSatoshis(openChannelIds:[ChannelId]) -> Int {
+        return self.lightningBalances.totalSatoshis(excludingChannels: openChannelIds)
+            + self.pendingBalancesFromChannelClosures.unbroadcastSatoshis()
+    }
 }
 
 extension [PendingSweepBalance] {

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -568,6 +568,9 @@ extension [LightningBalance] {
         var totalSatoshis = 0
         for eachBalance in self {
             switch eachBalance {
+            case .claimableAwaitingConfirmations(_, _, _, _, .coopClose):
+                // Don't include cooperative closes, because those funds already count towards the onchain balance.
+                break
             case .claimableOnChannelClose(let channelId, _, let amountSatoshis, _, _, _, _, _),
                  .claimableAwaitingConfirmations(let channelId, _, let amountSatoshis, _, _),
                  .contentiousClaimable(let channelId, _, let amountSatoshis, _, _, _),

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -229,7 +229,7 @@ extension HomeViewController {
     
     func setTotalSats() {
         // Calculate total balance
-        let totalBalanceSats = BitcoinManager.shared.bittrWallet.satoshisOnchain + BitcoinManager.shared.bittrWallet.satoshisLightning
+        let totalBalanceSats = BitcoinManager.shared.bittrWallet.satoshisOnchain + BitcoinManager.shared.bittrWallet.satoshisLightning + BitcoinManager.shared.bittrWallet.pendingBalancesFromChannelClosures
         let totalBalanceSatsString = "\(totalBalanceSats)"
         
         // Load balance label.

--- a/ios/bittr/Home/LoadWalletData.swift
+++ b/ios/bittr/Home/LoadWalletData.swift
@@ -578,8 +578,11 @@ extension [LightningBalance] {
                 if !openChannelIds.contains(channelId) {
                     totalSatoshis += Int(amountSatoshis)
                 }
-            case .claimableOnChannelClose, .claimableAwaitingConfirmations:
+            case .claimableOnChannelClose,
+                 .claimableAwaitingConfirmations(_, _, _, _, .coopClose):
                 // Don't include cooperative closes, because those funds already count towards the onchain balance.
+                // Matching .coopClose explicitly (rather than a catch-all) keeps this switch exhaustive over
+                // BalanceSource, so a future LDK case is a compile error to classify rather than a silent exclusion.
                 break
             }
         }

--- a/ios/bittr/Language.swift
+++ b/ios/bittr/Language.swift
@@ -199,7 +199,7 @@ class Language: NSObject {
             "fundingtx": "Channel funding transaction",
             "questionvc1": "There's a limit to the amount of satoshis you can receive per invoice.\n\nThe size of your bitcoin lightning connection is <b><channelsize> satoshis</b>. You've already received <b><channelbalance> sats</b>, so you can still receive up to <b><receivelimit> sats</b> in total.\n\nWhen the connection is full, we'll invite you to move your funds to your regular bitcoin wallet to make space for future transactions.",
             "questionvc6": "why can't I send instant payments?",
-            "questionvc7": "Your bittr wallet consists of a bitcoin wallet (for regular payments) and a bitcoin lightning connection (for instant payments).\n\nYou've already received <b><channelbalance> satoshis</b> into your lightning connection. Your lightning connection needs to contain a minimum of <b><channelreserve> sats</b>, so the maximum amount you can send in total is <b><sendlimit> sats</b>.\n\nWhen the connection is full, we invite you to empty its funds into your bitcoin wallet so that you have space again.",
+            "questionvc7": "As part of your bittr wallet, you have a <b>bitcoin wallet</b> (for regular payments) and a <b>bitcoin lightning connection</b> (for instant payments).\n\nYour lightning balance is <b><channelbalance> satoshis</b>. The connection needs to contain a minimum of <b><channelreserve> sats</b>, so you can send up to <b><sendlimit> sats</b>.",
             "questionvc12": "why can't I receive instant payments?",
             "questionvc13": "Your bittr wallet consists of a bitcoin wallet (for regular payments) and a bitcoin lightning connection (for instant payments).\n\nYou don't currently have a lightning connection.\n\nTo open a connection with bittr, buy bitcoin worth between 20 and 100 €. Check your wallet's Buy section or getbittr.com for all information.",
             "reserve": "reserve",
@@ -573,7 +573,10 @@ class Language: NSObject {
             "buyvclightning": "Lightning",
             "buyvclightningexplanation": "Purchases up to 100 EUR/CHF go into your Lightning connection. Spend and receive instantly, with very low fees.\n\nTurn this off to receive your bittr purchases on-chain instead, in the regular part of your wallet.",
             "lightningnotready": "Lightning not ready",
-            "paymentmodeupdateerror": "Couldn't update payout mode"
+            "paymentmodeupdateerror": "Couldn't update payout mode",
+            "connectionclosed": "Connection closed",
+            "pendingclosure": "Your lightning connection was recently closed. These funds (<pendingfunds> satoshis) will be deposited into your regular wallet.",
+            "viewactiveconnection": "View active connection"
             
         ]
         

--- a/ios/bittr/Move, Send, Receive/MoveVC/MoveVCLanguage.swift
+++ b/ios/bittr/Move, Send, Receive/MoveVC/MoveVCLanguage.swift
@@ -32,12 +32,15 @@ extension MoveViewController {
         self.leftCard.backgroundColor = Colors.getColor("white0.7orblue2")
         self.rightCard.backgroundColor = Colors.getColor("white0.7orblue2")
         
+        // Grey out lightning funds in case they're pending from channel closure.
+        let instantColor = self.hasPendingClosureFunds ? Colors.getColor("unconfirmed") : Colors.getColor("blackorwhite")
+        self.satsInstant.textColor = instantColor
+        self.conversionInstant.textColor = instantColor
+        
         self.conversionTotal.textColor = Colors.getColor("blackorwhite")
-        self.conversionInstant.textColor = Colors.getColor("blackorwhite")
         self.conversionRegular.textColor = Colors.getColor("blackorwhite")
         self.satsTotal.textColor = Colors.getColor("blackorwhite")
         self.satsRegular.textColor = Colors.getColor("blackorwhite")
-        self.satsInstant.textColor = Colors.getColor("blackorwhite")
         self.questionMark.tintColor = Colors.getColor("blackorwhite")
         self.sendLabel.textColor = Colors.getColor("blackorwhite")
         self.receiveLabel.textColor = Colors.getColor("blackorwhite")

--- a/ios/bittr/Move, Send, Receive/MoveVC/MoveViewController.swift
+++ b/ios/bittr/Move, Send, Receive/MoveVC/MoveViewController.swift
@@ -70,20 +70,30 @@ class MoveViewController: UIViewController {
         self.addHeader(iconLight: "iconpiggywhite", iconDark: "iconpiggyyellow", title: Language.getWord(withID: "balance"))
     }
     
+    // Calculate the sum of spendable and pending lightning funds.
+    var instantSatoshis:Int {
+        return BitcoinManager.shared.bittrWallet.satoshisLightning + BitcoinManager.shared.bittrWallet.pendingBalancesFromChannelClosures
+    }
+    
+    // Check whether there are pending lightning funds.
+    var hasPendingClosureFunds:Bool {
+        return BitcoinManager.shared.bittrWallet.pendingBalancesFromChannelClosures > 0
+    }
+    
     func updateLabels() {
         
         // Calculate balance values.
         let correctBtcBalance:CGFloat = BitcoinManager.shared.bittrWallet.satoshisOnchain.inBTC()
-        let correctBtclnBalance:CGFloat = BitcoinManager.shared.bittrWallet.satoshisLightning.inBTC()
+        let correctBtclnBalance:CGFloat = self.instantSatoshis.inBTC()
         let bitcoinValue = BitcoinManager.shared.bittrWallet.getCorrectBitcoinValue()
         let balanceValue = String(Int(((correctBtcBalance+correctBtclnBalance)*bitcoinValue.currentValue).rounded())).addSpaces()
         let btcBalanceValue = String(Int(((correctBtcBalance)*bitcoinValue.currentValue).rounded())).addSpaces()
         let btclnBalanceValue = String(Int(((correctBtclnBalance)*bitcoinValue.currentValue).rounded())).addSpaces()
         
         // Show balance values.
-        self.satsTotal.text = "\(BitcoinManager.shared.bittrWallet.satoshisOnchain + BitcoinManager.shared.bittrWallet.satoshisLightning)".addSpaces() + " sats"
+        self.satsTotal.text = "\(BitcoinManager.shared.bittrWallet.satoshisOnchain + self.instantSatoshis)".addSpaces() + " sats"
         self.satsRegular.text = "\(BitcoinManager.shared.bittrWallet.satoshisOnchain)".addSpaces() + " sats"
-        self.satsInstant.text = "\(BitcoinManager.shared.bittrWallet.satoshisLightning)".addSpaces() + " sats"
+        self.satsInstant.text = "\(self.instantSatoshis)".addSpaces() + " sats"
         self.conversionTotal.text = bitcoinValue.chosenCurrency + " " + balanceValue
         self.conversionRegular.text = bitcoinValue.chosenCurrency + " " + btcBalanceValue
         self.conversionInstant.text = bitcoinValue.chosenCurrency + " " + btclnBalanceValue
@@ -122,13 +132,33 @@ class MoveViewController: UIViewController {
     
     @IBAction func channelButtonTapped(_ sender: UIButton) {
         
-        if BitcoinManager.shared.bittrWallet.lightningChannels.count == 0 {
+        if self.hasPendingClosureFunds {
+            self.showPendingClosureAlert()
+        } else if BitcoinManager.shared.bittrWallet.lightningChannels.count == 0 {
             // There is no Lightning channel.
             self.coreVC!.launchQuestion(question: Language.getWord(withID: "lightningchannels"), answer: Language.getWord(withID: "lightningexplanation1"), type: nil)
         } else {
             // There's a Lightning channel.
-            self.coreVC!.launchQuestion(question: Language.getWord(withID: "lightningchannel"), answer: Language.getWord(withID: "lightningexplanation1"), type: "lightningexplanation")
+            self.launchChannelQuestion()
         }
+    }
+    
+    func showPendingClosureAlert() {
+        // Part of the lightning funds are pending.
+        let message = Language.getWord(withID: "pendingclosure").replacingOccurrences(of: "<pendingfunds>", with: "\(BitcoinManager.shared.bittrWallet.pendingBalancesFromChannelClosures)".addSpaces())
+        
+        if BitcoinManager.shared.bittrWallet.satoshisLightning == 0 {
+            // All lightning funds are pending.
+            self.showAlert(presentingController: self, title: Language.getWord(withID: "connectionclosed"), message: message, buttons: [Language.getWord(withID: "okay")], actions: nil)
+        } else {
+            // There is an active channel with spendable lightning funds.
+            self.showAlert(presentingController: self, title: Language.getWord(withID: "connectionclosed"), message: message, buttons: [Language.getWord(withID: "close"), Language.getWord(withID: "viewactiveconnection")], actions: [nil, #selector(self.launchChannelQuestion)])
+        }
+    }
+    
+    @objc func launchChannelQuestion() {
+        self.hideAlert()
+        self.coreVC!.launchQuestion(question: Language.getWord(withID: "lightningchannel"), answer: Language.getWord(withID: "lightningexplanation1"), type: "lightningexplanation")
     }
     
     @IBAction func swapButtonTapped(_ sender: UIButton) {


### PR DESCRIPTION
**The problem**
When a channel closes, its funds leave `listChannels()` immediately but take a while to arrive on-chain. The Instant balance dropped to 0 for that whole window — up to about a day after a force close, since the `to_local` output sits behind the CSV delay.

**The solution**
BittrWallet now carries **pendingBalancesFromChannelClosures**, accumulated in loadWalletData(). 
The **HomeVC** and **MoveVC** both include it. 
The **MoveVC** greys the Instant label while any of it is pending and explains it in an alert on tap.

**What counts as pending**
Only funds a **force close** has put out of reach — locked in a script the on-chain wallet doesn't own, so nothing else counts them until the sweeper brings them back. 
A **cooperative close** pays our own shutdown script, so it lands in the  on-chain balance as unconfirmed within seconds.

**Improvements to lightSync**
The light sync only refreshed when the on-chain balance or the payment count changed. After a force close neither does for the whole CSV delay, so the 30s timer never reached `loadWalletData()` and both screens kept showing a stale balance for about a day. It now compares the pending total as well.