### PR TITLE
Give every API call a deadline

### DIFF
--- a/ios/bittr/CallsManager.swift
+++ b/ios/bittr/CallsManager.swift
@@ -17,9 +17,21 @@ enum APIError: Error {
 
 class CallsManager: NSObject {
     
-    static func makeApiCall(url:String, parameters:[String:Any]?, getOrPost:CallType, completion: @escaping (Result<NSDictionary, APIError>) -> Void) async {
+    // How long a request may go without producing data.
+    static let defaultTimeout:TimeInterval = 30
+    // Ceiling on a whole request, however steadily data trickles in.
+    private static let resourceTimeout:TimeInterval = 60
+    // Our own session.
+    private static let session:URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = defaultTimeout
+        configuration.timeoutIntervalForResource = resourceTimeout
+        return URLSession(configuration: configuration)
+    }()
+    
+    static func makeApiCall(url:String, parameters:[String:Any]?, getOrPost:CallType, timeout:TimeInterval = defaultTimeout, completion: @escaping (Result<NSDictionary, APIError>) -> Void) async {
         
-        var request = URLRequest(url: URL(string: url.replacingOccurrences(of: "\0", with: "").trimmingCharacters(in: .controlCharacters))!,timeoutInterval: Double.infinity)
+        var request = URLRequest(url: URL(string: url.replacingOccurrences(of: "\0", with: "").trimmingCharacters(in: .controlCharacters))!,timeoutInterval: timeout)
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.httpMethod = {
@@ -36,7 +48,7 @@ class CallsManager: NSObject {
                 request.httpBody = postData
             }
             
-            let task = URLSession.shared.dataTask(with: request) { data, response, dataError in
+            let task = Self.session.dataTask(with: request) { data, response, dataError in
                 
                 if let error = dataError {
                     Log.info("Error: \(error.localizedDescription)")


### PR DESCRIPTION
makeApiCall built its requests with `timeoutInterval: Double.infinity`, so a server that accepted the connection and then went quiet left the call hanging forever. Whatever was waiting on it waited forever too — a swap's Next button spinning until the user gave up, with no error to report.

Two deadlines, because one isn't enough: `timeoutInterval` is an inactivity timer that resets whenever bytes arrive, so a server dribbling out data can hold it open indefinitely. The total ceiling is `timeoutIntervalForResource`, which lives on the session configuration — hence our own URLSession, as URLSession.shared's configuration is fixed.

Callers that talk to something legitimately slow can raise the per-request timeout; values above the 60s resource ceiling need that raised too.