### PR TITLE
Properly report HTTP status code in alerts and to Sentry

### DIFF
--- a/ios/bittr/CallsManager.swift
+++ b/ios/bittr/CallsManager.swift
@@ -63,6 +63,11 @@ class CallsManager: NSObject {
                             return
                         }
                     } catch {
+                        if let statusCode = (response as? HTTPURLResponse)?.statusCode, !(200..<300).contains(statusCode) {
+                            Log.info("Request failed with status \(statusCode).")
+                            completion(.failure(.requestFailed("HTTP \(statusCode)")))
+                            return
+                        }
                         DispatchQueue.main.async {
                             SentrySDK.capture(error: error) { scope in
                                 scope.setExtra(value: "CallsManager row 60", key: "context")

--- a/ios/bittr/CallsManager.swift
+++ b/ios/bittr/CallsManager.swift
@@ -15,6 +15,19 @@ enum APIError: Error {
     case decodingFailed
 }
 
+extension APIError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Invalid URL."
+        case .requestFailed(let message):
+            return message
+        case .decodingFailed:
+            return "Could not read the server's response."
+        }
+    }
+}
+
 class CallsManager: NSObject {
     
     static func makeApiCall(url:String, parameters:[String:Any]?, getOrPost:CallType, completion: @escaping (Result<NSDictionary, APIError>) -> Void) async {

--- a/ios/bittr/Swaps/Swap Manager/BoltzAPI.swift
+++ b/ios/bittr/Swaps/Swap Manager/BoltzAPI.swift
@@ -62,6 +62,19 @@ enum BoltzAPIError: Error {
     case decodingFailed
 }
 
+extension BoltzAPIError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Invalid URL."
+        case .requestFailed(let message):
+            return message
+        case .decodingFailed:
+            return "Could not read the server's response."
+        }
+    }
+}
+
 // MARK: - BoltzAPI Class
 
 class BoltzAPI {


### PR DESCRIPTION
**Problem**
Whenever any API called by CallsManager returned a generic HTTP error status code, this code wasn't read. So the error sent to Sentry didn't include helpful descriptions.
Additionally, the custom objects APIError and BoltzAPIError didn't conform to the localizedDescription parameter, which meant any error shown to the app user in an alert was ugly.

**Solution**
CallsManager now reads and reports the HTTP status code when it can't parse JSON from the API's reply.
APIError and BoltzAPIError now conform to localizedDescription, to show the user user-friendly error information.