### PR TITLE
Keep LDK channel state out of device backups

### DIFF
--- a/ios/bittr/AppDelegate.swift
+++ b/ios/bittr/AppDelegate.swift
@@ -144,6 +144,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         // getters also self-heal on first read, so this is just eager cleanup.
         CacheManager.migrateSecretsToKeychainIfNeeded()
 
+        // Keep Documents out of iCloud/Finder backups.
+        LightningStorage.excludeFromBackup()
+        
         UNUserNotificationCenter.current().delegate = self
         
         return true

--- a/ios/bittr/BitcoinManager.swift
+++ b/ios/bittr/BitcoinManager.swift
@@ -37,6 +37,9 @@ class BitcoinManager {
     var xpub = ""
     var coreVC:CoreViewController?
 
+    // Prevent reconstructing foreign LDK Node data
+    var didQuarantineForeignState = false
+    
     // Bittr wallet
     var bittrWallet = BittrWallet()
     
@@ -118,6 +121,9 @@ class BitcoinManager {
         
         // Delete previous LDK Node log.
         try? FileManager.deleteLDKNodeLogLatestFile()
+        
+        // Keep the channel state out of iCloud/Finder backups.
+        LightningStorage.excludeFromBackup()
         
         // Congifure LDK Node settings.
         let correctListeningAddresses = EnvironmentConfig.isDevelopment ? ["0.0.0.0:19735"] : ["0.0.0.0:9735"]

--- a/ios/bittr/Cache/CacheManager.swift
+++ b/ios/bittr/Cache/CacheManager.swift
@@ -737,7 +737,33 @@ class CacheManager: NSObject {
     // MARK: - Mnemonic
     
     static func storeMnemonic(_ mnemonic:String) throws {
+        
+        // Make sure no foreign LDK Node data remains available when creating or restoring a wallet.
+        // Foreign LDK Node data can never restore a channel, and may lead to loss of funds.
+        try quarantineLightningStateBeforeSeedImport()
+        
+        // Store new or restored mnemonic.
         try persistSecret(mnemonic, account: EnvironmentConfig.cacheKey(for: "mnemonic"), label: "mnemonic", accessibility: .afterFirstUnlockThisDeviceOnly)
+    }
+    
+    private static func quarantineLightningStateBeforeSeedImport() throws {
+        
+        guard try readSecretOrThrow(account: EnvironmentConfig.cacheKey(for: "mnemonic")) == nil else {
+            // A mnemonic already exists on this device, or is unreadable. Don't touch anything.
+            return
+        }
+        guard LightningStorage.hasLightningState() else {
+            // There is no LDK Node data on this device. Nothing to quarantine.
+            return
+        }
+        Log.info("Foreign LDK Node data found while importing a seed.")
+        
+        // Quarantine foreign LDK Node data.
+        // If this fails somehow, prevent the creation or restoration of the wallet.
+        try LightningStorage.quarantineLightningState()
+        
+        // Inform the user about the discovery of foreign LDK Node data.
+        BitcoinManager.shared.didQuarantineForeignState = true
     }
     
     static func getMnemonic() -> String? {

--- a/ios/bittr/Core/StartLightning.swift
+++ b/ios/bittr/Core/StartLightning.swift
@@ -98,6 +98,14 @@ extension CoreViewController {
 
         self.completeSync(.ldk)
         
+        if BitcoinManager.shared.didQuarantineForeignState {
+            Log.info("User has restored a backup on a new device. Their channel will not be available.")
+            // This is only reachable for users with Lightning connections before these stopped being synced.
+            // Newer users will never encounter this issue.
+            BitcoinManager.shared.didQuarantineForeignState = false
+            self.showAlert(presentingController: self, title: Language.getWord(withID: "restoredbackup"), message: Language.getWord(withID: "restoredbackup2"), buttons: [Language.getWord(withID: "okay")], actions: nil)
+        }
+        
         // Start final calculations.
         self.startSync(.final)
         

--- a/ios/bittr/Helpers/LightningStorage.swift
+++ b/ios/bittr/Helpers/LightningStorage.swift
@@ -96,8 +96,14 @@ struct LightningStorage {
             try fileManager.removeItem(at: quarantineURL)
         }
         
-        // Create quarantine directory.
+        // Create the quarantine directory and keep it out of backups. Its name
+        // isn't matched by excludeFromBackup's state-file prefix, so without this
+        // the quarantined data could be re-synced and re-restored onto the next
+        // device — defeating the whole point of quarantining it. Excluding the
+        // directory covers everything moved into it below.
         try fileManager.createDirectory(at: quarantineURL, withIntermediateDirectories: true)
+        setExcludedFromBackup(quarantineURL)
+
         // Add all foreign LDK Node data into quarantine.
         for file in stateFiles {
             try fileManager.moveItem(at: file, to: quarantineURL.appendingPathComponent(file.lastPathComponent))

--- a/ios/bittr/Helpers/LightningStorage.swift
+++ b/ios/bittr/Helpers/LightningStorage.swift
@@ -9,10 +9,99 @@ import Foundation
 import LDKNode
 
 struct LightningStorage {
+    
     func getDocumentsDirectory() -> String {
         let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
         let pathString = path.path
-        //print("Path string: " + pathString)
         return pathString
+    }
+    
+    //  This is the directory LDK Node persists into.
+    //    1. Never sync it to other devices (excludeFromBackup).
+    //    2. Never allow restoring of the channel on a new device (quarantineLightningState).
+    //       This is a migration for existing users, whose iCloud still holds their channel data.
+    //       Trying to restore a foreign channel on a new device, would force-close the channel and potentially         lose the remaining funds.
+    
+    
+// MARK: - Backup exclusion
+    
+    // The URL that houses the files.
+    static var documentsURL: URL {
+        URL(fileURLWithPath: LightningStorage().getDocumentsDirectory())
+    }
+    
+    // LDK Node channel monitors and channel manager files.
+    // SQLite may carry `-wal`/`-shm` siblings, hence the prefix match.
+    private static let ldkStateFilePrefix = "ldk_node_data.sqlite"
+    
+    // Keep Documents out of every iCloud/Finder backup.
+    static func excludeFromBackup() {
+        setExcludedFromBackup(documentsURL)
+        for file in lightningStateFiles() {
+            setExcludedFromBackup(file)
+        }
+    }
+    
+    private static func setExcludedFromBackup(_ url: URL) {
+        var target = url
+        do {
+            if try target.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup == true {
+                // File has already been excluded from backups.
+                return
+            }
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = true
+            try target.setResourceValues(values)
+            Log.info("Excluded \(target.lastPathComponent) from device backups.")
+        } catch {
+            Log.info("Could not exclude \(target.lastPathComponent) from device backups: \(error)")
+        }
+    }
+    
+    
+// MARK: - Quarantine
+    
+    // A new URL to quarantine foreign LDK Node data.
+    private static var quarantineURL: URL {
+        documentsURL.appendingPathComponent("foreign_ldk_state", isDirectory: true)
+    }
+    
+    // All currently available LDK Node channel data.
+    private static func lightningStateFiles() -> [URL] {
+        guard let contents = try? FileManager.default.contentsOfDirectory(
+            at: documentsURL,
+            includingPropertiesForKeys: nil
+        ) else { return [] }
+        return contents.filter { $0.lastPathComponent.hasPrefix(ldkStateFilePrefix) }
+    }
+    
+    // Check whether LDK Node has channel data persisted here.
+    static func hasLightningState() -> Bool {
+        !lightningStateFiles().isEmpty
+    }
+    
+    // Quarantine any foreign LDK Node data (don't delete it).
+    // This file is the only thing that could help sweep funds from a force-closed channel.
+    static func quarantineLightningState() throws {
+        let fileManager = FileManager.default
+        let stateFiles = lightningStateFiles()
+        
+        guard !stateFiles.isEmpty else {
+            // There are no LDK Node files on this device.
+            return
+        }
+        
+        if fileManager.fileExists(atPath: quarantineURL.path) {
+            // Replace existing quarantined data with the latest.
+            try fileManager.removeItem(at: quarantineURL)
+        }
+        
+        // Create quarantine directory.
+        try fileManager.createDirectory(at: quarantineURL, withIntermediateDirectories: true)
+        // Add all foreign LDK Node data into quarantine.
+        for file in stateFiles {
+            try fileManager.moveItem(at: file, to: quarantineURL.appendingPathComponent(file.lastPathComponent))
+            Log.info("Quarantined Lightning state: \(file.lastPathComponent)")
+        }
     }
 }

--- a/ios/bittr/Language.swift
+++ b/ios/bittr/Language.swift
@@ -249,6 +249,8 @@ class Language: NSObject {
             "stillclosing": "Your Lightning connection is still being closed. For your safety, the wallet can only be reset once the connection is fully closed and the funds have returned on-chain — this can take a while.\n\nPlease reopen the app later to finish the reset. Do not delete the app from your phone, as this will lead to loss of funds.",
             "closeretrylater": "Your Lightning connection could not be closed right now — the bittr node may be temporarily offline. Your wallet has not been reset.\n\nPlease reopen the app to try again later. Do not delete the app from your phone, as this will lead to loss of funds.",
             "removalfailed": "Something went wrong removing your wallet, so it hasn't been removed — your wallet and funds are safe.\n\nPlease reopen the app to try again. Do not delete the app from your phone.",
+            "restoredbackup": "Wallet restored",
+            "restoredbackup2": "It seems that this wallet was restored from a backup. Your Lightning connection could not be carried over.\n\nIf you need our help, please contact support@getbittr.com.",
             "pinlength": "PIN Length",
             "pincanbeupto8": "PIN can be up to 8 digits",
             "pinrequired": "PIN Required",


### PR DESCRIPTION
**The problem**

- Unlike the pin and mnemonic (which are backed up to ThisDeviceOnly), all **LDK Node data** (i.e. channel state, channel manager) is backed up through **LightningStorage** and **included in syncs** across the user's devices.
- However, it's **not possible to reconstruct the users channel** on a new device. Doing so would lead to a **force-close** of the channel where the user could **lose their lightning funds**.

**The solution**

- LDK Node data should be **excluded from device backups**.
- Additionally, as a **migration for current users**, foreign LDK Node data should be recognized as such and not be reinstated when the user recovers a backup on a new device.
- Foreign LDK Node data remains valuable as a last resort to try and recover lost funds, so it gets **"quarantined"** but not removed.
- If foreign LDK Node data gets recognized, the user is **informed during wallet launch** that it's not possible to restore a Lightning connection from another device.