### PR TITLE
Validate onchain addresses with BDK instead of a regex

### DIFF
--- a/ios/bittr/Move, Send, Receive/SendVC/Send/AddressParsing.swift
+++ b/ios/bittr/Move, Send, Receive/SendVC/Send/AddressParsing.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import BitcoinDevKit
 import LNURLDecoder
 import LightningDevKit
 import Sentry
@@ -16,7 +17,7 @@ extension SendViewController {
         print("Code: " + code)
         
         // Parse code components.
-        let bitcoinAddress = code.lowercased().extractBitcoinAddress()
+        let bitcoinAddress = code.extractBitcoinAddress()
         let lightningInvoice = code.lowercased().extractLightningInvoice()
         let lnurl = code.lowercased().extractLNURL()
         let amount = code.lowercased().extractAmount()
@@ -87,8 +88,10 @@ extension String {
     
     func extractBitcoinAddress() -> String? {
         let components = self.components(separatedBy: CharacterSet(charactersIn: "&:?="))
-        for eachComponent in components where eachComponent.isValidBitcoinAddress() {
-            return eachComponent
+        for eachComponent in components {
+            if let address = eachComponent.asBitcoinAddress() {
+                return address
+            }
         }
         return nil
     }
@@ -117,17 +120,17 @@ extension String {
         return nil
     }
     
+    func asBitcoinAddress() -> String? {
+        // Verify non-lowercased address first.
+        if self.isValidBitcoinAddress() { return self }
+        
+        // If invalid, then verify lowercased address.
+        guard self.rangeOfCharacter(from: .lowercaseLetters) == nil else { return nil }
+        return self.lowercased().isValidBitcoinAddress() ? self.lowercased() : nil
+    }
+    
     func isValidBitcoinAddress() -> Bool {
-        let patterns = [
-            "^1[a-km-zA-HJ-NP-Z1-9]{25,34}$",  // P2PKH Mainnet
-            "^[mn2][a-km-zA-HJ-NP-Z1-9]{33}$",  // P2PKH or P2SH Testnet
-            "^bc1[qzp][a-z0-9]{38,}$",  // Bech32 Mainnet
-            "^tb1[qzp][a-z0-9]{38,}$",  // Bech32 Testnet,
-            "^bcrt1[qzp][a-z0-9]{38,}$"  // Bech32 Regtest
-        ]
-        return patterns.contains {
-            self.range(of: $0, options: [.regularExpression, .caseInsensitive]) != nil
-        }
+        (try? BitcoinDevKit.Address(address: self, network: EnvironmentConfig.bitcoinDevKitNetwork)) != nil
     }
     
     func isValidInvoice() -> Bool {


### PR DESCRIPTION
**Improvements to SendVC onchain address validation**

- Previous regex did not recognize mainnet P2SH entries. This is now fixed.
- Testnet and Regtest addresses were being accepted on Mainnet. This is now fixed.
- Regex did not recognize case-sensitive Base58 addresses. This is now fixed.
- We now use BDK's built-in address validation rather than a custom regex.